### PR TITLE
音声の前の無音を少し長くするワークアラウンドとREADMEの修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,12 @@ VOICEVOX ソフトウェアを起動した状態で、ブラウザから http://
 ### HTTP リクエストで音声合成するサンプルコード
 
 ```bash
-text="ABCDEFG"
+echo -n "こんにちは、音声合成の世界へようこそ" >text.txt
 
 curl -s \
     -X POST \
-    "localhost:50021/audio_query?text=$text&speaker=1"\
+    "localhost:50021/audio_query?speaker=1"\
+    --get --data-urlencode text@text.txt \
     > query.json
 
 curl -s \
@@ -26,15 +27,15 @@ curl -s \
     > audio.wav
 ```
 
-### 読み方をAquesTalk記法で取得・修正するサンプルコード
-`/audio_query`のレスポンスにはエンジンが判断した読み方がAquesTalkライクな記法([本家の記法](https://www.a-quest.com/archive/manual/siyo_onseikigou.pdf)とは一部異なります)で記録されています。
+### 読み方を AquesTalk 記法で取得・修正するサンプルコード
+
+`/audio_query`のレスポンスにはエンジンが判断した読み方が AquesTalk ライクな記法([本家の記法](https://www.a-quest.com/archive/manual/siyo_onseikigou.pdf)とは一部異なります)で記録されています。
 記法は次のルールに従います。
 
-* 全てのカナはカタカナで記述される
-* アクセント句は`/`または`、`で区切る。`、`で区切った場合に限り無音区間が挿入される。
-* カナの手前に`_`を入れるとそのカナは無声化される
-* アクセント位置を`'`で指定する。全てのアクセント句にはアクセント位置を1つ指定する必要がある。
-
+- 全てのカナはカタカナで記述される
+- アクセント句は`/`または`、`で区切る。`、`で区切った場合に限り無音区間が挿入される。
+- カナの手前に`_`を入れるとそのカナは無声化される
+- アクセント位置を`'`で指定する。全てのアクセント句にはアクセント位置を 1 つ指定する必要がある。
 
 ```bash
 # 読ませたい文章をutf-8でtext.txtに書き出す

--- a/run.py
+++ b/run.py
@@ -72,7 +72,10 @@ def make_synthesis_engine(
         )
 
     if voicelib_dir is None:
-        voicelib_dir = Path(__file__).parent  # core.__file__だとnuitkaビルド後にエラー
+        if voicevox_dir is not None:
+            voicelib_dir = voicevox_dir
+        else:
+            voicelib_dir = Path(__file__).parent  # core.__file__だとnuitkaビルド後にエラー
 
     core.initialize(voicelib_dir.as_posix() + "/", use_gpu)
 

--- a/voicevox_engine/synthesis_engine.py
+++ b/voicevox_engine/synthesis_engine.py
@@ -313,6 +313,10 @@ class SynthesisEngine:
 
         phoneme_length /= query.speedScale
 
+        # TODO: 前の無音を少し長くすると最初のワードが途切れないワークアラウンド実装
+        pre_padding_length = 0.4
+        phoneme_length[0] += pre_padding_length
+
         # pitch
         f0_list = [0] + [mora.pitch for mora in flatten_moras] + [0]
         f0 = numpy.array(f0_list, dtype=numpy.float32)
@@ -349,6 +353,9 @@ class SynthesisEngine:
             phoneme=phoneme,
             speaker_id=numpy.array(speaker_id, dtype=numpy.int64).reshape(-1),
         )
+
+        # TODO: 前の無音を少し長くすると最初のワードが途切れないワークアラウンド実装の後処理
+        wave = wave[int(self.default_sampling_rate * pre_padding_length) :]
 
         # volume
         if query.volumeScale != 1:


### PR DESCRIPTION
## 内容

音声の前に無音を0.5秒ほど含めると、最初が読まれない問題が若干低減します。
ワークアラウンドとして、無音を少し足して生成した後、生成された音声を削ります。

本当はコアに実装すべきなので、コアに実装され次第この機能は削除します。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
