### PR TITLE
pipenvのファイルを無視

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ venv/
 /cache
 
 /licenses.json
+
+/Pipfile
+/Pipfile.lock


### PR DESCRIPTION
## 内容
pipenv使用時に設定される`/Pipfile`と`/Pipfile.lock`をgitの管理外にします。
pipenvを使っていて不便だったのでPRさせていただきました。