### PR TITLE
coverageコメントに使うトークンを修正

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,7 @@ jobs:
         if: github.event_name == 'pull_request' && matrix.os == 'ubuntu-latest'
         uses: actions/github-script@v5.0.0
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN_WITH_REPO_ACCESS }}
+          github-token: ${{ secrets.TOKEN_THAT_CAN_GITHUB_REPO_ACCESS }}
           script: |
             const fs = require('fs')
             const baseReport = fs.readFileSync('report.txt', 'utf8').toString().split('\n')


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->
`GITHUB_TOKEN`は、与えられている権限が狭く、他人の開いたPRにコメントをする権限がありません。
そこで、`ACCESS_TOKEN`をHiroshibaさんに別途設定してもらい、それを利用する形にしたいです。
`ACCESS_TOKEN`に設定するものは、GitHubの`repo`の権限を持ったParsonal Access Tokenです。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->
- #143 

## その他

お手数おかけして申し訳ないです....