### PR TITLE
coverageのコメントに失敗する・コメントが壊れる問題を修正

### DIFF
--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -72,5 +72,5 @@ jobs:
               issue_number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `## Coverage Result\n\n<details>\n<summary>Resultを開く</summary>\n${report}\n</details>`
+              body: `## Coverage Result\n\n<details>\n<summary>Resultを開く</summary>\n\n${report}\n</details>`
             })


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->
はい、何度も何度もすみません....

`workflow_run`を用いたActionは[GitHub公式を参照した](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)のですが、この時用いられていた`github-scripts`が`v3`だったので、`v5`を用いるように修正を行ったところ、`v5`で加えられていた破壊的変更(APIを叩くときに`rest`が必要になる)を直し忘れていたので、動いていませんでした...

加えて、coverageのコメント自体にもミスがあって、[`<details>`を使うと、フォーマットが崩れる](https://gist.github.com/Phroneris/e7e6c869640b95bd42434bdc995cd4f6)みたいで、`<summary>`のあとに改行が2ついるみたいです。それの修正も行いました...

これによって4度目の正直ですが、今度こそ完全に動作するはずです

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->
#143 
#144 
#146 

## その他

Coverageの変更のためだけにいくつもPRを送ることになってしまってすみません....
