### PR TITLE
coverageのコメントをアップデートするように修正

### DIFF
--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -73,8 +73,8 @@ jobs:
               issue_number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-            }).data
-            listComments = listComments.filter((comment) => {
+            })
+            listComments = listComments.data.filter((comment) => {
               return comment.body.includes('Coverage Result') && comment.user.login.includes('github-actions')
             })
 


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->
Coverageコメントを新たに追加するのではなく、すでにある場合はそれを更新するようにしました。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->
close #148 

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->
https://github.com/y-chan/voicevox_engine/pull/6#issuecomment-950151965
![image](https://user-images.githubusercontent.com/34832037/138559047-86d871b9-7ab7-465e-981a-382d096f1b05.png)
コメントがBot自身によって更新されていることがわかります。
