### PR TITLE
synthesis engine向けにdocstringを追加

### DIFF
--- a/voicevox_engine/synthesis_engine.py
+++ b/voicevox_engine/synthesis_engine.py
@@ -4,10 +4,7 @@ from typing import List, Optional
 import numpy
 import resampy
 
-from voicevox_engine.acoustic_feature_extractor import (
-    OjtPhoneme,
-    SamplingData,
-)
+from voicevox_engine.acoustic_feature_extractor import OjtPhoneme, SamplingData
 from voicevox_engine.model import AccentPhrase, AudioQuery, Mora
 
 unvoiced_mora_phoneme_list = ["A", "I", "U", "E", "O", "cl", "pau"]


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->
どうやってテスト向けにmockを実装しようか、と悩みつつ、とりあえずdocstringのみを追加しました。
これでエンジン本体のコア関数(=voicevox_engineフォルダ内のファイル・関数。forwarder.pyを除く)に対して何かしらdoc(or 説明)が導入された段階になると思います。
モデル(`model.py`)はdocstringを書くまでもなく用途が自明かつ、実装するとOpenAPIの表記がぶっ壊れると思われるので実装しません。
あとは`run.py`の一部docstringがない関数・docstringではないdocの書き換えで #59 は完了です。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->
#59 



## その他

一点だけ、`mean_f0`関数のみ使われておらず、どういう使い道なのかわからずdocstringを付与できていません。

synthesis engineは音声合成を行うにあたって中心の部分なので、各処理ごとにコメントを振ってあげた方が優しい...?(`サードパーティー製エンジンの作成や、これからの改善がしやすくなる`という点では良いかも...?)