### PR TITLE
pip installをpython -m pip installに変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,10 +147,10 @@ Issue 側で取り組み始めたことを伝えるか、最初に Draft プル�
 
 ```bash
 # 開発に必要なライブラリのインストール
-pip install -r requirements-test.txt
+python -m pip install -r requirements-test.txt
 
 # とりあえず実行したいだけなら代わりにこちら
-pip install -r requirements.txt
+python -m pip install -r requirements.txt
 ```
 
 ## 実行
@@ -187,7 +187,7 @@ pysen run format lint
 Build Tools for Visual Studio 2019 が必要です。
 
 ```bash
-pip install -r requirements-dev.txt
+python -m pip install -r requirements-dev.txt
 
 python generate_licenses.py > licenses.json
 


### PR DESCRIPTION
## 内容

windowsだと、`pip install pip`ができず、requirements-dev.txtなどをインストールするときにエラーが出ることがあります。
なのでREADMEをpython -m pip installに統一してみました。
