### PR TITLE
SynthesisEngineの抽象基底クラスSynthesisEngineBaseを追加

### DIFF
--- a/run.py
+++ b/run.py
@@ -28,7 +28,7 @@ from voicevox_engine.model import (
     SpeakerInfo,
 )
 from voicevox_engine.preset import Preset, PresetLoader
-from voicevox_engine.synthesis_engine import SynthesisEngine, make_synthesis_engine
+from voicevox_engine.synthesis_engine import SynthesisEngineBase, make_synthesis_engine
 from voicevox_engine.utility import ConnectBase64WavesException, connect_base64_waves
 
 
@@ -36,7 +36,7 @@ def b64encode_str(s):
     return base64.b64encode(s).decode("utf-8")
 
 
-def generate_app(engine: SynthesisEngine) -> FastAPI:
+def generate_app(engine: SynthesisEngineBase) -> FastAPI:
     root_dir = Path(__file__).parent
 
     default_sampling_rate = engine.default_sampling_rate

--- a/test/test_mock_synthesis_engine.py
+++ b/test/test_mock_synthesis_engine.py
@@ -1,0 +1,107 @@
+from unittest import TestCase
+from voicevox_engine.dev.synthesis_engine import MockSynthesisEngine
+from voicevox_engine.model import AccentPhrase, AudioQuery, Mora
+
+class TestMockSynthesisEngine(TestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.accent_phrases_hello_hiho = [
+            AccentPhrase(
+                moras=[
+                    Mora(
+                        text="コ",
+                        consonant="k",
+                        consonant_length=0.0,
+                        vowel="o",
+                        vowel_length=0.0,
+                        pitch=0.0,
+                    ),
+                    Mora(
+                        text="ン",
+                        consonant=None,
+                        consonant_length=None,
+                        vowel="N",
+                        vowel_length=0.0,
+                        pitch=0.0,
+                    ),
+                    Mora(
+                        text="ニ",
+                        consonant="n",
+                        consonant_length=0.0,
+                        vowel="i",
+                        vowel_length=0.0,
+                        pitch=0.0,
+                    ),
+                    Mora(
+                        text="チ",
+                        consonant="ch",
+                        consonant_length=0.0,
+                        vowel="i",
+                        vowel_length=0.0,
+                        pitch=0.0,
+                    ),
+                    Mora(
+                        text="ワ",
+                        consonant="w",
+                        consonant_length=0.0,
+                        vowel="a",
+                        vowel_length=0.0,
+                        pitch=0.0,
+                    ),
+                ],
+                accent=5,
+                pause_mora=Mora(
+                    text="、",
+                    consonant=None,
+                    consonant_length=None,
+                    vowel="pau",
+                    vowel_length=0.0,
+                    pitch=0.0,
+                ),
+            ),
+            AccentPhrase(
+                moras=[
+                    Mora(
+                        text="ヒ",
+                        consonant="h",
+                        consonant_length=0.0,
+                        vowel="i",
+                        vowel_length=0.0,
+                        pitch=0.0,
+                    ),
+                    Mora(
+                        text="ホ",
+                        consonant="h",
+                        consonant_length=0.0,
+                        vowel="o",
+                        vowel_length=0.0,
+                        pitch=0.0,
+                    ),
+                    Mora(
+                        text="デ",
+                        consonant="d",
+                        consonant_length=0.0,
+                        vowel="e",
+                        vowel_length=0.0,
+                        pitch=0.0,
+                    ),
+                    Mora(
+                        text="ス",
+                        consonant="s",
+                        consonant_length=0.0,
+                        vowel="U",
+                        vowel_length=0.0,
+                        pitch=0.0,
+                    ),
+                ],
+                accent=1,
+                pause_mora=None,
+            ),
+        ]
+
+    def test_mock_synthesis_engine(self):
+        engine = MockSynthesisEngine(speakers='')
+
+        self.assertEqual(engine.replace_phoneme_length(accent_phrases=self.accent_phrases_hello_hiho, speaker_id=0), self.accent_phrases_hello_hiho)
+        self.assertEqual(engine.replace_mora_pitch(accent_phrases=self.accent_phrases_hello_hiho, speaker_id=0), self.accent_phrases_hello_hiho)

--- a/test/test_mock_synthesis_engine.py
+++ b/test/test_mock_synthesis_engine.py
@@ -1,7 +1,8 @@
 from unittest import TestCase
 
 from voicevox_engine.dev.synthesis_engine import MockSynthesisEngine
-from voicevox_engine.model import AccentPhrase, Mora
+from voicevox_engine.kana_parser import create_kana
+from voicevox_engine.model import AccentPhrase, AudioQuery, Mora
 
 
 class TestMockSynthesisEngine(TestCase):
@@ -106,7 +107,8 @@ class TestMockSynthesisEngine(TestCase):
     def test_replace_phoneme_length(self):
         self.assertEqual(
             self.engine.replace_phoneme_length(
-                accent_phrases=self.accent_phrases_hello_hiho, speaker_id=0
+                accent_phrases=self.accent_phrases_hello_hiho,
+                speaker_id=0,
             ),
             self.accent_phrases_hello_hiho,
         )
@@ -114,7 +116,25 @@ class TestMockSynthesisEngine(TestCase):
     def test_replace_mora_pitch(self):
         self.assertEqual(
             self.engine.replace_mora_pitch(
-                accent_phrases=self.accent_phrases_hello_hiho, speaker_id=0
+                accent_phrases=self.accent_phrases_hello_hiho,
+                speaker_id=0,
             ),
             self.accent_phrases_hello_hiho,
+        )
+
+    def test_synthesis(self):
+        self.engine.synthesis(
+            AudioQuery(
+                accent_phrases=self.accent_phrases_hello_hiho,
+                speedScale=1,
+                pitchScale=0,
+                intonationScale=1,
+                volumeScale=1,
+                prePhonemeLength=0.1,
+                postPhonemeLength=0.1,
+                outputSamplingRate=24000,
+                outputStereo=False,
+                kana=create_kana(self.accent_phrases_hello_hiho),
+            ),
+            speaker_id=0,
         )

--- a/test/test_mock_synthesis_engine.py
+++ b/test/test_mock_synthesis_engine.py
@@ -1,6 +1,8 @@
 from unittest import TestCase
+
 from voicevox_engine.dev.synthesis_engine import MockSynthesisEngine
-from voicevox_engine.model import AccentPhrase, AudioQuery, Mora
+from voicevox_engine.model import AccentPhrase, Mora
+
 
 class TestMockSynthesisEngine(TestCase):
     def setUp(self):
@@ -99,9 +101,20 @@ class TestMockSynthesisEngine(TestCase):
                 pause_mora=None,
             ),
         ]
+        self.engine = MockSynthesisEngine(speakers="")
 
-    def test_mock_synthesis_engine(self):
-        engine = MockSynthesisEngine(speakers='')
+    def test_replace_phoneme_length(self):
+        self.assertEqual(
+            self.engine.replace_phoneme_length(
+                accent_phrases=self.accent_phrases_hello_hiho, speaker_id=0
+            ),
+            self.accent_phrases_hello_hiho,
+        )
 
-        self.assertEqual(engine.replace_phoneme_length(accent_phrases=self.accent_phrases_hello_hiho, speaker_id=0), self.accent_phrases_hello_hiho)
-        self.assertEqual(engine.replace_mora_pitch(accent_phrases=self.accent_phrases_hello_hiho, speaker_id=0), self.accent_phrases_hello_hiho)
+    def test_replace_mora_pitch(self):
+        self.assertEqual(
+            self.engine.replace_mora_pitch(
+                accent_phrases=self.accent_phrases_hello_hiho, speaker_id=0
+            ),
+            self.accent_phrases_hello_hiho,
+        )

--- a/test/test_mora_to_text.py
+++ b/test/test_mora_to_text.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 
 # TODO: import from voicevox_engine.synthesis_engine.mora
-from voicevox_engine.synthesis_engine.synthesis_engine import mora_to_text
+from voicevox_engine.synthesis_engine.synthesis_engine_base import mora_to_text
 
 
 class TestMoraToText(TestCase):

--- a/voicevox_engine/dev/synthesis_engine/__init__.py
+++ b/voicevox_engine/dev/synthesis_engine/__init__.py
@@ -1,3 +1,3 @@
-from .mock import SynthesisEngine
+from .mock import MockSynthesisEngine
 
-__all__ = ["SynthesisEngine"]
+__all__ = ["MockSynthesisEngine"]

--- a/voicevox_engine/dev/synthesis_engine/mock.py
+++ b/voicevox_engine/dev/synthesis_engine/mock.py
@@ -6,10 +6,11 @@ from pyopenjtalk import tts
 from scipy.signal import resample
 
 from ...model import AccentPhrase, AudioQuery
+from ...synthesis_engine import SynthesisEngineBase
 from ...synthesis_engine.synthesis_engine import to_flatten_moras
 
 
-class SynthesisEngine:
+class MockSynthesisEngine(SynthesisEngineBase):
     """
     SynthesisEngine [Mock]
     """

--- a/voicevox_engine/synthesis_engine/__init__.py
+++ b/voicevox_engine/synthesis_engine/__init__.py
@@ -1,9 +1,11 @@
 from .forwarder import Forwarder
 from .make_synthesis_engine import make_synthesis_engine
 from .synthesis_engine import SynthesisEngine
+from .synthesis_engine_base import SynthesisEngineBase
 
 __all__ = [
     "Forwarder",
     "make_synthesis_engine",
     "SynthesisEngine",
+    "SynthesisEngineBase",
 ]

--- a/voicevox_engine/synthesis_engine/make_synthesis_engine.py
+++ b/voicevox_engine/synthesis_engine/make_synthesis_engine.py
@@ -57,7 +57,7 @@ def make_synthesis_engine(
             speakers=core.metas(),
         )
 
-    from ..dev.synthesis_engine import SynthesisEngine as MockSynthesisEngine
+    from ..dev.synthesis_engine import MockSynthesisEngine
 
     # モックで置き換える
     return MockSynthesisEngine(speakers=core.metas())

--- a/voicevox_engine/synthesis_engine/make_synthesis_engine.py
+++ b/voicevox_engine/synthesis_engine/make_synthesis_engine.py
@@ -2,14 +2,14 @@ import sys
 from pathlib import Path
 from typing import Optional
 
-from .synthesis_engine import SynthesisEngine
+from .synthesis_engine import SynthesisEngine, SynthesisEngineBase
 
 
 def make_synthesis_engine(
     use_gpu: bool,
     voicelib_dir: Path,
     voicevox_dir: Optional[Path] = None,
-) -> SynthesisEngine:
+) -> SynthesisEngineBase:
     """
     音声ライブラリをロードして、音声合成エンジンを生成
 

--- a/voicevox_engine/synthesis_engine/synthesis_engine_base.py
+++ b/voicevox_engine/synthesis_engine/synthesis_engine_base.py
@@ -1,4 +1,4 @@
-from abc import abstractmethod
+from abc import ABCMeta, abstractmethod
 from typing import List
 
 from ..full_context_label import extract_full_context_label
@@ -16,7 +16,7 @@ def mora_to_text(mora: str) -> str:
         return mora
 
 
-class SynthesisEngineBase:
+class SynthesisEngineBase(metaclass=ABCMeta):
     @abstractmethod
     def replace_phoneme_length(
         self, accent_phrases: List[AccentPhrase], speaker_id: int

--- a/voicevox_engine/synthesis_engine/synthesis_engine_base.py
+++ b/voicevox_engine/synthesis_engine/synthesis_engine_base.py
@@ -1,0 +1,135 @@
+from typing import List
+
+from ..full_context_label import extract_full_context_label
+from ..model import AccentPhrase, AudioQuery, Mora
+from ..mora_list import openjtalk_mora2text
+
+
+def mora_to_text(mora: str) -> str:
+    if mora[-1:] in ["A", "I", "U", "E", "O"]:
+        # 無声化母音を小文字に
+        mora = mora[:-1] + mora[-1].lower()
+    if mora in openjtalk_mora2text:
+        return openjtalk_mora2text[mora]
+    else:
+        return mora
+
+
+class SynthesisEngineBase:
+    def replace_phoneme_length(
+        self, accent_phrases: List[AccentPhrase], speaker_id: int
+    ) -> List[AccentPhrase]:
+        """
+        accent_phrasesの母音・子音の長さを設定する
+        Parameters
+        ----------
+        accent_phrases : List[AccentPhrase]
+            アクセント句モデルのリスト
+        speaker_id : int
+            話者ID
+        Returns
+        -------
+        accent_phrases : List[AccentPhrase]
+            母音・子音の長さが設定されたアクセント句モデルのリスト
+        """
+        raise Exception('Unimplemented')
+
+    def replace_mora_pitch(
+        self, accent_phrases: List[AccentPhrase], speaker_id: int
+    ) -> List[AccentPhrase]:
+        """
+        accent_phrasesの音高(ピッチ)を設定する
+        Parameters
+        ----------
+        accent_phrases : List[AccentPhrase]
+            アクセント句モデルのリスト
+        speaker_id : int
+            話者ID
+        Returns
+        -------
+        accent_phrases : List[AccentPhrase]
+            音高(ピッチ)が設定されたアクセント句モデルのリスト
+        """
+        raise Exception('Unimplemented')
+
+    def replace_mora_data(
+        self,
+        accent_phrases: List[AccentPhrase],
+        speaker_id: int,
+    ) -> List[AccentPhrase]:
+        return self.replace_mora_pitch(
+            accent_phrases=self.replace_phoneme_length(
+                accent_phrases=accent_phrases,
+                speaker_id=speaker_id,
+            ),
+            speaker_id=speaker_id,
+        )
+
+    def create_accent_phrases(self, text: str, speaker_id: int) -> List[AccentPhrase]:
+        if len(text.strip()) == 0:
+            return []
+
+        utterance = extract_full_context_label(text)
+        if len(utterance.breath_groups) == 0:
+            return []
+
+        return self.replace_mora_data(
+            accent_phrases=[
+                AccentPhrase(
+                    moras=[
+                        Mora(
+                            text=mora_to_text(
+                                "".join([p.phoneme for p in mora.phonemes])
+                            ),
+                            consonant=(
+                                mora.consonant.phoneme
+                                if mora.consonant is not None
+                                else None
+                            ),
+                            consonant_length=0 if mora.consonant is not None else None,
+                            vowel=mora.vowel.phoneme,
+                            vowel_length=0,
+                            pitch=0,
+                        )
+                        for mora in accent_phrase.moras
+                    ],
+                    accent=accent_phrase.accent,
+                    pause_mora=(
+                        Mora(
+                            text="、",
+                            consonant=None,
+                            consonant_length=None,
+                            vowel="pau",
+                            vowel_length=0,
+                            pitch=0,
+                        )
+                        if (
+                            i_accent_phrase == len(breath_group.accent_phrases) - 1
+                            and i_breath_group != len(utterance.breath_groups) - 1
+                        )
+                        else None
+                    ),
+                )
+                for i_breath_group, breath_group in enumerate(utterance.breath_groups)
+                for i_accent_phrase, accent_phrase in enumerate(
+                    breath_group.accent_phrases
+                )
+            ],
+            speaker_id=speaker_id,
+        )
+
+    def synthesis(self, query: AudioQuery, speaker_id: int):
+        """
+        音声合成クエリから音声合成に必要な情報を構成し、実際に音声合成を行う
+        Parameters
+        ----------
+        query : AudioQuery
+            音声合成クエリ
+        speaker_id : int
+            話者ID
+        Returns
+        -------
+        wave : numpy.ndarray
+            音声合成結果
+        """
+        raise Exception('Unimplemented')

--- a/voicevox_engine/synthesis_engine/synthesis_engine_base.py
+++ b/voicevox_engine/synthesis_engine/synthesis_engine_base.py
@@ -1,3 +1,4 @@
+from abc import abstractmethod
 from typing import List
 
 from ..full_context_label import extract_full_context_label
@@ -16,6 +17,7 @@ def mora_to_text(mora: str) -> str:
 
 
 class SynthesisEngineBase:
+    @abstractmethod
     def replace_phoneme_length(
         self, accent_phrases: List[AccentPhrase], speaker_id: int
     ) -> List[AccentPhrase]:
@@ -34,6 +36,7 @@ class SynthesisEngineBase:
         """
         raise NotImplementedError()
 
+    @abstractmethod
     def replace_mora_pitch(
         self, accent_phrases: List[AccentPhrase], speaker_id: int
     ) -> List[AccentPhrase]:
@@ -118,6 +121,7 @@ class SynthesisEngineBase:
             speaker_id=speaker_id,
         )
 
+    @abstractmethod
     def synthesis(self, query: AudioQuery, speaker_id: int):
         """
         音声合成クエリから音声合成に必要な情報を構成し、実際に音声合成を行う

--- a/voicevox_engine/synthesis_engine/synthesis_engine_base.py
+++ b/voicevox_engine/synthesis_engine/synthesis_engine_base.py
@@ -32,7 +32,7 @@ class SynthesisEngineBase:
         accent_phrases : List[AccentPhrase]
             母音・子音の長さが設定されたアクセント句モデルのリスト
         """
-        raise Exception('Unimplemented')
+        raise NotImplementedError()
 
     def replace_mora_pitch(
         self, accent_phrases: List[AccentPhrase], speaker_id: int
@@ -50,7 +50,7 @@ class SynthesisEngineBase:
         accent_phrases : List[AccentPhrase]
             音高(ピッチ)が設定されたアクセント句モデルのリスト
         """
-        raise Exception('Unimplemented')
+        raise NotImplementedError()
 
     def replace_mora_data(
         self,
@@ -132,4 +132,4 @@ class SynthesisEngineBase:
         wave : numpy.ndarray
             音声合成結果
         """
-        raise Exception('Unimplemented')
+        raise NotImplementedError()


### PR DESCRIPTION
## 内容

#199 にて、`run.py` の複雑さを減らすため、
`create_accent_phrases` 関数を `run.py` から `SynthesisEngine` クラスに移動させましたが、
Mockに `create_accent_phrases` 関数を実装し忘れていたため、Mockが動作しなくなっていました。

このPRは、SynthesisEngineとMockの両方が持つべき処理を `SynthesisEngineBase` クラスに実装し、
SynthesisEngineとMockは `SynthesisEngineBase` クラスを継承するようにして、
Mockが動作するようにします。

また、Mockの動作を確認するため、MockSynthesisEngineのテストを追加します。

SynthesisEngineBaseでは、`yukarin_s_forwarder`、`yukarin_sa_forwarder`、`decode_forwarder`、`speakers`に依存する処理は未実装とし、呼び出し時に例外を投げます（が、`abc.abstractmethod`を指定しているので、あくまでマーカー＝実際に使われることはない、と思います）。

- <https://docs.python.org/ja/3.8/library/exceptions.html#NotImplementedError>

SynthesisEngineBaseは抽象基底クラスとし、抽象メソッドが実装されていない場合にインスタンスを作成できないようにしています（`abc.abstractmethod`）。

- <https://docs.python.org/ja/3.8/library/abc.html#abc.abstractmethod>

<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue

ref: #226 

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## その他

命名規則ちょっと悩みます。

- `SynthesisEngineBase`、`MockSynthesisEngine`
    - 補完がしやすそうなので採用しています
- `BaseSynthesisEngine`、`MockSynthesisEngine`
    - 統一感があります
- `SynthesisEngineBase`、`SynthesisEngineMock`
    - こちらでもいいかも
- `BaseSynthesisEngine`、`SynthesisEngineMock`
