### PR TITLE
Workaround: Dockerイメージ, entrypointでldconfigを実行

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -285,11 +285,16 @@ COPY --chmod=775 <<EOF /entrypoint.sh
 set -eux
 cat /opt/voicevox_core/README.txt > /dev/stderr
 
-# Workaround: ldconfig fail to load LibTorch if glibc < 2.31.
-# For isolating problems and simplifing script, use flag USE_GLIBC_231_WORKAROUND
-# instead of implementing version check logic.
 if [ "${USE_GLIBC_231_WORKAROUND}" = "1" ]; then
+    # Workaround: ldconfig fail to load LibTorch if glibc < 2.31.
+    # For isolating problems and simplifing script, use flag USE_GLIBC_231_WORKAROUND
+    # instead of implementing version check logic.
     export LD_LIBRARY_PATH="/opt/libtorch/lib:\${LD_LIBRARY_PATH:-}"
+else
+    # Workaround: ld.so.cache may not be updated on image build.
+    # Fix the problem of `libtorch_cuda_cpp.so` not being recognized for unknown reason.
+    # Execute ldconfig on every container run.
+    ldconfig
 fi
 
 exec "\$@"


### PR DESCRIPTION
## 内容

GPU版Dockerイメージのビルド時に、`libtorch_cuda_cpp.so`が認識されない（ld.so.cacheに追加されていない）現象が起きることがあります。

```
ImportError: libtorch_cuda_cpp.so: cannot open shared object file: No such file or directory
```

Workaround/QuickFixとして、コンテナ実行時の初期化処理（entrypoint）で毎回ldconfigを実行するようにします。

ベースイメージがUbuntu 18.04の場合は、ldconfigを実行すると、glibcのバージョンが古く、LibTorchの共有ライブラリを正しく認識することができないため、従来どおりビルド時変数`USE_GLIBC_231_WORKAROUND`に基づいて、`LD_LIBRARY_PATH`環境変数を使用しますが、ユーザが環境変数を上書きしにくくなるため、本来はldconfigを実行するほうが望ましいと考えています。

また、Ubuntu 18.04のイメージは、互換性を確保した実行バイナリビルドに使用していることもあり、glibcのバージョンを、OSと対応していないバージョンに上げることは、望ましくないと考えています。

<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue

ref #226 

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## その他

正確な原因・直し方が分かる方いませんか...
