### PR TITLE
`labeler.yml`に`enable-versioned-regex`を追加

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -11,3 +11,4 @@ jobs:
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         configuration-path: .github/labeler.yml
+        enable-versioned-regex: 0


### PR DESCRIPTION
## 内容

必須パラメータの`enable-versioned-regex`が抜けていたので追加

## 関連 Issue

#232 

## その他

https://github.com/VOICEVOX/voicevox/actions/runs/1571876696