### PR TITLE
fix: TypeScriptのコード生成失敗するので修正

### DIFF
--- a/voicevox_engine/model.py
+++ b/voicevox_engine/model.py
@@ -138,4 +138,4 @@ class SpeakerInfo(BaseModel):
 
     policy: str = Field(title="policy.md")
     portrait: str = Field(title="portrait.pngをbase64エンコードしたもの")
-    style_infos: List[StyleInfo] = Field("スタイルの追加情報")
+    style_infos: List[StyleInfo] = Field(title="スタイルの追加情報")


### PR DESCRIPTION
## 内容

タイトル通りです。
Fieldの引数名が指定されていなかったためにdefaultが文字列になっていたのでエラーになりました。

## 関連 Issue
refs https://github.com/VOICEVOX/voicevox/issues/608


