### PR TITLE
個人的に使ってる環境依存のツールの設定ファイルを.gitignore追加させてほしい

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,12 @@ venv/
 /cache
 
 /licenses.json
+
+# direnv setting file
+.envrc
+
+# asdf setting file
+.tool-versions
+
+# neovim local workspace directory
+.vim/


### PR DESCRIPTION
## 内容
個人的に使用してる環境に依存したツールがあるのですが、
毎回それらのツールの設定ファイルを避けてcommitするのが辛くなってきたので勝手ながら.gitignoreで避けるようにするためのPRです
こういったものって取り込めていただけるでしょうか？

