### PR TITLE
accent_phrases APIのparse_kanaについて疑問文自動調整対応をした

### DIFF
--- a/test/test_kana_parser.py
+++ b/test/test_kana_parser.py
@@ -1,54 +1,60 @@
 from typing import List
 from unittest import TestCase
 
-from voicevox_engine.kana_parser import create_kana, parse_kana
-from voicevox_engine.model import ParseKanaError, ParseKanaErrorCode
+from voicevox_engine import kana_parser
+from voicevox_engine.kana_parser import create_kana
+from voicevox_engine.model import AccentPhrase, ParseKanaError, ParseKanaErrorCode
+
+
+def parse_kana(text: str) -> List[AccentPhrase]:
+    accent_phrases, _ = kana_parser.parse_kana(text, False)
+    return accent_phrases
 
 
 class TestParseKana(TestCase):
     def test_phrase_length(self):
-        self.assertEqual(len(parse_kana("ア'/ア'", False)[0]), 2)
-        self.assertEqual(len(parse_kana("ア'、ア'", False)[0]), 2)
-        self.assertEqual(len(parse_kana("ア'/ア'/ア'/ア'/ア'", False)[0]), 5)
-        self.assertEqual(len(parse_kana("ス'", False)[0]), 1)
-        self.assertEqual(len(parse_kana("_ス'", False)[0]), 1)
-        self.assertEqual(len(parse_kana("ギェ'", False)[0]), 1)
-        self.assertEqual(len(parse_kana("ギェ'、ギェ'/ギェ'", False)[0]), 3)
+        self.assertEqual(len(parse_kana("ア'/ア'")), 2)
+        self.assertEqual(len(parse_kana("ア'、ア'")), 2)
+        self.assertEqual(len(parse_kana("ア'/ア'/ア'/ア'/ア'")), 5)
+        self.assertEqual(len(parse_kana("ス'")), 1)
+        self.assertEqual(len(parse_kana("_ス'")), 1)
+        self.assertEqual(len(parse_kana("ギェ'")), 1)
+        self.assertEqual(len(parse_kana("ギェ'、ギェ'/ギェ'")), 3)
 
     def test_accent(self):
-        self.assertEqual(parse_kana("シャ'シシュシェショ", False)[0][0].accent, 1)
-        self.assertEqual(parse_kana("シャ'_シシュシェショ", False)[0][0].accent, 1)
-        self.assertEqual(parse_kana("シャシ'シュシェショ", False)[0][0].accent, 2)
-        self.assertEqual(parse_kana("シャ_シ'シュシェショ", False)[0][0].accent, 2)
-        self.assertEqual(parse_kana("シャシシュ'シェショ", False)[0][0].accent, 3)
-        self.assertEqual(parse_kana("シャ_シシュ'シェショ", False)[0][0].accent, 3)
-        self.assertEqual(parse_kana("シャシシュシェショ'", False)[0][0].accent, 5)
-        self.assertEqual(parse_kana("シャ_シシュシェショ'", False)[0][0].accent, 5)
+        self.assertEqual(parse_kana("シャ'シシュシェショ")[0].accent, 1)
+        self.assertEqual(parse_kana("シャ'_シシュシェショ")[0].accent, 1)
+        self.assertEqual(parse_kana("シャシ'シュシェショ")[0].accent, 2)
+        self.assertEqual(parse_kana("シャ_シ'シュシェショ")[0].accent, 2)
+        self.assertEqual(parse_kana("シャシシュ'シェショ")[0].accent, 3)
+        self.assertEqual(parse_kana("シャ_シシュ'シェショ")[0].accent, 3)
+        self.assertEqual(parse_kana("シャシシュシェショ'")[0].accent, 5)
+        self.assertEqual(parse_kana("シャ_シシュシェショ'")[0].accent, 5)
 
     def test_mora_length(self):
-        self.assertEqual(len(parse_kana("シャ'シシュシェショ", False)[0][0].moras), 5)
-        self.assertEqual(len(parse_kana("シャ'_シシュシェショ", False)[0][0].moras), 5)
-        self.assertEqual(len(parse_kana("シャシ'シュシェショ", False)[0][0].moras), 5)
-        self.assertEqual(len(parse_kana("シャ_シ'シュシェショ", False)[0][0].moras), 5)
-        self.assertEqual(len(parse_kana("シャシシュシェショ'", False)[0][0].moras), 5)
-        self.assertEqual(len(parse_kana("シャ_シシュシェショ'", False)[0][0].moras), 5)
+        self.assertEqual(len(parse_kana("シャ'シシュシェショ")[0].moras), 5)
+        self.assertEqual(len(parse_kana("シャ'_シシュシェショ")[0].moras), 5)
+        self.assertEqual(len(parse_kana("シャシ'シュシェショ")[0].moras), 5)
+        self.assertEqual(len(parse_kana("シャ_シ'シュシェショ")[0].moras), 5)
+        self.assertEqual(len(parse_kana("シャシシュシェショ'")[0].moras), 5)
+        self.assertEqual(len(parse_kana("シャ_シシュシェショ'")[0].moras), 5)
 
     def test_pause(self):
-        self.assertIsNone(parse_kana("ア'/ア'", False)[0][0].pause_mora)
-        self.assertIsNone(parse_kana("ア'/ア'", False)[0][1].pause_mora)
-        self.assertIsNotNone(parse_kana("ア'、ア'", False)[0][0].pause_mora)
-        self.assertIsNone(parse_kana("ア'、ア'", False)[0][1].pause_mora)
+        self.assertIsNone(parse_kana("ア'/ア'")[0].pause_mora)
+        self.assertIsNone(parse_kana("ア'/ア'")[1].pause_mora)
+        self.assertIsNotNone(parse_kana("ア'、ア'")[0].pause_mora)
+        self.assertIsNone(parse_kana("ア'、ア'")[1].pause_mora)
 
     def test_unvoice(self):
-        self.assertEqual(parse_kana("ス'", False)[0][0].moras[0].vowel, "u", False)
-        self.assertEqual(parse_kana("_ス'", False)[0][0].moras[0].vowel, "U", False)
+        self.assertEqual(parse_kana("ス'")[0].moras[0].vowel, "u")
+        self.assertEqual(parse_kana("_ス'")[0].moras[0].vowel, "U")
 
     def test_roundtrip(self):
         for text in ["コンニチワ'", "ワタシワ'/シャチョオデ'_ス", "トテモ'、エラ'インデス"]:
-            self.assertEqual(create_kana(parse_kana(text, False)[0]), text)
+            self.assertEqual(create_kana(parse_kana(text)), text)
 
         for text in ["ヲ'", "ェ'"]:
-            self.assertEqual(create_kana(parse_kana(text, False)[0]), text)
+            self.assertEqual(create_kana(parse_kana(text)), text)
 
     def _interrogative_accent_phrase_marks_base(
         self,
@@ -56,7 +62,7 @@ class TestParseKana(TestCase):
         enable_interrogative: bool,
         expected_interrogative_accent_phrase_marks: List[bool],
     ):
-        accent_phrases, interrogative_accent_phrase_marks = parse_kana(
+        accent_phrases, interrogative_accent_phrase_marks = kana_parser.parse_kana(
             text, enable_interrogative
         )
         self.assertEqual(len(accent_phrases), len(interrogative_accent_phrase_marks))
@@ -183,7 +189,7 @@ class TestParseKana(TestCase):
 class TestParseKanaException(TestCase):
     def _assert_error_code(self, kana: str, code: ParseKanaErrorCode):
         with self.assertRaises(ParseKanaError) as err:
-            parse_kana(kana, False)
+            parse_kana(kana)
         self.assertEqual(err.exception.errcode, code)
 
     def test_exceptions(self):
@@ -194,14 +200,17 @@ class TestParseKanaException(TestCase):
         self._assert_error_code("__ス'", ParseKanaErrorCode.UNKNOWN_TEXT)
         self._assert_error_code("ア'/", ParseKanaErrorCode.EMPTY_PHRASE)
         self._assert_error_code("/ア'", ParseKanaErrorCode.EMPTY_PHRASE)
-        self._assert_error_code("ア？ア'", ParseKanaErrorCode.UNKNOWN_TEXT)
 
         with self.assertRaises(ParseKanaError) as err:
-            parse_kana("ヒト'ツメ/フタツメ", False)
+            parse_kana("ヒト'ツメ/フタツメ")
         self.assertEqual(err.exception.errcode, ParseKanaErrorCode.ACCENT_NOTFOUND)
         self.assertEqual(err.exception.kwargs, {"text": "フタツメ"})
 
         with self.assertRaises(ParseKanaError) as err:
-            parse_kana("ア'/", False)
+            parse_kana("ア'/")
         self.assertEqual(err.exception.errcode, ParseKanaErrorCode.EMPTY_PHRASE)
         self.assertEqual(err.exception.kwargs, {"position": "2"})
+
+        with self.assertRaises(ParseKanaError) as err:
+            kana_parser.parse_kana("ア？ア'", True)
+        self.assertEqual(err.exception.errcode, ParseKanaErrorCode.UNKNOWN_TEXT)

--- a/test/test_kana_parser.py
+++ b/test/test_kana_parser.py
@@ -586,6 +586,7 @@ class TestParseKanaException(TestCase):
         self._assert_error_code("__ス'", ParseKanaErrorCode.UNKNOWN_TEXT)
         self._assert_error_code("ア'/", ParseKanaErrorCode.EMPTY_PHRASE)
         self._assert_error_code("/ア'", ParseKanaErrorCode.EMPTY_PHRASE)
+        self._assert_error_code("", ParseKanaErrorCode.EMPTY_PHRASE)
 
         with self.assertRaises(ParseKanaError) as err:
             parse_kana("ヒト'ツメ/フタツメ")

--- a/test/test_kana_parser.py
+++ b/test/test_kana_parser.py
@@ -1,3 +1,4 @@
+from typing import List
 from unittest import TestCase
 
 from voicevox_engine.kana_parser import create_kana, parse_kana
@@ -6,54 +7,183 @@ from voicevox_engine.model import ParseKanaError, ParseKanaErrorCode
 
 class TestParseKana(TestCase):
     def test_phrase_length(self):
-        self.assertEqual(len(parse_kana("ア'/ア'")), 2)
-        self.assertEqual(len(parse_kana("ア'、ア'")), 2)
-        self.assertEqual(len(parse_kana("ア'/ア'/ア'/ア'/ア'")), 5)
-        self.assertEqual(len(parse_kana("ス'")), 1)
-        self.assertEqual(len(parse_kana("_ス'")), 1)
-        self.assertEqual(len(parse_kana("ギェ'")), 1)
-        self.assertEqual(len(parse_kana("ギェ'、ギェ'/ギェ'")), 3)
+        self.assertEqual(len(parse_kana("ア'/ア'", False)[0]), 2)
+        self.assertEqual(len(parse_kana("ア'、ア'", False)[0]), 2)
+        self.assertEqual(len(parse_kana("ア'/ア'/ア'/ア'/ア'", False)[0]), 5)
+        self.assertEqual(len(parse_kana("ス'", False)[0]), 1)
+        self.assertEqual(len(parse_kana("_ス'", False)[0]), 1)
+        self.assertEqual(len(parse_kana("ギェ'", False)[0]), 1)
+        self.assertEqual(len(parse_kana("ギェ'、ギェ'/ギェ'", False)[0]), 3)
 
     def test_accent(self):
-        self.assertEqual(parse_kana("シャ'シシュシェショ")[0].accent, 1)
-        self.assertEqual(parse_kana("シャ'_シシュシェショ")[0].accent, 1)
-        self.assertEqual(parse_kana("シャシ'シュシェショ")[0].accent, 2)
-        self.assertEqual(parse_kana("シャ_シ'シュシェショ")[0].accent, 2)
-        self.assertEqual(parse_kana("シャシシュ'シェショ")[0].accent, 3)
-        self.assertEqual(parse_kana("シャ_シシュ'シェショ")[0].accent, 3)
-        self.assertEqual(parse_kana("シャシシュシェショ'")[0].accent, 5)
-        self.assertEqual(parse_kana("シャ_シシュシェショ'")[0].accent, 5)
+        self.assertEqual(parse_kana("シャ'シシュシェショ", False)[0][0].accent, 1)
+        self.assertEqual(parse_kana("シャ'_シシュシェショ", False)[0][0].accent, 1)
+        self.assertEqual(parse_kana("シャシ'シュシェショ", False)[0][0].accent, 2)
+        self.assertEqual(parse_kana("シャ_シ'シュシェショ", False)[0][0].accent, 2)
+        self.assertEqual(parse_kana("シャシシュ'シェショ", False)[0][0].accent, 3)
+        self.assertEqual(parse_kana("シャ_シシュ'シェショ", False)[0][0].accent, 3)
+        self.assertEqual(parse_kana("シャシシュシェショ'", False)[0][0].accent, 5)
+        self.assertEqual(parse_kana("シャ_シシュシェショ'", False)[0][0].accent, 5)
 
     def test_mora_length(self):
-        self.assertEqual(len(parse_kana("シャ'シシュシェショ")[0].moras), 5)
-        self.assertEqual(len(parse_kana("シャ'_シシュシェショ")[0].moras), 5)
-        self.assertEqual(len(parse_kana("シャシ'シュシェショ")[0].moras), 5)
-        self.assertEqual(len(parse_kana("シャ_シ'シュシェショ")[0].moras), 5)
-        self.assertEqual(len(parse_kana("シャシシュシェショ'")[0].moras), 5)
-        self.assertEqual(len(parse_kana("シャ_シシュシェショ'")[0].moras), 5)
+        self.assertEqual(len(parse_kana("シャ'シシュシェショ", False)[0][0].moras), 5)
+        self.assertEqual(len(parse_kana("シャ'_シシュシェショ", False)[0][0].moras), 5)
+        self.assertEqual(len(parse_kana("シャシ'シュシェショ", False)[0][0].moras), 5)
+        self.assertEqual(len(parse_kana("シャ_シ'シュシェショ", False)[0][0].moras), 5)
+        self.assertEqual(len(parse_kana("シャシシュシェショ'", False)[0][0].moras), 5)
+        self.assertEqual(len(parse_kana("シャ_シシュシェショ'", False)[0][0].moras), 5)
 
     def test_pause(self):
-        self.assertIsNone(parse_kana("ア'/ア'")[0].pause_mora)
-        self.assertIsNone(parse_kana("ア'/ア'")[1].pause_mora)
-        self.assertIsNotNone(parse_kana("ア'、ア'")[0].pause_mora)
-        self.assertIsNone(parse_kana("ア'、ア'")[1].pause_mora)
+        self.assertIsNone(parse_kana("ア'/ア'", False)[0][0].pause_mora)
+        self.assertIsNone(parse_kana("ア'/ア'", False)[0][1].pause_mora)
+        self.assertIsNotNone(parse_kana("ア'、ア'", False)[0][0].pause_mora)
+        self.assertIsNone(parse_kana("ア'、ア'", False)[0][1].pause_mora)
 
     def test_unvoice(self):
-        self.assertEqual(parse_kana("ス'")[0].moras[0].vowel, "u")
-        self.assertEqual(parse_kana("_ス'")[0].moras[0].vowel, "U")
+        self.assertEqual(parse_kana("ス'", False)[0][0].moras[0].vowel, "u", False)
+        self.assertEqual(parse_kana("_ス'", False)[0][0].moras[0].vowel, "U", False)
 
     def test_roundtrip(self):
         for text in ["コンニチワ'", "ワタシワ'/シャチョオデ'_ス", "トテモ'、エラ'インデス"]:
-            self.assertEqual(create_kana(parse_kana(text)), text)
+            self.assertEqual(create_kana(parse_kana(text, False)[0]), text)
 
         for text in ["ヲ'", "ェ'"]:
-            self.assertEqual(create_kana(parse_kana(text)), text)
+            self.assertEqual(create_kana(parse_kana(text, False)[0]), text)
+
+    def _interrogative_accent_phrase_marks_base(
+        self,
+        text: str,
+        enable_interrogative: bool,
+        expected_interrogative_accent_phrase_marks: List[bool],
+    ):
+        accent_phrases, interrogative_accent_phrase_marks = parse_kana(
+            text, enable_interrogative
+        )
+        self.assertEqual(len(accent_phrases), len(interrogative_accent_phrase_marks))
+        self.assertEqual(
+            interrogative_accent_phrase_marks,
+            expected_interrogative_accent_phrase_marks,
+        )
+
+    def test_interrogative_accent_phrase_marks(self):
+        self._interrogative_accent_phrase_marks_base(
+            text="ア'/ア'",
+            enable_interrogative=False,
+            expected_interrogative_accent_phrase_marks=[False, False],
+        )
+        self._interrogative_accent_phrase_marks_base(
+            text="ア'/ア'",
+            enable_interrogative=True,
+            expected_interrogative_accent_phrase_marks=[False, False],
+        )
+
+        self._interrogative_accent_phrase_marks_base(
+            text="ア'、ア'",
+            enable_interrogative=False,
+            expected_interrogative_accent_phrase_marks=[False, False],
+        )
+        self._interrogative_accent_phrase_marks_base(
+            text="ア'、ア'",
+            enable_interrogative=True,
+            expected_interrogative_accent_phrase_marks=[False, False],
+        )
+
+        self._interrogative_accent_phrase_marks_base(
+            text="ア'/ア'/ア'/ア'/ア'",
+            enable_interrogative=False,
+            expected_interrogative_accent_phrase_marks=[
+                False,
+                False,
+                False,
+                False,
+                False,
+            ],
+        )
+        self._interrogative_accent_phrase_marks_base(
+            text="ア'/ア'/ア'/ア'/ア'",
+            enable_interrogative=True,
+            expected_interrogative_accent_phrase_marks=[
+                False,
+                False,
+                False,
+                False,
+                False,
+            ],
+        )
+
+        self._interrogative_accent_phrase_marks_base(
+            text="ス'",
+            enable_interrogative=False,
+            expected_interrogative_accent_phrase_marks=[False],
+        )
+        self._interrogative_accent_phrase_marks_base(
+            text="ス'",
+            enable_interrogative=True,
+            expected_interrogative_accent_phrase_marks=[False],
+        )
+
+        self._interrogative_accent_phrase_marks_base(
+            text="_ス'",
+            enable_interrogative=False,
+            expected_interrogative_accent_phrase_marks=[False],
+        )
+        self._interrogative_accent_phrase_marks_base(
+            text="_ス'",
+            enable_interrogative=True,
+            expected_interrogative_accent_phrase_marks=[False],
+        )
+
+        self._interrogative_accent_phrase_marks_base(
+            text="ギェ'",
+            enable_interrogative=False,
+            expected_interrogative_accent_phrase_marks=[False],
+        )
+        self._interrogative_accent_phrase_marks_base(
+            text="ギェ'",
+            enable_interrogative=True,
+            expected_interrogative_accent_phrase_marks=[False],
+        )
+
+        self._interrogative_accent_phrase_marks_base(
+            text="ギェ'、ギェ'/ギェ'",
+            enable_interrogative=False,
+            expected_interrogative_accent_phrase_marks=[False, False, False],
+        )
+        self._interrogative_accent_phrase_marks_base(
+            text="ギェ'、ギェ'/ギェ'",
+            enable_interrogative=True,
+            expected_interrogative_accent_phrase_marks=[False, False, False],
+        )
+
+        self._interrogative_accent_phrase_marks_base(
+            text="ア'？",
+            enable_interrogative=False,
+            expected_interrogative_accent_phrase_marks=[False],
+        )
+
+        self._interrogative_accent_phrase_marks_base(
+            text="ア'？",
+            enable_interrogative=True,
+            expected_interrogative_accent_phrase_marks=[True],
+        )
+
+        self._interrogative_accent_phrase_marks_base(
+            text="ギェ'、ギェ'/ギェ'？",
+            enable_interrogative=False,
+            expected_interrogative_accent_phrase_marks=[False, False, False],
+        )
+
+        self._interrogative_accent_phrase_marks_base(
+            text="ギェ'、ギェ'/ギェ'？",
+            enable_interrogative=True,
+            expected_interrogative_accent_phrase_marks=[False, False, True],
+        )
 
 
 class TestParseKanaException(TestCase):
     def _assert_error_code(self, kana: str, code: ParseKanaErrorCode):
         with self.assertRaises(ParseKanaError) as err:
-            parse_kana(kana)
+            parse_kana(kana, False)
         self.assertEqual(err.exception.errcode, code)
 
     def test_exceptions(self):
@@ -64,13 +194,14 @@ class TestParseKanaException(TestCase):
         self._assert_error_code("__ス'", ParseKanaErrorCode.UNKNOWN_TEXT)
         self._assert_error_code("ア'/", ParseKanaErrorCode.EMPTY_PHRASE)
         self._assert_error_code("/ア'", ParseKanaErrorCode.EMPTY_PHRASE)
+        self._assert_error_code("ア？ア'", ParseKanaErrorCode.UNKNOWN_TEXT)
 
         with self.assertRaises(ParseKanaError) as err:
-            parse_kana("ヒト'ツメ/フタツメ")
+            parse_kana("ヒト'ツメ/フタツメ", False)
         self.assertEqual(err.exception.errcode, ParseKanaErrorCode.ACCENT_NOTFOUND)
         self.assertEqual(err.exception.kwargs, {"text": "フタツメ"})
 
         with self.assertRaises(ParseKanaError) as err:
-            parse_kana("ア'/")
+            parse_kana("ア'/", False)
         self.assertEqual(err.exception.errcode, ParseKanaErrorCode.EMPTY_PHRASE)
         self.assertEqual(err.exception.kwargs, {"position": "2"})

--- a/test/test_kana_parser.py
+++ b/test/test_kana_parser.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 
 from voicevox_engine import kana_parser
 from voicevox_engine.kana_parser import create_kana
-from voicevox_engine.model import AccentPhrase, ParseKanaError, ParseKanaErrorCode
+from voicevox_engine.model import AccentPhrase, Mora, ParseKanaError, ParseKanaErrorCode
 
 
 def parse_kana(text: str) -> List[AccentPhrase]:
@@ -60,43 +60,202 @@ class TestParseKana(TestCase):
         self,
         text: str,
         enable_interrogative: bool,
+        expected_accent_phrases: List[AccentPhrase],
         expected_interrogative_accent_phrase_marks: List[bool],
     ):
         accent_phrases, interrogative_accent_phrase_marks = kana_parser.parse_kana(
             text, enable_interrogative
         )
         self.assertEqual(len(accent_phrases), len(interrogative_accent_phrase_marks))
+        self.assertEqual(expected_accent_phrases, accent_phrases)
         self.assertEqual(
             interrogative_accent_phrase_marks,
             expected_interrogative_accent_phrase_marks,
         )
 
     def test_interrogative_accent_phrase_marks(self):
+        def a_slash_a_accent_phrases():
+            return [
+                AccentPhrase(
+                    moras=[
+                        Mora(
+                            text="ア",
+                            consonant=None,
+                            consonant_length=None,
+                            vowel="a",
+                            vowel_length=0.0,
+                            pitch=0.0,
+                        ),
+                    ],
+                    accent=1,
+                    pause_mora=None,
+                ),
+                AccentPhrase(
+                    moras=[
+                        Mora(
+                            text="ア",
+                            consonant=None,
+                            consonant_length=None,
+                            vowel="a",
+                            vowel_length=0.0,
+                            pitch=0.0,
+                        ),
+                    ],
+                    accent=1,
+                    pause_mora=None,
+                ),
+            ]
+
+        expected_accent_phrases = a_slash_a_accent_phrases()
         self._interrogative_accent_phrase_marks_base(
             text="ア'/ア'",
             enable_interrogative=False,
+            expected_accent_phrases=expected_accent_phrases,
             expected_interrogative_accent_phrase_marks=[False, False],
         )
+
+        expected_accent_phrases = a_slash_a_accent_phrases()
         self._interrogative_accent_phrase_marks_base(
             text="ア'/ア'",
             enable_interrogative=True,
+            expected_accent_phrases=expected_accent_phrases,
             expected_interrogative_accent_phrase_marks=[False, False],
         )
 
+        def a_jp_comma_a_accent_phrases():
+            return [
+                AccentPhrase(
+                    moras=[
+                        Mora(
+                            text="ア",
+                            consonant=None,
+                            consonant_length=None,
+                            vowel="a",
+                            vowel_length=0.0,
+                            pitch=0.0,
+                        ),
+                    ],
+                    accent=1,
+                    pause_mora=Mora(
+                        text="、",
+                        consonant=None,
+                        consonant_length=None,
+                        vowel="pau",
+                        vowel_length=0.0,
+                        pitch=0.0,
+                    ),
+                ),
+                AccentPhrase(
+                    moras=[
+                        Mora(
+                            text="ア",
+                            consonant=None,
+                            consonant_length=None,
+                            vowel="a",
+                            vowel_length=0.0,
+                            pitch=0.0,
+                        ),
+                    ],
+                    accent=1,
+                    pause_mora=None,
+                ),
+            ]
+
+        expected_accent_phrases = a_jp_comma_a_accent_phrases()
         self._interrogative_accent_phrase_marks_base(
             text="ア'、ア'",
             enable_interrogative=False,
-            expected_interrogative_accent_phrase_marks=[False, False],
-        )
-        self._interrogative_accent_phrase_marks_base(
-            text="ア'、ア'",
-            enable_interrogative=True,
+            expected_accent_phrases=expected_accent_phrases,
             expected_interrogative_accent_phrase_marks=[False, False],
         )
 
+        expected_accent_phrases = a_jp_comma_a_accent_phrases()
+        self._interrogative_accent_phrase_marks_base(
+            text="ア'、ア'",
+            enable_interrogative=True,
+            expected_accent_phrases=expected_accent_phrases,
+            expected_interrogative_accent_phrase_marks=[False, False],
+        )
+
+        def a_slash_a_slash_a_slash_a_slash_a_accent_phrases():
+            return [
+                AccentPhrase(
+                    moras=[
+                        Mora(
+                            text="ア",
+                            consonant=None,
+                            consonant_length=None,
+                            vowel="a",
+                            vowel_length=0.0,
+                            pitch=0.0,
+                        ),
+                    ],
+                    accent=1,
+                    pause_mora=None,
+                ),
+                AccentPhrase(
+                    moras=[
+                        Mora(
+                            text="ア",
+                            consonant=None,
+                            consonant_length=None,
+                            vowel="a",
+                            vowel_length=0.0,
+                            pitch=0.0,
+                        ),
+                    ],
+                    accent=1,
+                    pause_mora=None,
+                ),
+                AccentPhrase(
+                    moras=[
+                        Mora(
+                            text="ア",
+                            consonant=None,
+                            consonant_length=None,
+                            vowel="a",
+                            vowel_length=0.0,
+                            pitch=0.0,
+                        ),
+                    ],
+                    accent=1,
+                    pause_mora=None,
+                ),
+                AccentPhrase(
+                    moras=[
+                        Mora(
+                            text="ア",
+                            consonant=None,
+                            consonant_length=None,
+                            vowel="a",
+                            vowel_length=0.0,
+                            pitch=0.0,
+                        ),
+                    ],
+                    accent=1,
+                    pause_mora=None,
+                ),
+                AccentPhrase(
+                    moras=[
+                        Mora(
+                            text="ア",
+                            consonant=None,
+                            consonant_length=None,
+                            vowel="a",
+                            vowel_length=0.0,
+                            pitch=0.0,
+                        ),
+                    ],
+                    accent=1,
+                    pause_mora=None,
+                ),
+            ]
+
+        expected_accent_phrases = a_slash_a_slash_a_slash_a_slash_a_accent_phrases()
         self._interrogative_accent_phrase_marks_base(
             text="ア'/ア'/ア'/ア'/ア'",
             enable_interrogative=False,
+            expected_accent_phrases=expected_accent_phrases,
             expected_interrogative_accent_phrase_marks=[
                 False,
                 False,
@@ -105,9 +264,11 @@ class TestParseKana(TestCase):
                 False,
             ],
         )
+        expected_accent_phrases = a_slash_a_slash_a_slash_a_slash_a_accent_phrases()
         self._interrogative_accent_phrase_marks_base(
             text="ア'/ア'/ア'/ア'/ア'",
             enable_interrogative=True,
+            expected_accent_phrases=expected_accent_phrases,
             expected_interrogative_accent_phrase_marks=[
                 False,
                 False,
@@ -117,71 +278,296 @@ class TestParseKana(TestCase):
             ],
         )
 
+        def su_accent_phrases():
+            return [
+                AccentPhrase(
+                    moras=[
+                        Mora(
+                            text="ス",
+                            consonant="s",
+                            consonant_length=0.0,
+                            vowel="u",
+                            vowel_length=0.0,
+                            pitch=0.0,
+                        ),
+                    ],
+                    accent=1,
+                    pause_mora=None,
+                ),
+            ]
+
+        expected_accent_phrases = su_accent_phrases()
         self._interrogative_accent_phrase_marks_base(
             text="ス'",
             enable_interrogative=False,
+            expected_accent_phrases=expected_accent_phrases,
             expected_interrogative_accent_phrase_marks=[False],
         )
+        expected_accent_phrases = su_accent_phrases()
         self._interrogative_accent_phrase_marks_base(
             text="ス'",
             enable_interrogative=True,
+            expected_accent_phrases=expected_accent_phrases,
             expected_interrogative_accent_phrase_marks=[False],
         )
 
+        def under_score_su_accent_phrases():
+            return [
+                AccentPhrase(
+                    moras=[
+                        Mora(
+                            text="ス",
+                            consonant="s",
+                            consonant_length=0.0,
+                            vowel="U",
+                            vowel_length=0.0,
+                            pitch=0.0,
+                        ),
+                    ],
+                    accent=1,
+                    pause_mora=None,
+                ),
+            ]
+
+        expected_accent_phrases = under_score_su_accent_phrases()
         self._interrogative_accent_phrase_marks_base(
             text="_ス'",
             enable_interrogative=False,
+            expected_accent_phrases=expected_accent_phrases,
             expected_interrogative_accent_phrase_marks=[False],
         )
+
+        expected_accent_phrases = under_score_su_accent_phrases()
         self._interrogative_accent_phrase_marks_base(
             text="_ス'",
             enable_interrogative=True,
+            expected_accent_phrases=expected_accent_phrases,
             expected_interrogative_accent_phrase_marks=[False],
         )
 
+        def gye_accent_phrases():
+            return [
+                AccentPhrase(
+                    moras=[
+                        Mora(
+                            text="ギェ",
+                            consonant="gy",
+                            consonant_length=0.0,
+                            vowel="e",
+                            vowel_length=0.0,
+                            pitch=0.0,
+                        ),
+                    ],
+                    accent=1,
+                    pause_mora=None,
+                ),
+            ]
+
+        expected_accent_phrases = gye_accent_phrases()
         self._interrogative_accent_phrase_marks_base(
             text="ギェ'",
             enable_interrogative=False,
+            expected_accent_phrases=expected_accent_phrases,
             expected_interrogative_accent_phrase_marks=[False],
         )
+
+        expected_accent_phrases = gye_accent_phrases()
         self._interrogative_accent_phrase_marks_base(
             text="ギェ'",
             enable_interrogative=True,
+            expected_accent_phrases=expected_accent_phrases,
             expected_interrogative_accent_phrase_marks=[False],
         )
 
+        def gye_gye_gye_accent_phrases():
+            return [
+                AccentPhrase(
+                    moras=[
+                        Mora(
+                            text="ギェ",
+                            consonant="gy",
+                            consonant_length=0.0,
+                            vowel="e",
+                            vowel_length=0.0,
+                            pitch=0.0,
+                        ),
+                    ],
+                    accent=1,
+                    pause_mora=Mora(
+                        text="、",
+                        consonant=None,
+                        consonant_length=None,
+                        vowel="pau",
+                        vowel_length=0.0,
+                        pitch=0.0,
+                    ),
+                ),
+                AccentPhrase(
+                    moras=[
+                        Mora(
+                            text="ギェ",
+                            consonant="gy",
+                            consonant_length=0.0,
+                            vowel="e",
+                            vowel_length=0.0,
+                            pitch=0.0,
+                        ),
+                    ],
+                    accent=1,
+                    pause_mora=None,
+                ),
+                AccentPhrase(
+                    moras=[
+                        Mora(
+                            text="ギェ",
+                            consonant="gy",
+                            consonant_length=0.0,
+                            vowel="e",
+                            vowel_length=0.0,
+                            pitch=0.0,
+                        ),
+                    ],
+                    accent=1,
+                    pause_mora=None,
+                ),
+            ]
+
+        expected_accent_phrases = gye_gye_gye_accent_phrases()
         self._interrogative_accent_phrase_marks_base(
             text="ギェ'、ギェ'/ギェ'",
             enable_interrogative=False,
-            expected_interrogative_accent_phrase_marks=[False, False, False],
-        )
-        self._interrogative_accent_phrase_marks_base(
-            text="ギェ'、ギェ'/ギェ'",
-            enable_interrogative=True,
+            expected_accent_phrases=expected_accent_phrases,
             expected_interrogative_accent_phrase_marks=[False, False, False],
         )
 
+        expected_accent_phrases = gye_gye_gye_accent_phrases()
+        self._interrogative_accent_phrase_marks_base(
+            text="ギェ'、ギェ'/ギェ'",
+            enable_interrogative=True,
+            expected_accent_phrases=expected_accent_phrases,
+            expected_interrogative_accent_phrase_marks=[False, False, False],
+        )
+
+        def a_question_mark_accent_phrases():
+            return [
+                AccentPhrase(
+                    moras=[
+                        Mora(
+                            text="ア",
+                            consonant=None,
+                            consonant_length=None,
+                            vowel="a",
+                            vowel_length=0.0,
+                            pitch=0.0,
+                        ),
+                    ],
+                    accent=1,
+                    pause_mora=None,
+                ),
+            ]
+
+        expected_accent_phrases = a_question_mark_accent_phrases()
         self._interrogative_accent_phrase_marks_base(
             text="ア'？",
             enable_interrogative=False,
+            expected_accent_phrases=expected_accent_phrases,
             expected_interrogative_accent_phrase_marks=[False],
         )
 
+        expected_accent_phrases = a_question_mark_accent_phrases()
+        expected_accent_phrases[0].moras.append(
+            Mora(
+                text="ア",
+                consonant=None,
+                consonant_length=None,
+                vowel="a",
+                vowel_length=0.0,
+                pitch=0.0,
+            )
+        )
         self._interrogative_accent_phrase_marks_base(
             text="ア'？",
             enable_interrogative=True,
+            expected_accent_phrases=expected_accent_phrases,
             expected_interrogative_accent_phrase_marks=[True],
         )
 
+        def gye_gye_gye_question_mark_accent_phrases():
+            return [
+                AccentPhrase(
+                    moras=[
+                        Mora(
+                            text="ギェ",
+                            consonant="gy",
+                            consonant_length=0.0,
+                            vowel="e",
+                            vowel_length=0.0,
+                            pitch=0.0,
+                        ),
+                    ],
+                    accent=1,
+                    pause_mora=Mora(
+                        text="、",
+                        consonant=None,
+                        consonant_length=None,
+                        vowel="pau",
+                        vowel_length=0.0,
+                        pitch=0.0,
+                    ),
+                ),
+                AccentPhrase(
+                    moras=[
+                        Mora(
+                            text="ギェ",
+                            consonant="gy",
+                            consonant_length=0.0,
+                            vowel="e",
+                            vowel_length=0.0,
+                            pitch=0.0,
+                        ),
+                    ],
+                    accent=1,
+                    pause_mora=None,
+                ),
+                AccentPhrase(
+                    moras=[
+                        Mora(
+                            text="ギェ",
+                            consonant="gy",
+                            consonant_length=0.0,
+                            vowel="e",
+                            vowel_length=0.0,
+                            pitch=0.0,
+                        ),
+                    ],
+                    accent=1,
+                    pause_mora=None,
+                ),
+            ]
+
+        expected_accent_phrases = gye_gye_gye_question_mark_accent_phrases()
         self._interrogative_accent_phrase_marks_base(
             text="ギェ'、ギェ'/ギェ'？",
             enable_interrogative=False,
+            expected_accent_phrases=expected_accent_phrases,
             expected_interrogative_accent_phrase_marks=[False, False, False],
         )
 
+        expected_accent_phrases = gye_gye_gye_question_mark_accent_phrases()
+        expected_accent_phrases[-1].moras.append(
+            Mora(
+                text="エ",
+                consonant=None,
+                consonant_length=None,
+                vowel="e",
+                vowel_length=0.0,
+                pitch=0.0,
+            )
+        )
         self._interrogative_accent_phrase_marks_base(
             text="ギェ'、ギェ'/ギェ'？",
             enable_interrogative=True,
+            expected_accent_phrases=expected_accent_phrases,
             expected_interrogative_accent_phrase_marks=[False, False, True],
         )
 

--- a/voicevox_engine/kana_parser.py
+++ b/voicevox_engine/kana_parser.py
@@ -1,7 +1,7 @@
 from typing import List, Optional, Tuple
 
 from .model import AccentPhrase, Mora, ParseKanaError, ParseKanaErrorCode
-from .mora_list import openjtalk_text2mora
+from .mora_list import openjtalk_mora2text, openjtalk_text2mora
 
 LOOP_LIMIT = 300
 UNVOICE_SYMBOL = "_"
@@ -119,7 +119,7 @@ def parse_kana(
         last_mora = last_parsed_result.moras[-1]
         last_parsed_result.moras.append(
             Mora(
-                text=last_mora.vowel,
+                text=openjtalk_mora2text[last_mora.vowel],
                 consonant=None,
                 consonant_length=None,
                 vowel=last_mora.vowel,

--- a/voicevox_engine/kana_parser.py
+++ b/voicevox_engine/kana_parser.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 from .model import AccentPhrase, Mora, ParseKanaError, ParseKanaErrorCode
 from .mora_list import openjtalk_text2mora
@@ -8,6 +8,7 @@ UNVOICE_SYMBOL = "_"
 ACCENT_SYMBOL = "'"
 NOPAUSE_DELIMITER = "/"
 PAUSE_DELIMITER = "、"
+WIDE_INTERROGATION_MARK = "？"
 
 text2mora_with_unvoice = {}
 for text, (consonant, vowel) in openjtalk_text2mora.items():
@@ -78,12 +79,18 @@ def _text_to_accent_phrase(phrase: str) -> List[AccentPhrase]:
         return AccentPhrase(moras=moras, accent=accent_index, pause_mora=None)
 
 
-def parse_kana(text: str) -> List[AccentPhrase]:
+def parse_kana(
+    text: str, enable_interrogative: bool
+) -> Tuple[List[AccentPhrase], List[bool]]:
     """
     AquesTalkライクな読み仮名をパースして音長・音高未指定のaccent phraseに変換
     """
     parsed_results: List[AccentPhrase] = []
     phrase_base = 0
+    is_interrogative_text = text[-1] == WIDE_INTERROGATION_MARK
+    if is_interrogative_text:
+        text = text[:-1]
+
     for i in range(len(text) + 1):
         if i == len(text) or text[i] in [PAUSE_DELIMITER, NOPAUSE_DELIMITER]:
             phrase = text[phrase_base:i]
@@ -102,10 +109,27 @@ def parse_kana(text: str) -> List[AccentPhrase]:
                     vowel="pau",
                     vowel_length=0,
                     pitch=0,
-                    is_interrogative=False,
                 )
             parsed_results.append(accent_phrase)
-    return parsed_results
+
+    interrogative_accent_phrase_marks = [False] * len(parsed_results)
+
+    if enable_interrogative and is_interrogative_text:
+        last_parsed_result = parsed_results[-1]
+        last_mora = last_parsed_result.moras[-1]
+        last_parsed_result.moras.append(
+            Mora(
+                text=last_mora.vowel,
+                consonant=None,
+                consonant_length=None,
+                vowel=last_mora.vowel,
+                vowel_length=last_mora.vowel_length,
+                pitch=0,
+            )
+        )
+        interrogative_accent_phrase_marks[-1] = True
+
+    return parsed_results, interrogative_accent_phrase_marks
 
 
 def create_kana(accent_phrases: List[AccentPhrase]) -> str:

--- a/voicevox_engine/kana_parser.py
+++ b/voicevox_engine/kana_parser.py
@@ -87,6 +87,8 @@ def parse_kana(
     """
     parsed_results: List[AccentPhrase] = []
     phrase_base = 0
+    if len(text) == 0:
+        raise ParseKanaError(ParseKanaErrorCode.EMPTY_PHRASE, position=1)
     is_interrogative_text = text[-1] == WIDE_INTERROGATION_MARK
     if is_interrogative_text:
         text = text[:-1]

--- a/voicevox_engine/synthesis_engine/synthesis_engine_base.py
+++ b/voicevox_engine/synthesis_engine/synthesis_engine_base.py
@@ -37,22 +37,25 @@ def add_interrogative_mora_if_last_phoneme_is_interrogative(
 
 def adjust_interrogative_accent_phrases(
     accent_phrases: List[AccentPhrase],
-    fcl_accent_phrases: List[full_context_label.AccentPhrase],
+    interrogative_accent_phrase_marks: List[bool],
     enable_interrogative: bool,
 ) -> List[AccentPhrase]:
     """
     enable_interrogativeが有効になっていて与えられたaccent_phrasesに疑問系のものがあった場合、
     SynthesisEngineの実装によって調整されたあとの各accent_phraseの末尾にある疑問系発音用のMoraに対して直前のMoraより少し音を高くすることで疑問文ぽくする
+    NOTE: リファクタリング時に適切な場所へ移動させること
     """
     return [
         AccentPhrase(
             moras=adjust_interrogative_moras(accent_phrase.moras)
-            if enable_interrogative and fcl_accent_phrase.is_interrogative
+            if enable_interrogative and interrogative_accent_phrase_mark
             else accent_phrase.moras,
             accent=accent_phrase.accent,
             pause_mora=accent_phrase.pause_mora,
         )
-        for accent_phrase, fcl_accent_phrase in zip(accent_phrases, fcl_accent_phrases)
+        for accent_phrase, interrogative_accent_phrase_mark in zip(
+            accent_phrases, interrogative_accent_phrase_marks
+        )
     ]
 
 
@@ -153,8 +156,8 @@ class SynthesisEngineBase(metaclass=ABCMeta):
         if len(utterance.breath_groups) == 0:
             return []
 
-        fcl_accent_phrases = [
-            accent_phrase
+        interrogative_accent_phrase_marks = [
+            accent_phrase.is_interrogative
             for breath_group in utterance.breath_groups
             for accent_phrase in breath_group.accent_phrases
         ]
@@ -193,7 +196,7 @@ class SynthesisEngineBase(metaclass=ABCMeta):
             speaker_id=speaker_id,
         )
         return adjust_interrogative_accent_phrases(
-            accent_phrases, fcl_accent_phrases, enable_interrogative
+            accent_phrases, interrogative_accent_phrase_marks, enable_interrogative
         )
 
     @abstractmethod


### PR DESCRIPTION


## 内容

タイトル通りでparse_kanaで提供されてるaquestalk記法での疑問文対応を行いました。

## 関連 Issue
refs #235


## その他
とりあえずやってみたのですが、実装がどうもいびつになってしまい先にリファクタリングをしてからこれの実装をしたほうが良かったかもしれません
テストデータの共通化などもするべきですが、そもそもmergeされるか不透明なので一旦このままPR出します。
なお疑問文対応ですがaquestalkの仕様に基づき文の終わりのみに？(全角)がつけられてる場合に限り疑問文調整がされるようにしてます
https://www.a-quest.com/archive/manual/siyo_onseikigou.pdf
