### PR TITLE
Dockerイメージ: ONNX版コアに対応

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -51,13 +51,13 @@ jobs:
           - tag: nvidia
             target: runtime-nvidia-env
             base_image: ubuntu:focal
-            base_runtime_image: nvidia/driver:460.73.01-ubuntu20.04
+            base_runtime_image: nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu20.04
             voicevox_core_library_name: libcore_gpu_x64_nvidia.so
             onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-linux-x64-gpu-1.9.0.tgz
           - tag: nvidia-ubuntu20.04
             target: runtime-nvidia-env
             base_image: ubuntu:focal
-            base_runtime_image: nvidia/driver:460.73.01-ubuntu20.04
+            base_runtime_image: nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu20.04
             voicevox_core_library_name: libcore_gpu_x64_nvidia.so
             onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-linux-x64-gpu-1.9.0.tgz
           # Ubuntu 18.04
@@ -70,7 +70,7 @@ jobs:
           - tag: nvidia-ubuntu18.04
             target: runtime-nvidia-env
             base_image: ubuntu:bionic
-            base_runtime_image: nvidia/driver:460.73.01-ubuntu18.04
+            base_runtime_image: nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu18.04
             voicevox_core_library_name: libcore_gpu_x64_nvidia.so
             onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-linux-x64-gpu-1.9.0.tgz
 

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -51,13 +51,13 @@ jobs:
           - tag: nvidia
             target: runtime-nvidia-env
             base_image: ubuntu:focal
-            base_runtime_image: nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu20.04
+            base_runtime_image: nvidia/cuda:11.4.2-cudnn8-runtime-ubuntu20.04
             voicevox_core_library_name: libcore_gpu_x64_nvidia.so
             onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-linux-x64-gpu-1.9.0.tgz
           - tag: nvidia-ubuntu20.04
             target: runtime-nvidia-env
             base_image: ubuntu:focal
-            base_runtime_image: nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu20.04
+            base_runtime_image: nvidia/cuda:11.4.2-cudnn8-runtime-ubuntu20.04
             voicevox_core_library_name: libcore_gpu_x64_nvidia.so
             onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-linux-x64-gpu-1.9.0.tgz
           # Ubuntu 18.04
@@ -70,7 +70,7 @@ jobs:
           - tag: nvidia-ubuntu18.04
             target: runtime-nvidia-env
             base_image: ubuntu:bionic
-            base_runtime_image: nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu18.04
+            base_runtime_image: nvidia/cuda:11.4.2-cudnn8-runtime-ubuntu18.04
             voicevox_core_library_name: libcore_gpu_x64_nvidia.so
             onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-linux-x64-gpu-1.9.0.tgz
 

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -27,7 +27,7 @@ jobs:
           - cpu-ubuntu18.04
           - nvidia-ubuntu18.04
         voicevox_core_version: ['0.10.preview.0']
-        voicevox_core_example_version: ['0.10.preview.0']
+        voicevox_core_source_version: ['0.10.preview.0']
         include:
           # Ubuntu 20.04
           - tag: ''
@@ -107,7 +107,7 @@ jobs:
             BASE_IMAGE=${{ matrix.base_image }}
             BASE_RUNTIME_IMAGE=${{ matrix.base_runtime_image }}
             VOICEVOX_CORE_VERSION=${{ matrix.voicevox_core_version }}
-            VOICEVOX_CORE_EXAMPLE_VERSION=${{ matrix.voicevox_core_example_version }}
+            VOICEVOX_CORE_SOURCE_VERSION=${{ matrix.voicevox_core_source_version }}
             VOICEVOX_CORE_LIBRARY_NAME=${{ matrix.voicevox_core_library_name }}
             ONNXRUNTIME_URL=${{ matrix.onnxruntime_url }}
           target: ${{ matrix.target }}

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -14,7 +14,6 @@ jobs:
 
     env:
       IMAGE_NAME: ${{ secrets.DOCKERHUB_USERNAME }}/voicevox_engine
-      # IMAGE_NAME: voicevox/voicevox_engine
 
     strategy:
       matrix:
@@ -27,55 +26,53 @@ jobs:
           - nvidia-ubuntu20.04
           - cpu-ubuntu18.04
           - nvidia-ubuntu18.04
-        voicevox_core_version: [0.9.0]
-        voicevox_core_example_version: [0.9.0]
+        voicevox_core_version: ['0.10.preview.0']
+        voicevox_core_example_version: ['0.10.preview.0']
         include:
           # Ubuntu 20.04
           - tag: ''
             target: runtime-env
             base_image: ubuntu:focal
             base_runtime_image: ubuntu:focal
-            voicevox_core_library_name: core_cpu
-            libtorch_url: https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip
+            voicevox_core_library_name: libcore_cpu_x64.so
+            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-linux-x64-1.9.0.tgz
           - tag: cpu
             target: runtime-env
             base_image: ubuntu:focal
             base_runtime_image: ubuntu:focal
-            voicevox_core_library_name: core_cpu
-            libtorch_url: https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip
+            voicevox_core_library_name: libcore_cpu_x64.so
+            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-linux-x64-1.9.0.tgz
           - tag: cpu-ubuntu20.04
             target: runtime-env
             base_image: ubuntu:focal
             base_runtime_image: ubuntu:focal
-            voicevox_core_library_name: core_cpu
-            libtorch_url: https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip
+            voicevox_core_library_name: libcore_cpu_x64.so
+            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-linux-x64-1.9.0.tgz
           - tag: nvidia
             target: runtime-nvidia-env
             base_image: ubuntu:focal
             base_runtime_image: nvidia/driver:460.73.01-ubuntu20.04
-            voicevox_core_library_name: core
-            libtorch_url: https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip
+            voicevox_core_library_name: libcore_gpu_x64_nvidia.so
+            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-linux-x64-gpu-1.9.0.tgz
           - tag: nvidia-ubuntu20.04
             target: runtime-nvidia-env
             base_image: ubuntu:focal
             base_runtime_image: nvidia/driver:460.73.01-ubuntu20.04
-            voicevox_core_library_name: core
-            libtorch_url: https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip
+            voicevox_core_library_name: libcore_gpu_x64_nvidia.so
+            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-linux-x64-gpu-1.9.0.tgz
           # Ubuntu 18.04
           - tag: cpu-ubuntu18.04
             target: runtime-env
             base_image: ubuntu:bionic
             base_runtime_image: ubuntu:bionic
-            voicevox_core_library_name: core_cpu
-            libtorch_url: https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip
-            use_glibc_231_workaround: 1
+            voicevox_core_library_name: libcore_cpu_x64.so
+            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-linux-x64-1.9.0.tgz
           - tag: nvidia-ubuntu18.04
             target: runtime-nvidia-env
             base_image: ubuntu:bionic
             base_runtime_image: nvidia/driver:460.73.01-ubuntu18.04
-            voicevox_core_library_name: core
-            libtorch_url: https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip
-            use_glibc_231_workaround: 1
+            voicevox_core_library_name: libcore_gpu_x64_nvidia.so
+            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-linux-x64-gpu-1.9.0.tgz
 
     steps:
       - uses: actions/checkout@v2
@@ -112,8 +109,7 @@ jobs:
             VOICEVOX_CORE_VERSION=${{ matrix.voicevox_core_version }}
             VOICEVOX_CORE_EXAMPLE_VERSION=${{ matrix.voicevox_core_example_version }}
             VOICEVOX_CORE_LIBRARY_NAME=${{ matrix.voicevox_core_library_name }}
-            LIBTORCH_URL=${{ matrix.libtorch_url }}
-            USE_GLIBC_231_WORKAROUND=${{ matrix.use_glibc_231_workaround || '0' }}
+            ONNXRUNTIME_URL=${{ matrix.onnxruntime_url }}
           target: ${{ matrix.target }}
           push: true
           tags: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -272,7 +272,6 @@ jobs:
 
   # Build Linux binary (push only buildcache image)
   build-linux:
-    if: false
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -342,6 +341,14 @@ jobs:
           set -eux
           rm -r speaker_info
           cp -r download/resource/character_info speaker_info
+      
+      # Temporary: Download LibTorch Dockerfile
+      # ref https://github.com/VOICEVOX/voicevox_engine/pull/248
+      - name: Download Dockerfile for LibTorch Core
+        shell: bash
+        run: |
+          set -eux
+          wget -nv --show-progress -c -O "./Dockerfile.libtorchcore" https://raw.githubusercontent.com/VOICEVOX/voicevox_engine/86e06dc13d634562e92f799c5e75f06da23822cd/Dockerfile
 
       # NOTE: `load: true` may silently fail when the GitHub Actions disk (14GB) is full.
       # https://docs.github.com/ja/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
@@ -353,7 +360,7 @@ jobs:
         with:
           context: .
           builder: ${{ steps.buildx.outputs.name }}
-          file: ./Dockerfile
+          file: ./Dockerfile.libtorchcore
           build-args: |
             BASE_IMAGE=${{ matrix.base_image }}
             BASE_RUNTIME_IMAGE=${{ matrix.base_runtime_image }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -272,6 +272,7 @@ jobs:
 
   # Build Linux binary (push only buildcache image)
   build-linux:
+    if: false
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -344,6 +344,7 @@ jobs:
       
       # Temporary: Download LibTorch Dockerfile
       # ref https://github.com/VOICEVOX/voicevox_engine/pull/248
+      # tree https://github.com/VOICEVOX/voicevox_engine/tree/86e06dc13d634562e92f799c5e75f06da23822cd
       - name: Download Dockerfile for LibTorch Core
         shell: bash
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -178,14 +178,9 @@ RUN <<EOF
         gosu
     apt-get clean
     rm -rf /var/lib/apt/lists/*
-EOF
 
-RUN <<EOF
     # Create a general user
     useradd --create-home user
-
-    # Update dynamic library search cache
-    ldconfig
 EOF
 
 # Copy python env

--- a/Dockerfile
+++ b/Dockerfile
@@ -189,7 +189,7 @@ COPY --from=download-onnxruntime-env /etc/ld.so.conf.d/onnxruntime.conf /etc/ld.
 COPY --from=download-onnxruntime-env /opt/onnxruntime /opt/onnxruntime
 
 # Clone VOICEVOX Core example
-ARG VOICEVOX_CORE_EXAMPLE_VERSION=0.9.0
+ARG VOICEVOX_CORE_EXAMPLE_VERSION=0.10.preview.0
 RUN <<EOF
     set -eux
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -213,21 +213,18 @@ RUN <<EOF
     # Create a general user
     useradd --create-home user
 
-    # Update ld
+    # Update dynamic library search cache
     ldconfig
 
-    # Const environment
-    # FIXME: These values may be undefined, so `set +u` is needed
-    set +u
-    export PATH="/home/user/.local/bin:/opt/python/bin:$PATH"
-    export LIBRARY_PATH="/opt/voicevox_core:$LIBRARY_PATH"
-    set -u
+    # Define temporary env vars
+    export PATH="/home/user/.local/bin:/opt/python/bin:${PATH:-}"
+    export LIBRARY_PATH="/opt/voicevox_core:${LIBRARY_PATH:-}"
 
     # Install requirements
     gosu user python3 -m pip install --upgrade pip setuptools wheel
     gosu user pip3 install -r /tmp/requirements.txt
 
-    # Install voicevox_core
+    # Install voicevox_core Python module
     # Files will be generated at build time, so move to a writable directory
     gosu user cp -r /opt/voicevox_core_example/example/python /tmp/voicevox_core_example_setup
     cd /tmp/voicevox_core_example_setup

--- a/Dockerfile
+++ b/Dockerfile
@@ -214,6 +214,7 @@ RUN <<EOF
     cp /opt/voicevox_core/libcore.so /tmp/voicevox_core_source/core/lib/
     cp -d /opt/onnxruntime/lib/*.so* /tmp/voicevox_core_source/core/lib/
 
+    # TODO: remove redundant shared library copy to reduce image size
     if [ -f /opt/onnxruntime/lib/libonnxruntime_providers_cuda.so ]; then
         # assert nvidia/cuda base image
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -191,6 +191,8 @@ COPY --from=download-libtorch-env /opt/libtorch /opt/libtorch
 # Clone VOICEVOX Core example
 ARG VOICEVOX_CORE_EXAMPLE_VERSION=0.9.0
 RUN <<EOF
+    set -eux
+
     git clone -b "${VOICEVOX_CORE_EXAMPLE_VERSION}" --depth 1 https://github.com/Hiroshiba/voicevox_core.git /opt/voicevox_core_example
     cd /opt/voicevox_core_example/
     cp ./core.h ./example/python/

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN <<EOF
     set -eux
 
     # Download Core
-    wget -nv --show-progress -c -O "./core.zip" "https://github.com/Hiroshiba/voicevox_core/releases/download/${VOICEVOX_CORE_VERSION}/core.zip"
+    wget -nv --show-progress -c -O "./core.zip" "https://github.com/VOICEVOX/voicevox_core/releases/download/${VOICEVOX_CORE_VERSION}/core.zip"
     unzip "./core.zip"
     rm ./core.zip
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -362,6 +362,8 @@ RUN <<EOF
         # LIBCORE_SO=/opt/voicevox_engine_build/run.dist/libcore.so
         # patchelf --set-rpath \$(patchelf --print-rpath \${LIBCORE_SO} | sed -e 's%^/[^:]*%\$ORIGIN%') \${LIBCORE_SO}
 
+        # FIXME: pack CUDA/cuDNN shared libraries
+
         chmod +x /opt/voicevox_engine_build/run.dist/run
 EOD
     chmod +x /build.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -258,23 +258,10 @@ RUN <<EOF
 EOF
 
 # Create container start shell
-ARG USE_GLIBC_231_WORKAROUND=0
 COPY --chmod=775 <<EOF /entrypoint.sh
 #!/bin/bash
 set -eux
 cat /opt/voicevox_core/README.txt > /dev/stderr
-
-if [ "${USE_GLIBC_231_WORKAROUND}" = "1" ]; then
-    # Workaround: ldconfig fail to load LibTorch if glibc < 2.31.
-    # For isolating problems and simplifing script, use flag USE_GLIBC_231_WORKAROUND
-    # instead of implementing version check logic.
-    export LD_LIBRARY_PATH="/opt/libtorch/lib:\${LD_LIBRARY_PATH:-}"
-else
-    # Workaround: ld.so.cache may not be updated on image build.
-    # Fix the problem of `libtorch_cuda_cpp.so` not being recognized for unknown reason.
-    # Execute ldconfig on every container run.
-    ldconfig
-fi
 
 exec "\$@"
 EOF

--- a/Dockerfile
+++ b/Dockerfile
@@ -212,10 +212,13 @@ RUN <<EOF
     # Copy shared libraries to repo to be packed in Python package
     mkdir -p /tmp/voicevox_core_source/core/lib
     cp /opt/voicevox_core/libcore.so /tmp/voicevox_core_source/core/lib/
-    cp -d /opt/onnxruntime/lib/*.so* /tmp/voicevox_core_source/core/lib/
+
+    cd /opt/onnxruntime/lib
+    cp -d *.so* /tmp/voicevox_core_source/core/lib/
+    cd -
 
     # TODO: remove redundant shared library copy to reduce image size
-    if [ -f /opt/onnxruntime/lib/libonnxruntime_providers_cuda.so ]; then
+    if [ -f /tmp/voicevox_core_source/core/lib/libonnxruntime_providers_cuda.so ]; then
         # assert nvidia/cuda base image
 
         cd /usr/local/cuda/lib64

--- a/Dockerfile
+++ b/Dockerfile
@@ -184,9 +184,9 @@ COPY --from=compile-python-env /opt/python /opt/python
 COPY --from=download-core-env /etc/ld.so.conf.d/voicevox_core.conf /etc/ld.so.conf.d/voicevox_core.conf
 COPY --from=download-core-env /opt/voicevox_core /opt/voicevox_core
 
-# Copy LibTorch
-COPY --from=download-libtorch-env /etc/ld.so.conf.d/libtorch.conf /etc/ld.so.conf.d/libtorch.conf
-COPY --from=download-libtorch-env /opt/libtorch /opt/libtorch
+# Copy ONNX Runtime
+COPY --from=download-onnxruntime-env /etc/ld.so.conf.d/onnxruntime.conf /etc/ld.so.conf.d/onnxruntime.conf
+COPY --from=download-onnxruntime-env /opt/onnxruntime /opt/onnxruntime
 
 # Clone VOICEVOX Core example
 ARG VOICEVOX_CORE_EXAMPLE_VERSION=0.9.0
@@ -343,8 +343,8 @@ RUN <<EOF
                 --include-data-file=/opt/voicevox_engine/VERSION.txt=./ \
                 --include-data-file=/opt/voicevox_engine/licenses.json=./ \
                 --include-data-file=/opt/voicevox_engine/presets.yaml=./ \
-                --include-data-file=/opt/libtorch/lib/*.so=./ \
-                --include-data-file=/opt/libtorch/lib/*.so.*=./ \
+                --include-data-file=/opt/onnxruntime/lib/*.so=./ \
+                --include-data-file=/opt/onnxruntime/lib/*.so.*=./ \
                 --include-data-file=/opt/voicevox_core/*.so=./ \
                 --include-data-file=/opt/voicevox_core/*.bin=./ \
                 --include-data-file=/opt/voicevox_core/metas.json=./ \
@@ -353,7 +353,7 @@ RUN <<EOF
                 --no-prefer-source-code \
                 /opt/voicevox_engine/run.py
 
-        # set relative path in libcore.so for searching libtorch
+        # set relative path in libcore.so for searching onnxruntime
         LIBCORE_SO=/opt/voicevox_engine_build/run.dist/libcore.so
         patchelf --set-rpath \$(patchelf --print-rpath \${LIBCORE_SO} | sed -e 's%^/[^:]*%\$ORIGIN%') \${LIBCORE_SO}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -214,17 +214,18 @@ RUN <<EOF
     cp /opt/voicevox_core/libcore.so /tmp/voicevox_core_source/core/lib/
     cp -d /opt/onnxruntime/lib/*.so* /tmp/voicevox_core_source/core/lib/
 
-    if [ -f /opt/onnxruntime/lib/libonnxruntime_providers_cuda.so ]; then
-        # assert nvidia/cuda base image
-
-        cd /usr/local/cuda/lib64
-        cp -d libcublas.so* libcublasLt.so* libcudart.so* libcufft.so* libcurand.so* /tmp/voicevox_core_source/core/lib/
-        cd -
-
-        cd /usr/lib/x86_64-linux-gnu
-        cp -d libcudnn.so* /tmp/voicevox_core_source/core/lib/
-        cd -
-    fi
+    # Skip CUDA/cuDNN copy to prevent redundant copies
+    # if [ -f /opt/onnxruntime/lib/libonnxruntime_providers_cuda.so ]; then
+    #     # assert nvidia/cuda base image
+    #
+    #     cd /usr/local/cuda/lib64
+    #     cp -d libcublas.so* libcublasLt.so* libcudart.so* libcufft.so* libcurand.so* /tmp/voicevox_core_source/core/lib/
+    #     cd -
+    #
+    #     cd /usr/lib/x86_64-linux-gnu
+    #     cp -d libcudnn.so* /tmp/voicevox_core_source/core/lib/
+    #     cd -
+    # fi
 
     # Duplicate core.h in repo
     cp /tmp/voicevox_core_source/core/src/core.h /tmp/voicevox_core_source/core/lib/

--- a/Dockerfile
+++ b/Dockerfile
@@ -213,8 +213,9 @@ RUN <<EOF
     mkdir -p /tmp/voicevox_core_source/core/lib
     cp /opt/voicevox_core/libcore.so /tmp/voicevox_core_source/core/lib/
 
+    # Copy versioned shared library only (setup.py copy will copy as real file)
     cd /opt/onnxruntime/lib
-    cp -d *.so* /tmp/voicevox_core_source/core/lib/
+    find . -name 'libonnxruntime.so.*' -or -name 'libonnxruntime_*.so' | xargs -I% cp -v % /tmp/voicevox_core_source/core/lib/
     cd -
 
     # TODO: remove redundant shared library copy to reduce image size
@@ -222,11 +223,22 @@ RUN <<EOF
         # assert nvidia/cuda base image
 
         cd /usr/local/cuda/lib64
-        cp -d libcublas.so* libcublasLt.so* libcudart.so* libcufft.so* libcurand.so* /tmp/voicevox_core_source/core/lib/
+        cp libcublas.so.* libcublasLt.so.* libcudart.so.* libcufft.so.* libcurand.so.* /tmp/voicevox_core_source/core/lib/
+        cd -
+
+        # remove unneed full version libraries
+        cd /tmp/voicevox_core_source/core/lib
+        rm -f libcublas.so.*.* libcublasLt.so.*.* libcufft.so.*.* libcurand.so.*.*
+        rm -f libcudart.so.*.*.*
         cd -
 
         cd /usr/lib/x86_64-linux-gnu
-        cp -d libcudnn.so* libcudnn_*_infer.so* /tmp/voicevox_core_source/core/lib/
+        cp libcudnn.so.* libcudnn_*_infer.so.* /tmp/voicevox_core_source/core/lib/
+        cd -
+
+        # remove unneed full version libraries
+        cd /tmp/voicevox_core_source/core/lib
+        rm -f libcudnn.so.*.* libcudnn_*_infer.so.*.*
         cd -
     fi
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -193,7 +193,7 @@ ARG VOICEVOX_CORE_EXAMPLE_VERSION=0.10.preview.0
 RUN <<EOF
     set -eux
 
-    git clone -b "${VOICEVOX_CORE_EXAMPLE_VERSION}" --depth 1 https://github.com/Hiroshiba/voicevox_core.git /opt/voicevox_core_example
+    git clone -b "${VOICEVOX_CORE_EXAMPLE_VERSION}" --depth 1 https://github.com/VOICEVOX/voicevox_core.git /opt/voicevox_core_example
 
     # Copy core.h from core.zip
     cp /opt/voicevox_core/core.h /opt/voicevox_core_example/example/python/

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ WORKDIR /work
 
 RUN <<EOF
     set -eux
+
     apt-get update
     apt-get install -y \
         wget \
@@ -62,6 +63,7 @@ WORKDIR /work
 
 RUN <<EOF
     set -eux
+
     apt-get update
     apt-get install -y \
         wget \
@@ -128,9 +130,11 @@ ARG PYENV_ROOT=/tmp/.pyenv
 ARG PYBUILD_ROOT=/tmp/python-build
 RUN <<EOF
     set -eux
+
     git clone -b "${PYENV_VERSION}" https://github.com/pyenv/pyenv.git "$PYENV_ROOT"
     PREFIX="$PYBUILD_ROOT" "$PYENV_ROOT"/plugins/python-build/install.sh
     "$PYBUILD_ROOT/bin/python-build" -v "$PYTHON_VERSION" /opt/python
+
     rm -rf "$PYBUILD_ROOT" "$PYENV_ROOT"
 EOF
 
@@ -160,6 +164,7 @@ WORKDIR /opt/voicevox_engine
 # build-essential: pyopenjtalk local build
 RUN <<EOF
     set -eux
+
     apt-get update
     apt-get install -y \
         git \

--- a/Dockerfile
+++ b/Dockerfile
@@ -218,6 +218,7 @@ RUN <<EOF
     ldconfig
 
     # Define temporary env vars
+    # /home/user/.local/bin is required to use the commands installed by pip
     export PATH="/home/user/.local/bin:/opt/python/bin:${PATH:-}"
     export LIBRARY_PATH="/opt/voicevox_core:${LIBRARY_PATH:-}"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -360,15 +360,14 @@ RUN <<EOF
                 --include-data-file=/opt/voicevox_engine/presets.yaml=./ \
                 --include-data-file=/opt/voicevox_core/*.bin=./ \
                 --include-data-file=/opt/voicevox_core/metas.json=./ \
-                --include-data-file=/home/user/.local/lib/python*/site-packages/core/lib/*=./lib/ \
                 --include-data-dir=/opt/voicevox_engine/speaker_info=./speaker_info \
                 --follow-imports \
                 --no-prefer-source-code \
                 /opt/voicevox_engine/run.py
 
         # set relative path in libcore.so for searching onnxruntime
-        LIBCORE_SO=/opt/voicevox_engine_build/run.dist/libcore.so
-        patchelf --set-rpath \$(patchelf --print-rpath \${LIBCORE_SO} | sed -e 's%^/[^:]*%\$ORIGIN%') \${LIBCORE_SO}
+        # LIBCORE_SO=/opt/voicevox_engine_build/run.dist/libcore.so
+        # patchelf --set-rpath \$(patchelf --print-rpath \${LIBCORE_SO} | sed -e 's%^/[^:]*%\$ORIGIN%') \${LIBCORE_SO}
 
         chmod +x /opt/voicevox_engine_build/run.dist/run
 EOD

--- a/Dockerfile
+++ b/Dockerfile
@@ -226,7 +226,7 @@ RUN <<EOF
         cd -
 
         cd /usr/lib/x86_64-linux-gnu
-        cp -d libcudnn.so* /tmp/voicevox_core_source/core/lib/
+        cp -d libcudnn.so* libcudnn_*_infer.so* /tmp/voicevox_core_source/core/lib/
         cd -
     fi
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,10 @@ RUN <<EOF
     mv "./core/${VOICEVOX_CORE_LIBRARY_NAME}" /opt/voicevox_core/
 
     if [ "${VOICEVOX_CORE_LIBRARY_NAME}" != "libcore.so" ]; then
-        ln -sf "/opt/voicevox_core/${VOICEVOX_CORE_LIBRARY_NAME}" /opt/voicevox_core/libcore.so
+        # Create relative symbilic link
+        cd /opt/voicevox_core
+        ln -sf "${VOICEVOX_CORE_LIBRARY_NAME}" libcore.so
+        cd -
     fi
 
     # Move Voice Library to /opt/voicevox_core/

--- a/Dockerfile
+++ b/Dockerfile
@@ -214,18 +214,17 @@ RUN <<EOF
     cp /opt/voicevox_core/libcore.so /tmp/voicevox_core_source/core/lib/
     cp -d /opt/onnxruntime/lib/*.so* /tmp/voicevox_core_source/core/lib/
 
-    # Skip CUDA/cuDNN copy to prevent redundant copies
-    # if [ -f /opt/onnxruntime/lib/libonnxruntime_providers_cuda.so ]; then
-    #     # assert nvidia/cuda base image
-    #
-    #     cd /usr/local/cuda/lib64
-    #     cp -d libcublas.so* libcublasLt.so* libcudart.so* libcufft.so* libcurand.so* /tmp/voicevox_core_source/core/lib/
-    #     cd -
-    #
-    #     cd /usr/lib/x86_64-linux-gnu
-    #     cp -d libcudnn.so* /tmp/voicevox_core_source/core/lib/
-    #     cd -
-    # fi
+    if [ -f /opt/onnxruntime/lib/libonnxruntime_providers_cuda.so ]; then
+        # assert nvidia/cuda base image
+
+        cd /usr/local/cuda/lib64
+        cp -d libcublas.so* libcublasLt.so* libcudart.so* libcufft.so* libcurand.so* /tmp/voicevox_core_source/core/lib/
+        cd -
+
+        cd /usr/lib/x86_64-linux-gnu
+        cp -d libcudnn.so* /tmp/voicevox_core_source/core/lib/
+        cd -
+    fi
 
     # Duplicate core.h in repo
     cp /tmp/voicevox_core_source/core/src/core.h /tmp/voicevox_core_source/core/lib/

--- a/Dockerfile
+++ b/Dockerfile
@@ -263,6 +263,7 @@ EOF
 COPY --chmod=775 <<EOF /entrypoint.sh
 #!/bin/bash
 set -eux
+
 cat /opt/voicevox_core/README.txt > /dev/stderr
 
 exec "\$@"
@@ -282,6 +283,7 @@ FROM runtime-env AS build-env
 # chrpath: required for nuitka build; 'RPATH' settings in used shared
 RUN <<EOF
     set -eux
+
     apt-get update
     apt-get install -y \
         ccache \
@@ -295,6 +297,7 @@ EOF
 ADD ./requirements-dev.txt /tmp/
 RUN <<EOF
     set -eux
+
     gosu user /opt/python/bin/pip3 install -r /tmp/requirements-dev.txt
 EOF
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.3-labs
 
 ARG BASE_IMAGE=ubuntu:focal
-ARG BASE_RUNTIME_IMAGE=ubuntu:focal
+ARG BASE_RUNTIME_IMAGE=$BASE_IMAGE
 
 # Download VOICEVOX Core shared object
 FROM ${BASE_IMAGE} AS download-core-env

--- a/Dockerfile
+++ b/Dockerfile
@@ -175,8 +175,6 @@ RUN <<EOF
         libsndfile1 \
         ca-certificates \
         build-essential \
-        patchelf \
-        chrpath \
         gosu
     apt-get clean
     rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -358,11 +358,9 @@ RUN <<EOF
                 --include-data-file=/opt/voicevox_engine/VERSION.txt=./ \
                 --include-data-file=/opt/voicevox_engine/licenses.json=./ \
                 --include-data-file=/opt/voicevox_engine/presets.yaml=./ \
-                --include-data-file=/opt/onnxruntime/lib/*.so=./ \
-                --include-data-file=/opt/onnxruntime/lib/*.so.*=./ \
-                --include-data-file=/opt/voicevox_core/*.so=./ \
                 --include-data-file=/opt/voicevox_core/*.bin=./ \
                 --include-data-file=/opt/voicevox_core/metas.json=./ \
+                --include-data-file=/home/user/.local/lib/python*/site-packages/core/lib/*=./lib/ \
                 --include-data-dir=/opt/voicevox_engine/speaker_info=./speaker_info \
                 --follow-imports \
                 --no-prefer-source-code \

--- a/Dockerfile
+++ b/Dockerfile
@@ -216,7 +216,7 @@ RUN <<EOF
     mkdir -p /tmp/voicevox_core_source/core/lib
     cp /opt/voicevox_core/libcore.so /tmp/voicevox_core_source/core/lib/
 
-    # Copy versioned shared library only (setup.py copy will copy as real file)
+    # Copy versioned shared library only (setup.py will copy package data as real file on install)
     cd /opt/onnxruntime/lib
     find . -name 'libonnxruntime.so.*' -or -name 'libonnxruntime_*.so' | xargs -I% cp -v % /tmp/voicevox_core_source/core/lib/
     cd -

--- a/Dockerfile
+++ b/Dockerfile
@@ -300,11 +300,11 @@ exec "\$@"
 EOF
 
 ENTRYPOINT [ "/entrypoint.sh"  ]
-CMD [ "gosu", "user", "/opt/python/bin/python3", "./run.py", "--voicevox_dir", "/opt/voicevox_core/", "--voicelib_dir", "/opt/voicevox_core/", "--host", "0.0.0.0" ]
+CMD [ "gosu", "user", "/opt/python/bin/python3", "./run.py", "--voicelib_dir", "/opt/voicevox_core/", "--host", "0.0.0.0" ]
 
 # Enable use_gpu
 FROM runtime-env AS runtime-nvidia-env
-CMD [ "gosu", "user", "/opt/python/bin/python3", "./run.py", "--use_gpu", "--voicevox_dir", "/opt/voicevox_core/", "--voicelib_dir", "/opt/voicevox_core/", "--host", "0.0.0.0" ]
+CMD [ "gosu", "user", "/opt/python/bin/python3", "./run.py", "--use_gpu", "--voicelib_dir", "/opt/voicevox_core/", "--host", "0.0.0.0" ]
 
 # Binary build environment (common to CPU, GPU)
 FROM runtime-env AS build-env

--- a/Dockerfile
+++ b/Dockerfile
@@ -194,8 +194,9 @@ RUN <<EOF
     set -eux
 
     git clone -b "${VOICEVOX_CORE_EXAMPLE_VERSION}" --depth 1 https://github.com/Hiroshiba/voicevox_core.git /opt/voicevox_core_example
-    cd /opt/voicevox_core_example/
-    cp ./core.h ./example/python/
+
+    # Copy core.h from core.zip
+    cp /opt/voicevox_core/core.h /opt/voicevox_core_example/example/python/
 EOF
 
 # Add local files

--- a/Dockerfile
+++ b/Dockerfile
@@ -240,9 +240,6 @@ RUN <<EOF
 
     cd /tmp/voicevox_core_source
 
-    # Define temporary env vars
-    export LIBRARY_PATH="/opt/voicevox_core:${LIBRARY_PATH:-}"
-
     gosu user /opt/python/bin/pip3 install .
 
     # remove cloned repository before layer end to reduce image size

--- a/Makefile
+++ b/Makefile
@@ -53,8 +53,7 @@ build-linux-docker-ubuntu18.04:
 		--build-arg BASE_IMAGE=ubuntu:bionic \
 		--build-arg BASE_RUNTIME_IMAGE=ubuntu:bionic \
 		--build-arg ONNXRUNTIME_URL=https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-linux-x64-1.9.0.tgz \
-		--build-arg VOICEVOX_CORE_LIBRARY_NAME=libcore_cpu_x64.so \
-		--build-arg USE_GLIBC_231_WORKAROUND=1 $(ARGS)
+		--build-arg VOICEVOX_CORE_LIBRARY_NAME=libcore_cpu_x64.so $(ARGS)
 
 .PHONY: run-linux-docker-ubuntu18.04
 run-linux-docker-ubuntu18.04:
@@ -71,8 +70,7 @@ build-linux-docker-nvidia-ubuntu18.04:
 		--build-arg BASE_IMAGE=ubuntu:bionic \
 		--build-arg BASE_RUNTIME_IMAGE=nvidia/driver:460.73.01-ubuntu18.04 \
 		--build-arg ONNXRUNTIME_URL=https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-linux-x64-gpu-1.9.0.tgz \
-		--build-arg VOICEVOX_CORE_LIBRARY_NAME=libcore_gpu_x64_nvidia.so \
-		--build-arg USE_GLIBC_231_WORKAROUND=1 $(ARGS)
+		--build-arg VOICEVOX_CORE_LIBRARY_NAME=libcore_gpu_x64_nvidia.so $(ARGS)
 
 .PHONY: run-linux-docker-nvidia-ubuntu18.04
 run-linux-docker-nvidia-ubuntu18.04:
@@ -174,8 +172,7 @@ build-linux-docker-build-ubuntu18.04:
 		--build-arg BASE_IMAGE=ubuntu:bionic \
 		--build-arg BASE_RUNTIME_IMAGE=ubuntu:bionic \
 		--build-arg ONNXRUNTIME_URL=https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-linux-x64-1.9.0.tgz \
-		--build-arg VOICEVOX_CORE_LIBRARY_NAME=libcore_cpu_x64.so \
-		--build-arg USE_GLIBC_231_WORKAROUND=1 $(ARGS)
+		--build-arg VOICEVOX_CORE_LIBRARY_NAME=libcore_cpu_x64.so $(ARGS)
 
 .PHONY: run-linux-docker-build-ubuntu18.04
 run-linux-docker-build-ubuntu18.04:
@@ -193,8 +190,7 @@ build-linux-docker-build-nvidia-ubuntu18.04:
 		--build-arg BASE_IMAGE=ubuntu:bionic \
 		--build-arg BASE_RUNTIME_IMAGE=nvidia/driver:460.73.01-ubuntu18.04 \
 		--build-arg ONNXRUNTIME_URL=https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-linux-x64-gpu-1.9.0.tgz \
-		--build-arg VOICEVOX_CORE_LIBRARY_NAME=libcore_gpu_x64_nvidia.so \
-		--build-arg USE_GLIBC_231_WORKAROUND=1 $(ARGS)
+		--build-arg VOICEVOX_CORE_LIBRARY_NAME=libcore_gpu_x64_nvidia.so $(ARGS)
 
 .PHONY: run-linux-docker-build-nvidia-ubuntu18.04
 run-linux-docker-build-nvidia-ubuntu18.04:

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ build-linux-docker-nvidia-ubuntu20.04:
 		--target runtime-nvidia-env \
 		--progress plain \
 		--build-arg BASE_IMAGE=ubuntu:focal \
-		--build-arg BASE_RUNTIME_IMAGE=nvidia/driver:460.73.01-ubuntu20.04 \
+		--build-arg BASE_RUNTIME_IMAGE=nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu20.04 \
 		--build-arg ONNXRUNTIME_URL=https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-linux-x64-gpu-1.9.0.tgz \
 		--build-arg VOICEVOX_CORE_LIBRARY_NAME=libcore_gpu_x64_nvidia.so $(ARGS)
 
@@ -68,7 +68,7 @@ build-linux-docker-nvidia-ubuntu18.04:
 		--target runtime-nvidia-env \
 		--progress plain \
 		--build-arg BASE_IMAGE=ubuntu:bionic \
-		--build-arg BASE_RUNTIME_IMAGE=nvidia/driver:460.73.01-ubuntu18.04 \
+		--build-arg BASE_RUNTIME_IMAGE=nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu18.04 \
 		--build-arg ONNXRUNTIME_URL=https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-linux-x64-gpu-1.9.0.tgz \
 		--build-arg VOICEVOX_CORE_LIBRARY_NAME=libcore_gpu_x64_nvidia.so $(ARGS)
 
@@ -151,7 +151,7 @@ build-linux-docker-build-nvidia-ubuntu20.04:
 		--target build-env \
 		--progress plain \
 		--build-arg BASE_IMAGE=ubuntu:focal \
-		--build-arg BASE_RUNTIME_IMAGE=nvidia/driver:460.73.01-ubuntu20.04 \
+		--build-arg BASE_RUNTIME_IMAGE=nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu20.04 \
 		--build-arg ONNXRUNTIME_URL=https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-linux-x64-gpu-1.9.0.tgz \
 		--build-arg VOICEVOX_CORE_LIBRARY_NAME=libcore_gpu_x64_nvidia.so $(ARGS)
 
@@ -188,7 +188,7 @@ build-linux-docker-build-nvidia-ubuntu18.04:
 		--target build-env \
 		--progress plain \
 		--build-arg BASE_IMAGE=ubuntu:bionic \
-		--build-arg BASE_RUNTIME_IMAGE=nvidia/driver:460.73.01-ubuntu18.04 \
+		--build-arg BASE_RUNTIME_IMAGE=nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu18.04 \
 		--build-arg ONNXRUNTIME_URL=https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-linux-x64-gpu-1.9.0.tgz \
 		--build-arg VOICEVOX_CORE_LIBRARY_NAME=libcore_gpu_x64_nvidia.so $(ARGS)
 

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ build-linux-docker-ubuntu18.04:
 		--build-arg BASE_IMAGE=ubuntu:bionic \
 		--build-arg BASE_RUNTIME_IMAGE=ubuntu:bionic \
 		--build-arg LIBTORCH_URL=https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip \
-		--build-arg VOICEVOX_CORE_LIBRARY_NAME=core_cpu \
+		--build-arg VOICEVOX_CORE_LIBRARY_NAME=libcore_cpu_x64.so \
 		--build-arg USE_GLIBC_231_WORKAROUND=1 $(ARGS)
 
 .PHONY: run-linux-docker-ubuntu18.04
@@ -71,7 +71,7 @@ build-linux-docker-nvidia-ubuntu18.04:
 		--build-arg BASE_IMAGE=ubuntu:bionic \
 		--build-arg BASE_RUNTIME_IMAGE=nvidia/driver:460.73.01-ubuntu18.04 \
 		--build-arg LIBTORCH_URL=https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip \
-		--build-arg VOICEVOX_CORE_LIBRARY_NAME=core \
+		--build-arg VOICEVOX_CORE_LIBRARY_NAME=libcore_gpu_x64_nvidia.so \
 		--build-arg USE_GLIBC_231_WORKAROUND=1 $(ARGS)
 
 .PHONY: run-linux-docker-nvidia-ubuntu18.04

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ build-linux-docker-ubuntu20.04:
 		--build-arg BASE_IMAGE=ubuntu:focal \
 		--build-arg BASE_RUNTIME_IMAGE=ubuntu:focal \
 		--build-arg LIBTORCH_URL=https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip \
-		--build-arg VOICEVOX_CORE_LIBRARY_NAME=core_cpu $(ARGS)
+		--build-arg VOICEVOX_CORE_LIBRARY_NAME=libcore_cpu_x64.so $(ARGS)
 
 .PHONY: run-linux-docker-ubuntu20.04
 run-linux-docker-ubuntu20.04:
@@ -33,7 +33,7 @@ build-linux-docker-nvidia-ubuntu20.04:
 		--build-arg BASE_IMAGE=ubuntu:focal \
 		--build-arg BASE_RUNTIME_IMAGE=nvidia/driver:460.73.01-ubuntu20.04 \
 		--build-arg LIBTORCH_URL=https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip \
-		--build-arg VOICEVOX_CORE_LIBRARY_NAME=core $(ARGS)
+		--build-arg VOICEVOX_CORE_LIBRARY_NAME=libcore_gpu_x64_nvidia.so $(ARGS)
 
 .PHONY: run-linux-docker-nvidia-ubuntu20.04
 run-linux-docker-nvidia-ubuntu20.04:
@@ -137,7 +137,7 @@ build-linux-docker-build-ubuntu20.04:
 		--build-arg BASE_IMAGE=ubuntu:focal \
 		--build-arg BASE_RUNTIME_IMAGE=ubuntu:focal \
 		--build-arg LIBTORCH_URL=https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip \
-		--build-arg VOICEVOX_CORE_LIBRARY_NAME=core_cpu $(ARGS)
+		--build-arg VOICEVOX_CORE_LIBRARY_NAME=libcore_cpu_x64.so $(ARGS)
 
 .PHONY: run-linux-docker-build-ubuntu20.04
 run-linux-docker-build-ubuntu20.04:
@@ -155,7 +155,7 @@ build-linux-docker-build-nvidia-ubuntu20.04:
 		--build-arg BASE_IMAGE=ubuntu:focal \
 		--build-arg BASE_RUNTIME_IMAGE=nvidia/driver:460.73.01-ubuntu20.04 \
 		--build-arg LIBTORCH_URL=https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip \
-		--build-arg VOICEVOX_CORE_LIBRARY_NAME=core $(ARGS)
+		--build-arg VOICEVOX_CORE_LIBRARY_NAME=libcore_gpu_x64_nvidia.so $(ARGS)
 
 .PHONY: run-linux-docker-build-nvidia-ubuntu20.04
 run-linux-docker-build-nvidia-ubuntu20.04:
@@ -174,7 +174,7 @@ build-linux-docker-build-ubuntu18.04:
 		--build-arg BASE_IMAGE=ubuntu:bionic \
 		--build-arg BASE_RUNTIME_IMAGE=ubuntu:bionic \
 		--build-arg LIBTORCH_URL=https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip \
-		--build-arg VOICEVOX_CORE_LIBRARY_NAME=core_cpu \
+		--build-arg VOICEVOX_CORE_LIBRARY_NAME=libcore_cpu_x64.so \
 		--build-arg USE_GLIBC_231_WORKAROUND=1 $(ARGS)
 
 .PHONY: run-linux-docker-build-ubuntu18.04
@@ -193,7 +193,7 @@ build-linux-docker-build-nvidia-ubuntu18.04:
 		--build-arg BASE_IMAGE=ubuntu:bionic \
 		--build-arg BASE_RUNTIME_IMAGE=nvidia/driver:460.73.01-ubuntu18.04 \
 		--build-arg LIBTORCH_URL=https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip \
-		--build-arg VOICEVOX_CORE_LIBRARY_NAME=core \
+		--build-arg VOICEVOX_CORE_LIBRARY_NAME=libcore_gpu_x64_nvidia.so \
 		--build-arg USE_GLIBC_231_WORKAROUND=1 $(ARGS)
 
 .PHONY: run-linux-docker-build-nvidia-ubuntu18.04

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ build-linux-docker-ubuntu20.04:
 		--progress plain \
 		--build-arg BASE_IMAGE=ubuntu:focal \
 		--build-arg BASE_RUNTIME_IMAGE=ubuntu:focal \
-		--build-arg LIBTORCH_URL=https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip \
+		--build-arg ONNXRUNTIME_URL=https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-linux-x64-1.9.0.tgz \
 		--build-arg VOICEVOX_CORE_LIBRARY_NAME=libcore_cpu_x64.so $(ARGS)
 
 .PHONY: run-linux-docker-ubuntu20.04
@@ -32,7 +32,7 @@ build-linux-docker-nvidia-ubuntu20.04:
 		--progress plain \
 		--build-arg BASE_IMAGE=ubuntu:focal \
 		--build-arg BASE_RUNTIME_IMAGE=nvidia/driver:460.73.01-ubuntu20.04 \
-		--build-arg LIBTORCH_URL=https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip \
+		--build-arg ONNXRUNTIME_URL=https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-linux-x64-gpu-1.9.0.tgz \
 		--build-arg VOICEVOX_CORE_LIBRARY_NAME=libcore_gpu_x64_nvidia.so $(ARGS)
 
 .PHONY: run-linux-docker-nvidia-ubuntu20.04
@@ -52,7 +52,7 @@ build-linux-docker-ubuntu18.04:
 		--progress plain \
 		--build-arg BASE_IMAGE=ubuntu:bionic \
 		--build-arg BASE_RUNTIME_IMAGE=ubuntu:bionic \
-		--build-arg LIBTORCH_URL=https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip \
+		--build-arg ONNXRUNTIME_URL=https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-linux-x64-1.9.0.tgz \
 		--build-arg VOICEVOX_CORE_LIBRARY_NAME=libcore_cpu_x64.so \
 		--build-arg USE_GLIBC_231_WORKAROUND=1 $(ARGS)
 
@@ -70,7 +70,7 @@ build-linux-docker-nvidia-ubuntu18.04:
 		--progress plain \
 		--build-arg BASE_IMAGE=ubuntu:bionic \
 		--build-arg BASE_RUNTIME_IMAGE=nvidia/driver:460.73.01-ubuntu18.04 \
-		--build-arg LIBTORCH_URL=https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip \
+		--build-arg ONNXRUNTIME_URL=https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-linux-x64-gpu-1.9.0.tgz \
 		--build-arg VOICEVOX_CORE_LIBRARY_NAME=libcore_gpu_x64_nvidia.so \
 		--build-arg USE_GLIBC_231_WORKAROUND=1 $(ARGS)
 
@@ -136,7 +136,7 @@ build-linux-docker-build-ubuntu20.04:
 		--progress plain \
 		--build-arg BASE_IMAGE=ubuntu:focal \
 		--build-arg BASE_RUNTIME_IMAGE=ubuntu:focal \
-		--build-arg LIBTORCH_URL=https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip \
+		--build-arg ONNXRUNTIME_URL=https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-linux-x64-1.9.0.tgz \
 		--build-arg VOICEVOX_CORE_LIBRARY_NAME=libcore_cpu_x64.so $(ARGS)
 
 .PHONY: run-linux-docker-build-ubuntu20.04
@@ -154,7 +154,7 @@ build-linux-docker-build-nvidia-ubuntu20.04:
 		--progress plain \
 		--build-arg BASE_IMAGE=ubuntu:focal \
 		--build-arg BASE_RUNTIME_IMAGE=nvidia/driver:460.73.01-ubuntu20.04 \
-		--build-arg LIBTORCH_URL=https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip \
+		--build-arg ONNXRUNTIME_URL=https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-linux-x64-gpu-1.9.0.tgz \
 		--build-arg VOICEVOX_CORE_LIBRARY_NAME=libcore_gpu_x64_nvidia.so $(ARGS)
 
 .PHONY: run-linux-docker-build-nvidia-ubuntu20.04
@@ -173,7 +173,7 @@ build-linux-docker-build-ubuntu18.04:
 		--progress plain \
 		--build-arg BASE_IMAGE=ubuntu:bionic \
 		--build-arg BASE_RUNTIME_IMAGE=ubuntu:bionic \
-		--build-arg LIBTORCH_URL=https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip \
+		--build-arg ONNXRUNTIME_URL=https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-linux-x64-1.9.0.tgz \
 		--build-arg VOICEVOX_CORE_LIBRARY_NAME=libcore_cpu_x64.so \
 		--build-arg USE_GLIBC_231_WORKAROUND=1 $(ARGS)
 
@@ -192,7 +192,7 @@ build-linux-docker-build-nvidia-ubuntu18.04:
 		--progress plain \
 		--build-arg BASE_IMAGE=ubuntu:bionic \
 		--build-arg BASE_RUNTIME_IMAGE=nvidia/driver:460.73.01-ubuntu18.04 \
-		--build-arg LIBTORCH_URL=https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip \
+		--build-arg ONNXRUNTIME_URL=https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-linux-x64-gpu-1.9.0.tgz \
 		--build-arg VOICEVOX_CORE_LIBRARY_NAME=libcore_gpu_x64_nvidia.so \
 		--build-arg USE_GLIBC_231_WORKAROUND=1 $(ARGS)
 

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ build-linux-docker-nvidia-ubuntu20.04:
 		--target runtime-nvidia-env \
 		--progress plain \
 		--build-arg BASE_IMAGE=ubuntu:focal \
-		--build-arg BASE_RUNTIME_IMAGE=nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu20.04 \
+		--build-arg BASE_RUNTIME_IMAGE=nvidia/cuda:11.4.2-cudnn8-runtime-ubuntu20.04 \
 		--build-arg ONNXRUNTIME_URL=https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-linux-x64-gpu-1.9.0.tgz \
 		--build-arg VOICEVOX_CORE_LIBRARY_NAME=libcore_gpu_x64_nvidia.so $(ARGS)
 
@@ -68,7 +68,7 @@ build-linux-docker-nvidia-ubuntu18.04:
 		--target runtime-nvidia-env \
 		--progress plain \
 		--build-arg BASE_IMAGE=ubuntu:bionic \
-		--build-arg BASE_RUNTIME_IMAGE=nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu18.04 \
+		--build-arg BASE_RUNTIME_IMAGE=nvidia/cuda:11.4.2-cudnn8-runtime-ubuntu18.04 \
 		--build-arg ONNXRUNTIME_URL=https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-linux-x64-gpu-1.9.0.tgz \
 		--build-arg VOICEVOX_CORE_LIBRARY_NAME=libcore_gpu_x64_nvidia.so $(ARGS)
 
@@ -151,7 +151,7 @@ build-linux-docker-build-nvidia-ubuntu20.04:
 		--target build-env \
 		--progress plain \
 		--build-arg BASE_IMAGE=ubuntu:focal \
-		--build-arg BASE_RUNTIME_IMAGE=nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu20.04 \
+		--build-arg BASE_RUNTIME_IMAGE=nvidia/cuda:11.4.2-cudnn8-runtime-ubuntu20.04 \
 		--build-arg ONNXRUNTIME_URL=https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-linux-x64-gpu-1.9.0.tgz \
 		--build-arg VOICEVOX_CORE_LIBRARY_NAME=libcore_gpu_x64_nvidia.so $(ARGS)
 
@@ -188,7 +188,7 @@ build-linux-docker-build-nvidia-ubuntu18.04:
 		--target build-env \
 		--progress plain \
 		--build-arg BASE_IMAGE=ubuntu:bionic \
-		--build-arg BASE_RUNTIME_IMAGE=nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu18.04 \
+		--build-arg BASE_RUNTIME_IMAGE=nvidia/cuda:11.4.2-cudnn8-runtime-ubuntu18.04 \
 		--build-arg ONNXRUNTIME_URL=https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-linux-x64-gpu-1.9.0.tgz \
 		--build-arg VOICEVOX_CORE_LIBRARY_NAME=libcore_gpu_x64_nvidia.so $(ARGS)
 

--- a/Makefile
+++ b/Makefile
@@ -94,19 +94,19 @@ run-linux-docker-download-core-env-ubuntu18.04:
 	docker run --rm -it $(ARGS) \
 		hiroshiba/voicevox_engine:download-core-env-ubuntu18.04 $(CMD)
 
-# LibTorch env for test
-.PHONY: build-linux-docker-download-libtorch-env-ubuntu18.04
-build-linux-docker-download-libtorch-env-ubuntu18.04:
+# ONNX Runtime env for test
+.PHONY: build-linux-docker-download-onnxruntime-env-ubuntu18.04
+build-linux-docker-download-onnxruntime-env-ubuntu18.04:
 	docker buildx build . \
-		-t hiroshiba/voicevox_engine:download-libtorch-env-ubuntu18.04 \
-		--target download-libtorch-env \
+		-t hiroshiba/voicevox_engine:download-onnxruntime-env-ubuntu18.04 \
+		--target download-onnxruntime-env \
 		--progress plain \
 		--build-arg BASE_IMAGE=ubuntu:bionic $(ARGS)
 
-.PHONY: run-linux-docker-download-libtorch-env-ubuntu18.04
-run-linux-docker-download-libtorch-env-ubuntu18.04:
+.PHONY: run-linux-docker-download-onnxruntime-env-ubuntu18.04
+run-linux-docker-download-onnxruntime-env-ubuntu18.04:
 	docker run --rm -it $(ARGS) \
-		hiroshiba/voicevox_engine:download-libtorch-env-ubuntu18.04 $(CMD)
+		hiroshiba/voicevox_engine:download-onnxruntime-env-ubuntu18.04 $(CMD)
 
 
 # Python env for test


### PR DESCRIPTION
## 内容

DockerイメージをONNX版コア（[0.10.preview.0](https://github.com/VOICEVOX/voicevox_core/releases/tag/0.10.preview.0)）に対応させます。

- [x] Makefile
- [x] 自動ビルド

fork先で自動ビルドされたイメージでの動作を確認したらDraftを外します。

- https://github.com/aoirint/voicevox_engine/actions/runs/1632213380
- CPU
    - [x] Ubuntu 18.04
    - [x] Ubuntu 20.04
- GPU
    - [x] Ubuntu 18.04
    - [x] Ubuntu 20.04

## ノート

- `USE_GLIBC_231_WORKAROUND`を削除
    - Ubuntu 18.04上で、動的ライブラリを検索するldconfigコマンドがLibTorchを扱えない問題を回避するためのWorkaroundだった
        - <https://github.com/VOICEVOX/voicevox_engine/pull/98#issuecomment-924313095>
    - LibTorchへの依存が外れたため、不要になった
- Linux用バイナリビルドは一時的に古いDockerfileをダウンロードして使うようにした
    - 新しいDockerfileのバイナリビルド用のステージは動作未確認
- GPU版のベースイメージをnvidia/driverからnvidia/cudaに変更
    - LibTorchにはCUDAが同梱されていたため、不要だった
        - <https://github.com/VOICEVOX/voicevox_engine/pull/123>
    - ONNX RuntimeにはCUDAが同梱されていない
    - ONNX RuntimeはCUDA 11.4向け: https://github.com/microsoft/onnxruntime/releases/tag/v1.9.0#:~:text=GPU%20packages%20are%20built%20with%20CUDA%2011.4
    - CUDA 11.4.2を使用: https://hub.docker.com/r/nvidia/cuda/tags?page=1&name=11.4
- LibTorch版 エンジン Python実行環境
    - コアライブラリ（libcore.so）: システムにインストールを要求（ld.so.confまたはLD_LIBRARY_PATH）
    - LibTorch: システムにインストールを要求
    - CUDA/cuDNN: 別途インストール不要（LibTorchに同梱）
- ONNX版 エンジン Python実行環境
    - コアライブラリ（libcore.so）: コア Pythonモジュールに同梱
    - ONNX Runtime: コア Pythonモジュールに同梱
    - CUDA/cuDNN: システムにインストールを要求

### libonnxruntime_providers_cuda.so の依存ライブラリ

<details>

```
# nvidia/driver 環境でのログ
$ ldd libonnxruntime_providers_cuda.so 
        linux-vdso.so.1 (0x00007ffe28fb2000)
        libcublas.so.11 => not found
        libcudnn.so.8 => not found
        libcurand.so.10 => not found
        libcufft.so.10 => not found
        libstdc++.so.6 => /usr/lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007ff43cf35000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007ff43cb97000)
        libcudart.so.11.0 => /usr/local/cuda/targets/x86_64-linux/lib/libcudart.so.11.0 (0x00007ff43c908000)
        libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007ff43c6f0000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007ff43c2ff000)
        /lib64/ld-linux-x86-64.so.2 (0x00007ff44cbfd000)
        libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007ff43c0fb000)
        libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007ff43bedc000)
        librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007ff43bcd4000)
```

```
# nvidia/cuda 環境でのログ
$ ldd libonnxruntime_providers_cuda.so 
        linux-vdso.so.1 (0x00007fffaf591000)
        libcublas.so.11 => /usr/local/cuda/targets/x86_64-linux/lib/libcublas.so.11 (0x00007f47a3cdc000)
        libcudnn.so.8 => /usr/lib/x86_64-linux-gnu/libcudnn.so.8 (0x00007f47a3ab4000)
        libcurand.so.10 => /usr/local/cuda/targets/x86_64-linux/lib/libcurand.so.10 (0x00007f479e305000)
        libcufft.so.10 => /usr/local/cuda/targets/x86_64-linux/lib/libcufft.so.10 (0x00007f4788685000)
        libstdc++.so.6 => /usr/lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007f47882fc000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f4787f5e000)
        libcudart.so.11.0 => /usr/local/cuda/targets/x86_64-linux/lib/libcudart.so.11.0 (0x00007f4787cbc000)
        libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f4787aa4000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f47876b3000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f47bc9cf000)
        libcublasLt.so.11 => /usr/local/cuda/targets/x86_64-linux/lib/libcublasLt.so.11 (0x00007f4773cb7000)
        libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f4773a98000)
        librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007f4773890000)
        libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f477368c000)
```

#### 依存ツリー（[libtree](https://github.com/haampie/libtree)）

```
# libtree libonnxruntime_providers_cuda.so 
libonnxruntime_providers_cuda.so 
├── libcublas.so.11 [ld.so.conf]
│   ├── libcublasLt.so.11 [runpath]
│   │   └── librt.so.1 [ld.so.conf]
│   └── librt.so.1 [ld.so.conf]
├── libcudart.so.11.0 [ld.so.conf]
│   └── librt.so.1 [ld.so.conf]
├── libcufft.so.10 [ld.so.conf]
│   └── librt.so.1 [ld.so.conf]
├── libcurand.so.10 [ld.so.conf]
│   └── librt.so.1 [ld.so.conf]
└── libcudnn.so.8 [ld.so.conf]
    └── librt.so.1 [ld.so.conf]
```

</details>

- GPU版はCtrl+Cで終了時に以下の警告が出る。メモリ解放まわりのログだと思うので無視している

```
terminate called after throwing an instance of 'onnxruntime::OnnxRuntimeException'
  what():  /onnxruntime_src/onnxruntime/core/providers/cuda/cuda_call.cc:122 bool onnxruntime::CudaCall(ERRTYPE, const char*, const char*, ERRTYPE, const char*) [with ERRTYPE = cudaError; bool THRW = true] /onnxruntime_src/onnxruntime/core/providers/cuda/cuda_call.cc:116 bool onnxruntime::CudaCall(ERRTYPE, const char*, const char*, ERRTYPE, const char*) [with ERRTYPE = cudaError; bool THRW = true] CUDA failure 4: driver shutting down ; GPU=-1196249303 ; hostname=14ac57f8a082 ; expr=cudaEventSynchronize(e);
```

<!--
プルリクエストの内容説明を端的に記載してください。
-->

## ローカルでのテスト方法

```
# Dockerイメージのビルド
make build-linux-docker-ubuntu18.04

# run.pyの実行
make run-linux-docker-ubuntu18.04

# GPU
make build-linux-docker-nvidia-ubuntu18.04
make run-linux-docker-nvidia-ubuntu18.04
```

※ Dockerfileでは`speaker_info`の取得をしていないため、立ち絵などはダミーが返ります

## 自動ビルドされたイメージのテスト方法

```shell
# CPU
docker pull aoirint/voicevox_engine:cpu-ubuntu18.04-0.10.preview.0-aoirint-docker-3
docker run --rm -p '127.0.0.1:50021:50021' aoirint/voicevox_engine:cpu-ubuntu18.04-0.10.preview.0-aoirint-docker-3

# GPU
docker pull aoirint/voicevox_engine:nvidia-ubuntu18.04-0.10.preview.0-aoirint-docker-3
docker run --rm --gpus all -p '127.0.0.1:50021:50021' aoirint/voicevox_engine:nvidia-ubuntu18.04-0.10.preview.0-aoirint-docker-3
```

※ こちらでも立ち絵などはダミーが返ります（もとの仕様のまま）

## 関連 Issue

- ref #245 

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->
