### PR TITLE
疑問文の仕様変更反映 #272

### DIFF
--- a/run.py
+++ b/run.py
@@ -184,9 +184,7 @@ def generate_app(engine: SynthesisEngineBase) -> FastAPI:
         """
         if is_kana:
             try:
-                accent_phrases, interrogative_accent_phrase_marks = parse_kana(
-                    text, enable_interrogative
-                )
+                accent_phrases = parse_kana(text, enable_interrogative)
             except ParseKanaError as err:
                 raise HTTPException(
                     status_code=400,
@@ -196,9 +194,7 @@ def generate_app(engine: SynthesisEngineBase) -> FastAPI:
                 accent_phrases=accent_phrases, speaker_id=speaker
             )
 
-            return adjust_interrogative_accent_phrases(
-                accent_phrases, interrogative_accent_phrase_marks, enable_interrogative
-            )
+            return adjust_interrogative_accent_phrases(accent_phrases)
         else:
             return engine.create_accent_phrases(
                 text,

--- a/test/test_kana_parser.py
+++ b/test/test_kana_parser.py
@@ -576,26 +576,26 @@ class TestCreateKana(TestCase):
                         Mora(
                             text="コ",
                             consonant="k",
-                            consonant_length=0,
+                            consonant_length=2.5,
                             vowel="o",
-                            vowel_length=0,
-                            pitch=0,
+                            vowel_length=2.5,
+                            pitch=2.5,
                         ),
                         Mora(
                             text="レ",
                             consonant="r",
-                            consonant_length=0,
+                            consonant_length=2.5,
                             vowel="e",
-                            vowel_length=0,
-                            pitch=0,
+                            vowel_length=2.5,
+                            pitch=2.5,
                         ),
                         Mora(
                             text="ワ",
                             consonant="w",
-                            consonant_length=0,
+                            consonant_length=2.5,
                             vowel="a",
-                            vowel_length=0,
-                            pitch=0,
+                            vowel_length=2.5,
+                            pitch=2.5,
                         ),
                     ],
                     accent=3,
@@ -609,48 +609,48 @@ class TestCreateKana(TestCase):
                             consonant=None,
                             consonant_length=None,
                             vowel="a",
-                            vowel_length=0,
-                            pitch=0,
+                            vowel_length=2.5,
+                            pitch=2.5,
                         ),
                         Mora(
                             text="リ",
                             consonant="r",
-                            consonant_length=0,
+                            consonant_length=2.5,
                             vowel="i",
-                            vowel_length=0,
-                            pitch=0,
+                            vowel_length=2.5,
+                            pitch=2.5,
                         ),
                         Mora(
                             text="マ",
                             consonant="m",
-                            consonant_length=0,
+                            consonant_length=2.5,
                             vowel="a",
-                            vowel_length=0,
-                            pitch=0,
+                            vowel_length=2.5,
+                            pitch=2.5,
                         ),
                         Mora(
                             text="ス",
                             consonant="s",
-                            consonant_length=0,
+                            consonant_length=2.5,
                             vowel="U",
-                            vowel_length=0,
-                            pitch=0,
+                            vowel_length=2.5,
+                            pitch=2.5,
                         ),
                         Mora(
                             text="カ",
                             consonant="k",
-                            consonant_length=0,
+                            consonant_length=2.5,
                             vowel="a",
-                            vowel_length=0,
-                            pitch=0,
+                            vowel_length=2.5,
+                            pitch=2.5,
                         ),
                         Mora(
                             text="ア",
                             consonant=None,
                             consonant_length=None,
                             vowel="a",
-                            vowel_length=0,
-                            pitch=0,
+                            vowel_length=2.5,
+                            pitch=2.5,
                         ),
                     ],
                     accent=3,
@@ -665,3 +665,37 @@ class TestCreateKana(TestCase):
         accent_phrases = koreha_arimasuka_accent_phrases()
         accent_phrases[-1].is_interrogative = True
         self.assertEqual(create_kana(accent_phrases), "コレワ'/アリマ'_スカ？")
+
+        def kya_accent_phrases():
+            return [
+                AccentPhrase(
+                    moras=[
+                        Mora(
+                            text="キャ",
+                            consonant="ky",
+                            consonant_length=2.5,
+                            vowel="a",
+                            vowel_length=2.5,
+                            pitch=2.5,
+                        ),
+                        Mora(
+                            text="ッ",
+                            consonant=None,
+                            consonant_length=None,
+                            vowel="cl",
+                            vowel_length=0.1,
+                            pitch=0,
+                        ),
+                    ],
+                    accent=1,
+                    pause_mora=None,
+                    is_interrogative=False,
+                ),
+            ]
+
+        accent_phrases = kya_accent_phrases()
+        self.assertEqual(create_kana(accent_phrases), "キャ'ッ")
+
+        accent_phrases = kya_accent_phrases()
+        accent_phrases[-1].is_interrogative = True
+        self.assertEqual(create_kana(accent_phrases), "キャ'ッ")

--- a/test/test_kana_parser.py
+++ b/test/test_kana_parser.py
@@ -7,7 +7,7 @@ from voicevox_engine.model import AccentPhrase, Mora, ParseKanaError, ParseKanaE
 
 
 def parse_kana(text: str) -> List[AccentPhrase]:
-    accent_phrases, _ = kana_parser.parse_kana(text, False)
+    accent_phrases = kana_parser.parse_kana(text, False)
     return accent_phrases
 
 
@@ -61,17 +61,9 @@ class TestParseKana(TestCase):
         text: str,
         enable_interrogative: bool,
         expected_accent_phrases: List[AccentPhrase],
-        expected_interrogative_accent_phrase_marks: List[bool],
     ):
-        accent_phrases, interrogative_accent_phrase_marks = kana_parser.parse_kana(
-            text, enable_interrogative
-        )
-        self.assertEqual(len(accent_phrases), len(interrogative_accent_phrase_marks))
+        accent_phrases = kana_parser.parse_kana(text, enable_interrogative)
         self.assertEqual(expected_accent_phrases, accent_phrases)
-        self.assertEqual(
-            interrogative_accent_phrase_marks,
-            expected_interrogative_accent_phrase_marks,
-        )
 
     def test_interrogative_accent_phrase_marks(self):
         def a_slash_a_accent_phrases():
@@ -111,7 +103,6 @@ class TestParseKana(TestCase):
             text="ア'/ア'",
             enable_interrogative=False,
             expected_accent_phrases=expected_accent_phrases,
-            expected_interrogative_accent_phrase_marks=[False, False],
         )
 
         expected_accent_phrases = a_slash_a_accent_phrases()
@@ -119,7 +110,6 @@ class TestParseKana(TestCase):
             text="ア'/ア'",
             enable_interrogative=True,
             expected_accent_phrases=expected_accent_phrases,
-            expected_interrogative_accent_phrase_marks=[False, False],
         )
 
         def a_jp_comma_a_accent_phrases():
@@ -166,7 +156,6 @@ class TestParseKana(TestCase):
             text="ア'、ア'",
             enable_interrogative=False,
             expected_accent_phrases=expected_accent_phrases,
-            expected_interrogative_accent_phrase_marks=[False, False],
         )
 
         expected_accent_phrases = a_jp_comma_a_accent_phrases()
@@ -174,7 +163,6 @@ class TestParseKana(TestCase):
             text="ア'、ア'",
             enable_interrogative=True,
             expected_accent_phrases=expected_accent_phrases,
-            expected_interrogative_accent_phrase_marks=[False, False],
         )
 
         def a_slash_a_slash_a_slash_a_slash_a_accent_phrases():
@@ -256,26 +244,12 @@ class TestParseKana(TestCase):
             text="ア'/ア'/ア'/ア'/ア'",
             enable_interrogative=False,
             expected_accent_phrases=expected_accent_phrases,
-            expected_interrogative_accent_phrase_marks=[
-                False,
-                False,
-                False,
-                False,
-                False,
-            ],
         )
         expected_accent_phrases = a_slash_a_slash_a_slash_a_slash_a_accent_phrases()
         self._interrogative_accent_phrase_marks_base(
             text="ア'/ア'/ア'/ア'/ア'",
             enable_interrogative=True,
             expected_accent_phrases=expected_accent_phrases,
-            expected_interrogative_accent_phrase_marks=[
-                False,
-                False,
-                False,
-                False,
-                False,
-            ],
         )
 
         def su_accent_phrases():
@@ -301,14 +275,12 @@ class TestParseKana(TestCase):
             text="ス'",
             enable_interrogative=False,
             expected_accent_phrases=expected_accent_phrases,
-            expected_interrogative_accent_phrase_marks=[False],
         )
         expected_accent_phrases = su_accent_phrases()
         self._interrogative_accent_phrase_marks_base(
             text="ス'",
             enable_interrogative=True,
             expected_accent_phrases=expected_accent_phrases,
-            expected_interrogative_accent_phrase_marks=[False],
         )
 
         def under_score_su_accent_phrases():
@@ -334,7 +306,6 @@ class TestParseKana(TestCase):
             text="_ス'",
             enable_interrogative=False,
             expected_accent_phrases=expected_accent_phrases,
-            expected_interrogative_accent_phrase_marks=[False],
         )
 
         expected_accent_phrases = under_score_su_accent_phrases()
@@ -342,7 +313,6 @@ class TestParseKana(TestCase):
             text="_ス'",
             enable_interrogative=True,
             expected_accent_phrases=expected_accent_phrases,
-            expected_interrogative_accent_phrase_marks=[False],
         )
 
         def gye_accent_phrases():
@@ -368,7 +338,6 @@ class TestParseKana(TestCase):
             text="ギェ'",
             enable_interrogative=False,
             expected_accent_phrases=expected_accent_phrases,
-            expected_interrogative_accent_phrase_marks=[False],
         )
 
         expected_accent_phrases = gye_accent_phrases()
@@ -376,7 +345,6 @@ class TestParseKana(TestCase):
             text="ギェ'",
             enable_interrogative=True,
             expected_accent_phrases=expected_accent_phrases,
-            expected_interrogative_accent_phrase_marks=[False],
         )
 
         def gye_gye_gye_accent_phrases():
@@ -437,7 +405,6 @@ class TestParseKana(TestCase):
             text="ギェ'、ギェ'/ギェ'",
             enable_interrogative=False,
             expected_accent_phrases=expected_accent_phrases,
-            expected_interrogative_accent_phrase_marks=[False, False, False],
         )
 
         expected_accent_phrases = gye_gye_gye_accent_phrases()
@@ -445,7 +412,6 @@ class TestParseKana(TestCase):
             text="ギェ'、ギェ'/ギェ'",
             enable_interrogative=True,
             expected_accent_phrases=expected_accent_phrases,
-            expected_interrogative_accent_phrase_marks=[False, False, False],
         )
 
         def a_question_mark_accent_phrases():
@@ -471,11 +437,11 @@ class TestParseKana(TestCase):
             text="ア'？",
             enable_interrogative=False,
             expected_accent_phrases=expected_accent_phrases,
-            expected_interrogative_accent_phrase_marks=[False],
         )
 
         expected_accent_phrases = a_question_mark_accent_phrases()
-        expected_accent_phrases[0].moras.append(
+        expected_accent_phrases[-1].is_interrogative = True
+        expected_accent_phrases[-1].moras.append(
             Mora(
                 text="ア",
                 consonant=None,
@@ -489,7 +455,6 @@ class TestParseKana(TestCase):
             text="ア'？",
             enable_interrogative=True,
             expected_accent_phrases=expected_accent_phrases,
-            expected_interrogative_accent_phrase_marks=[True],
         )
 
         def gye_gye_gye_question_mark_accent_phrases():
@@ -550,10 +515,10 @@ class TestParseKana(TestCase):
             text="ギェ'、ギェ'/ギェ'？",
             enable_interrogative=False,
             expected_accent_phrases=expected_accent_phrases,
-            expected_interrogative_accent_phrase_marks=[False, False, False],
         )
 
         expected_accent_phrases = gye_gye_gye_question_mark_accent_phrases()
+        expected_accent_phrases[-1].is_interrogative = True
         expected_accent_phrases[-1].moras.append(
             Mora(
                 text="エ",
@@ -568,7 +533,6 @@ class TestParseKana(TestCase):
             text="ギェ'、ギェ'/ギェ'？",
             enable_interrogative=True,
             expected_accent_phrases=expected_accent_phrases,
-            expected_interrogative_accent_phrase_marks=[False, False, True],
         )
 
 
@@ -601,3 +565,103 @@ class TestParseKanaException(TestCase):
         with self.assertRaises(ParseKanaError) as err:
             kana_parser.parse_kana("ア？ア'", True)
         self.assertEqual(err.exception.errcode, ParseKanaErrorCode.UNKNOWN_TEXT)
+
+
+class TestCreateKana(TestCase):
+    def test_create_kana_interrogative(self):
+        def koreha_arimasuka_accent_phrases():
+            return [
+                AccentPhrase(
+                    moras=[
+                        Mora(
+                            text="コ",
+                            consonant="k",
+                            consonant_length=0,
+                            vowel="o",
+                            vowel_length=0,
+                            pitch=0,
+                        ),
+                        Mora(
+                            text="レ",
+                            consonant="r",
+                            consonant_length=0,
+                            vowel="e",
+                            vowel_length=0,
+                            pitch=0,
+                        ),
+                        Mora(
+                            text="ワ",
+                            consonant="w",
+                            consonant_length=0,
+                            vowel="a",
+                            vowel_length=0,
+                            pitch=0,
+                        ),
+                    ],
+                    accent=3,
+                    pause_mora=None,
+                    is_interrogative=False,
+                ),
+                AccentPhrase(
+                    moras=[
+                        Mora(
+                            text="ア",
+                            consonant=None,
+                            consonant_length=None,
+                            vowel="a",
+                            vowel_length=0,
+                            pitch=0,
+                        ),
+                        Mora(
+                            text="リ",
+                            consonant="r",
+                            consonant_length=0,
+                            vowel="i",
+                            vowel_length=0,
+                            pitch=0,
+                        ),
+                        Mora(
+                            text="マ",
+                            consonant="m",
+                            consonant_length=0,
+                            vowel="a",
+                            vowel_length=0,
+                            pitch=0,
+                        ),
+                        Mora(
+                            text="ス",
+                            consonant="s",
+                            consonant_length=0,
+                            vowel="U",
+                            vowel_length=0,
+                            pitch=0,
+                        ),
+                        Mora(
+                            text="カ",
+                            consonant="k",
+                            consonant_length=0,
+                            vowel="a",
+                            vowel_length=0,
+                            pitch=0,
+                        ),
+                        Mora(
+                            text="ア",
+                            consonant=None,
+                            consonant_length=None,
+                            vowel="a",
+                            vowel_length=0,
+                            pitch=0,
+                        ),
+                    ],
+                    accent=3,
+                    pause_mora=None,
+                    is_interrogative=False,
+                ),
+            ]
+
+        accent_phrases = koreha_arimasuka_accent_phrases()
+        self.assertEqual(create_kana(accent_phrases), "コレワ'/アリマ'_スカア")
+
+        accent_phrases = koreha_arimasuka_accent_phrases()
+        accent_phrases[-1].is_interrogative = True
+        self.assertEqual(create_kana(accent_phrases), "コレワ'/アリマ'_スカ？")

--- a/test/test_synthesis_engine_base.py
+++ b/test/test_synthesis_engine_base.py
@@ -1,14 +1,84 @@
-from typing import List
+from typing import List, Union
 from unittest import TestCase
+from unittest.mock import Mock
 
-from voicevox_engine.dev.synthesis_engine.mock import MockSynthesisEngine
+import numpy
+
 from voicevox_engine.model import AccentPhrase, Mora
+from voicevox_engine.synthesis_engine import SynthesisEngine
+
+
+def yukarin_s_mock(length: int, phoneme_list: numpy.ndarray, speaker_id: numpy.ndarray):
+    result = []
+    # mockとしての適当な処理、特に意味はない
+    for i in range(length):
+        result.append(round(float(phoneme_list[i] * 0.0625 + speaker_id), 2))
+    return numpy.array(result)
+
+
+def yukarin_sa_mock(
+    length: int,
+    vowel_phoneme_list: numpy.ndarray,
+    consonant_phoneme_list: numpy.ndarray,
+    start_accent_list: numpy.ndarray,
+    end_accent_list: numpy.ndarray,
+    start_accent_phrase_list: numpy.ndarray,
+    end_accent_phrase_list: numpy.ndarray,
+    speaker_id: numpy.ndarray,
+):
+    result = []
+    # mockとしての適当な処理、特に意味はない
+    for i in range(length):
+        result.append(
+            round(
+                float(
+                    (
+                        vowel_phoneme_list[0][i]
+                        + consonant_phoneme_list[0][i]
+                        + start_accent_list[0][i]
+                        + end_accent_list[0][i]
+                        + start_accent_phrase_list[0][i]
+                        + end_accent_phrase_list[0][i]
+                    )
+                    * 0.0625
+                    + speaker_id
+                ),
+                2,
+            )
+        )
+    return numpy.array(result)[numpy.newaxis]
+
+
+def decode_mock(
+    length: int,
+    phoneme_size: int,
+    f0: numpy.ndarray,
+    phoneme: numpy.ndarray,
+    speaker_id: Union[numpy.ndarray, int],
+):
+    result = []
+    # mockとしての適当な処理、特に意味はない
+    for i in range(length):
+        # decode forwardはデータサイズがlengthの256倍になるのでとりあえず256回データをresultに入れる
+        for _ in range(256):
+            result.append(
+                float(
+                    f0[i][0] * (numpy.where(phoneme[i] == 1)[0] / phoneme_size)
+                    + speaker_id
+                )
+            )
+    return numpy.array(result)
 
 
 class TestSynthesisEngineBase(TestCase):
     def setUp(self):
         super().setUp()
-        self.synthesis_engine = MockSynthesisEngine(speakers="")
+        self.synthesis_engine = SynthesisEngine(
+            yukarin_s_forwarder=Mock(side_effect=yukarin_s_mock),
+            yukarin_sa_forwarder=Mock(side_effect=yukarin_sa_mock),
+            decode_forwarder=Mock(side_effect=decode_mock),
+            speakers="",
+        )
 
     def create_accent_phrases_test_base(
         self, text: str, expected: List[AccentPhrase], enable_interrogative: bool
@@ -16,6 +86,8 @@ class TestSynthesisEngineBase(TestCase):
         actual = self.synthesis_engine.create_accent_phrases(
             text, 1, enable_interrogative
         )
+        print(expected)
+        print(actual)
         self.assertEqual(
             expected,
             actual,
@@ -34,30 +106,31 @@ class TestSynthesisEngineBase(TestCase):
                         Mora(
                             text="コ",
                             consonant="k",
-                            consonant_length=0,
+                            consonant_length=2.44,
                             vowel="o",
-                            vowel_length=0,
-                            pitch=0,
+                            vowel_length=2.88,
+                            pitch=4.38,
                         ),
                         Mora(
                             text="レ",
                             consonant="r",
-                            consonant_length=0,
+                            consonant_length=3.06,
                             vowel="e",
-                            vowel_length=0,
-                            pitch=0,
+                            vowel_length=1.88,
+                            pitch=4.0,
                         ),
                         Mora(
                             text="ワ",
                             consonant="w",
-                            consonant_length=0,
+                            consonant_length=3.62,
                             vowel="a",
-                            vowel_length=0,
-                            pitch=0,
+                            vowel_length=1.44,
+                            pitch=4.19,
                         ),
                     ],
                     accent=3,
                     pause_mora=None,
+                    is_interrogative=False,
                 ),
                 AccentPhrase(
                     moras=[
@@ -66,48 +139,50 @@ class TestSynthesisEngineBase(TestCase):
                             consonant=None,
                             consonant_length=None,
                             vowel="a",
-                            vowel_length=0,
-                            pitch=0,
+                            vowel_length=1.44,
+                            pitch=1.44,
                         ),
                         Mora(
                             text="リ",
                             consonant="r",
-                            consonant_length=0,
+                            consonant_length=3.06,
                             vowel="i",
-                            vowel_length=0,
-                            pitch=0,
+                            vowel_length=2.31,
+                            pitch=4.44,
                         ),
                         Mora(
                             text="マ",
                             consonant="m",
-                            consonant_length=0,
+                            consonant_length=2.62,
                             vowel="a",
-                            vowel_length=0,
-                            pitch=0,
+                            vowel_length=1.44,
+                            pitch=3.12,
                         ),
                         Mora(
                             text="ス",
                             consonant="s",
-                            consonant_length=0,
+                            consonant_length=3.19,
                             vowel="U",
-                            vowel_length=0,
-                            pitch=0,
+                            vowel_length=1.38,
+                            pitch=0.0,
                         ),
                         Mora(
                             text="カ",
                             consonant="k",
-                            consonant_length=0,
+                            consonant_length=2.44,
                             vowel="a",
-                            vowel_length=0,
-                            pitch=0,
+                            vowel_length=1.44,
+                            pitch=2.94,
                         ),
                     ],
                     accent=3,
                     pause_mora=None,
+                    is_interrogative=False,
                 ),
             ]
 
         expected = koreha_arimasuka_base_expected()
+        expected[-1].is_interrogative = True
         expected[-1].moras += [
             Mora(
                 text="ア",
@@ -115,7 +190,7 @@ class TestSynthesisEngineBase(TestCase):
                 consonant_length=None,
                 vowel="a",
                 vowel_length=0.15,
-                pitch=0.3,
+                pitch=expected[-1].moras[-1].pitch + 0.3,
             )
         ]
         self.create_accent_phrases_test_base(
@@ -147,12 +222,13 @@ class TestSynthesisEngineBase(TestCase):
                             consonant=None,
                             consonant_length=None,
                             vowel="N",
-                            vowel_length=0,
-                            pitch=0,
-                        ),
+                            vowel_length=1.25,
+                            pitch=1.44,
+                        )
                     ],
                     accent=1,
                     pause_mora=None,
+                    is_interrogative=False,
                 )
             ]
 
@@ -164,6 +240,7 @@ class TestSynthesisEngineBase(TestCase):
         )
 
         expected = nn_base_expected()
+        expected[-1].is_interrogative = True
         expected[-1].moras += [
             Mora(
                 text="ン",
@@ -171,7 +248,7 @@ class TestSynthesisEngineBase(TestCase):
                 consonant_length=None,
                 vowel="N",
                 vowel_length=0.15,
-                pitch=0.3,
+                pitch=expected[-1].moras[-1].pitch + 0.3,
             )
         ]
         self.create_accent_phrases_test_base(
@@ -196,12 +273,13 @@ class TestSynthesisEngineBase(TestCase):
                             consonant=None,
                             consonant_length=None,
                             vowel="cl",
-                            vowel_length=0,
+                            vowel_length=1.69,
                             pitch=0.0,
-                        ),
+                        )
                     ],
                     accent=1,
                     pause_mora=None,
+                    is_interrogative=False,
                 )
             ]
 
@@ -213,16 +291,7 @@ class TestSynthesisEngineBase(TestCase):
         )
 
         expected = ltu_base_expected()
-        expected[-1].moras += [
-            Mora(
-                text="ッ",
-                consonant=None,
-                consonant_length=None,
-                vowel="cl",
-                vowel_length=0.15,
-                pitch=0.3,
-            )
-        ]
+        expected[-1].is_interrogative = True
         self.create_accent_phrases_test_base(
             text="っ？",
             expected=expected,
@@ -243,14 +312,15 @@ class TestSynthesisEngineBase(TestCase):
                         Mora(
                             text="ス",
                             consonant="s",
-                            consonant_length=0,
+                            consonant_length=3.19,
                             vowel="u",
-                            vowel_length=0,
-                            pitch=0,
-                        ),
+                            vowel_length=3.5,
+                            pitch=5.94,
+                        )
                     ],
                     accent=1,
                     pause_mora=None,
+                    is_interrogative=False,
                 )
             ]
 
@@ -262,6 +332,7 @@ class TestSynthesisEngineBase(TestCase):
         )
 
         expected = su_base_expected()
+        expected[-1].is_interrogative = True
         expected[-1].moras += [
             Mora(
                 text="ウ",
@@ -269,7 +340,7 @@ class TestSynthesisEngineBase(TestCase):
                 consonant_length=None,
                 vowel="u",
                 vowel_length=0.15,
-                pitch=0.3,
+                pitch=expected[-1].moras[-1].pitch + 0.3,
             )
         ]
         self.create_accent_phrases_test_base(

--- a/test/test_synthesis_engine_base.py
+++ b/test/test_synthesis_engine_base.py
@@ -86,8 +86,6 @@ class TestSynthesisEngineBase(TestCase):
         actual = self.synthesis_engine.create_accent_phrases(
             text, 1, enable_interrogative
         )
-        print(expected)
-        print(actual)
         self.assertEqual(
             expected,
             actual,

--- a/voicevox_engine/kana_parser.py
+++ b/voicevox_engine/kana_parser.py
@@ -133,7 +133,10 @@ def parse_kana(text: str, enable_interrogative: bool) -> List[AccentPhrase]:
 def create_kana(accent_phrases: List[AccentPhrase]) -> str:
     text = ""
     replace_vowel_to_interrogative = (
-        len(accent_phrases) > 0 and accent_phrases[-1].is_interrogative
+        len(accent_phrases) > 0
+        and accent_phrases[-1].is_interrogative
+        and len(accent_phrases[-1].moras) > 0
+        and accent_phrases[-1].moras[-1].pitch > 0
     )
     for i, phrase in enumerate(accent_phrases):
         for j, mora in enumerate(phrase.moras):

--- a/voicevox_engine/model.py
+++ b/voicevox_engine/model.py
@@ -32,6 +32,7 @@ class AccentPhrase(BaseModel):
     moras: List[Mora] = Field(title="モーラのリスト")
     accent: int = Field(title="アクセント箇所")
     pause_mora: Optional[Mora] = Field(title="後ろに無音を付けるかどうか")
+    is_interrogative: bool = Field(default=False, title="疑問系かどうか")
 
     def __hash__(self):
         items = [

--- a/voicevox_engine/synthesis_engine/synthesis_engine_base.py
+++ b/voicevox_engine/synthesis_engine/synthesis_engine_base.py
@@ -18,27 +18,8 @@ def mora_to_text(mora: str) -> str:
         return mora
 
 
-def add_interrogative_mora_if_last_phoneme_is_interrogative(
-    full_context_accent_phrase: full_context_label.AccentPhrase,
-    enable_interrogative: bool,
-) -> List[full_context_label.Mora]:
-    """
-    enable_interrogativeが有効になっていて与えられたfull_context_accent_phraseが疑問系だった場合、
-    accent_phraseのmoraに対して疑問系の発音を擬似的に行うMoraを末尾に一つ追加する
-    """
-    last_mora = full_context_accent_phrase.moras[-1]
-    return (
-        full_context_accent_phrase.moras
-        + [full_context_label.Mora(None, last_mora.vowel)]
-        if full_context_accent_phrase.is_interrogative and enable_interrogative
-        else full_context_accent_phrase.moras
-    )
-
-
 def adjust_interrogative_accent_phrases(
     accent_phrases: List[AccentPhrase],
-    interrogative_accent_phrase_marks: List[bool],
-    enable_interrogative: bool,
 ) -> List[AccentPhrase]:
     """
     enable_interrogativeが有効になっていて与えられたaccent_phrasesに疑問系のものがあった場合、
@@ -47,35 +28,37 @@ def adjust_interrogative_accent_phrases(
     """
     return [
         AccentPhrase(
-            moras=adjust_interrogative_moras(accent_phrase.moras)
-            if enable_interrogative and interrogative_accent_phrase_mark
-            else accent_phrase.moras,
+            moras=adjust_interrogative_moras(accent_phrase),
             accent=accent_phrase.accent,
             pause_mora=accent_phrase.pause_mora,
+            is_interrogative=accent_phrase.is_interrogative,
         )
-        for accent_phrase, interrogative_accent_phrase_mark in zip(
-            accent_phrases, interrogative_accent_phrase_marks
-        )
+        for accent_phrase in accent_phrases
     ]
 
 
-def adjust_interrogative_moras(moras: List[Mora]) -> List[Mora]:
-    if len(moras) <= 1:
+def adjust_interrogative_moras(accent_phrase: AccentPhrase) -> List[Mora]:
+    moras = copy.deepcopy(accent_phrase.moras)
+    if accent_phrase.is_interrogative and not (len(moras) == 0 or moras[-1].pitch == 0):
+        interrogative_mora = make_interrogative_mora(moras[-1])
+        moras.append(interrogative_mora)
         return moras
-    moras = copy.deepcopy(moras)
-    moras[-1] = adjust_interrogative_mora(moras[-1], moras[-2])
-    return moras
+    else:
+        return moras
 
 
-def adjust_interrogative_mora(mora: Mora, before_mora: Mora) -> Mora:
-    mora = copy.deepcopy(mora)
+def make_interrogative_mora(last_mora: Mora) -> Mora:
     fix_vowel_length = 0.15
-    mora.vowel_length = fix_vowel_length
-
     adjust_pitch = 0.3
     max_pitch = 6.5
-    mora.pitch = min(before_mora.pitch + adjust_pitch, max_pitch)
-    return mora
+    return Mora(
+        text=openjtalk_mora2text[last_mora.vowel],
+        consonant=None,
+        consonant_length=None,
+        vowel=last_mora.vowel,
+        vowel_length=fix_vowel_length,
+        pitch=min(last_mora.pitch + adjust_pitch, max_pitch),
+    )
 
 
 def full_context_label_moras_to_moras(
@@ -156,21 +139,10 @@ class SynthesisEngineBase(metaclass=ABCMeta):
         if len(utterance.breath_groups) == 0:
             return []
 
-        interrogative_accent_phrase_marks = [
-            accent_phrase.is_interrogative
-            for breath_group in utterance.breath_groups
-            for accent_phrase in breath_group.accent_phrases
-        ]
-
         accent_phrases = self.replace_mora_data(
             accent_phrases=[
                 AccentPhrase(
-                    moras=full_context_label_moras_to_moras(
-                        add_interrogative_mora_if_last_phoneme_is_interrogative(
-                            accent_phrase,
-                            enable_interrogative,
-                        ),
-                    ),
+                    moras=full_context_label_moras_to_moras(accent_phrase.moras),
                     accent=accent_phrase.accent,
                     pause_mora=(
                         Mora(
@@ -187,6 +159,8 @@ class SynthesisEngineBase(metaclass=ABCMeta):
                         )
                         else None
                     ),
+                    is_interrogative=accent_phrase.is_interrogative
+                    and enable_interrogative,
                 )
                 for i_breath_group, breath_group in enumerate(utterance.breath_groups)
                 for i_accent_phrase, accent_phrase in enumerate(
@@ -195,9 +169,7 @@ class SynthesisEngineBase(metaclass=ABCMeta):
             ],
             speaker_id=speaker_id,
         )
-        return adjust_interrogative_accent_phrases(
-            accent_phrases, interrogative_accent_phrase_marks, enable_interrogative
-        )
+        return adjust_interrogative_accent_phrases(accent_phrases)
 
     @abstractmethod
     def synthesis(self, query: AudioQuery, speaker_id: int):


### PR DESCRIPTION

## 内容
- AccentPhraseにis_interrogativeをもたせる
- 疑問符Mora追加を調整前ではなく調整後に行うようにした https://github.com/VOICEVOX/voicevox_engine/issues/272#issuecomment-1006316072
- APIが動かなくなるため #253 の修正をここに統合


## 関連 Issue
refs #272 #253
close #255

## スクリーンショット・動画など
accent_phraseのis_interrogativeがない状態でrequestしてもエラーにならないことの確認
![accent_phrase_add_improve_evidence](https://user-images.githubusercontent.com/939468/148408995-2c11bebc-acd0-4459-9a37-d3c08c9aeebd.gif)



## その他
