### PR TITLE
Mac 版ビルドが動作しなくなっていたので動作可能にする

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,39 +56,40 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
 
-      - name: Prepare Python for building VOICEVOX engine cache
-        uses: actions/cache@v2
-        id: venv-build-voicevox-cache
-        with:
-          path: ${{ env.pythonLocation }}
-          key: ${{ runner.os }}-libs-build_voicevox-${{ env.PYTHON_VERSION }}-${{ matrix.python_architecture }}-${{ env.VOICEVOX_CORE_VERSION }}-${{ env.VOICEVOX_CORE_SOURCE_VERSION }}-${{ hashFiles('**/requirements.txt', '**/requirements-dev.txt') }}
+      # - name: Prepare Python for building VOICEVOX engine cache
+      #   uses: actions/cache@v2
+      #   id: venv-build-voicevox-cache
+      #   with:
+      #     path: ${{ env.pythonLocation }}
+      #     key: ${{ runner.os }}-libs-build_voicevox-${{ env.PYTHON_VERSION }}-${{ matrix.python_architecture }}-${{ env.VOICEVOX_CORE_VERSION }}-${{ env.VOICEVOX_CORE_SOURCE_VERSION }}-${{ hashFiles('**/requirements.txt', '**/requirements-dev.txt') }}
 
-      - name: Prepare Python venv for licenses.json generation cache
-        uses: actions/cache@v2
-        id: venv-generate-licenses-cache
-        with:
-          path: generate_licenses
-          key: ${{ runner.os }}-venv-libs-generate_licenses-${{ env.PYTHON_VERSION }}-${{ matrix.python_architecture }}-${{ hashFiles('**/requirements.txt', '**/requirements-dev.txt') }}
+      # - name: Prepare Python venv for licenses.json generation cache
+      #   uses: actions/cache@v2
+      #   id: venv-generate-licenses-cache
+      #   with:
+      #     path: generate_licenses
+      #     key: ${{ runner.os }}-venv-libs-generate_licenses-${{ env.PYTHON_VERSION }}-${{ matrix.python_architecture }}-${{ hashFiles('**/requirements.txt', '**/requirements-dev.txt') }}
 
-      - name: Prepare Python venv for licenses.json generation
-        shell: bash
-        run: python -m venv generate_licenses
+      # - name: Prepare Python venv for licenses.json generation
+      #   shell: bash
+      #   run: python -m venv generate_licenses
 
-      - name: Install dependencies for licenses.json generation
-        if: steps.venv-generate-licenses-cache.outputs.cache-hit != 'true'
+      # - name: Install dependencies for licenses.json generation
+      #   if: steps.venv-generate-licenses-cache.outputs.cache-hit != 'true'
+      - name: Install Python dependencies
         shell: bash
         run: |
-          source generate_licenses/bin/activate
+          # source generate_licenses/bin/activate
           pip install --upgrade pip setuptools wheel
           pip install -r requirements-dev.txt
-          deactivate
+          # deactivate
 
       - name: Generate licenses.json
         shell: bash
         run: |
-          source generate_licenses/bin/activate
+          # source generate_licenses/bin/activate
           python generate_licenses.py > licenses.json
-          deactivate
+          # deactivate
 
       # Download ONNX Runtime
       - name: Export ONNX Runtime url to calc hash
@@ -174,10 +175,10 @@ jobs:
           ref: ${{ env.VOICEVOX_CORE_SOURCE_VERSION }}
           path: download/voicevox_core_source
 
-      - name: Install dependencies for building VOICEVOX Core Python package
-        shell: bash
-        run: |
-          pip install -r download/voicevox_core_source/requirements.txt
+      # - name: Install dependencies for building VOICEVOX Core Python package
+      #   shell: bash
+      #   run: |
+      #     pip install -r download/voicevox_core_source/requirements.txt
 
       - name: Install VOICEVOX Core Python package
         shell: bash
@@ -201,10 +202,10 @@ jobs:
           NUMPY_INCLUDE=`python -c "import numpy; print(numpy.get_include())"`
           CPATH="$NUMPY_INCLUDE:${CPATH:-}" pip install .
 
-      - name: Install dependencies for building VOICEVOX engine
-        shell: bash
-        run: |
-          pip install -r requirements-dev.txt
+      # - name: Install dependencies for building VOICEVOX engine
+      #   shell: bash
+      #   run: |
+      #     pip install -r requirements-dev.txt
 
       - name: Download PyOpenJTalk dictionary
         shell: bash
@@ -356,7 +357,7 @@ jobs:
           set -eux
           rm -r speaker_info
           cp -r download/resource/character_info speaker_info
-      
+
       # NOTE: `load: true` may silently fail when the GitHub Actions disk (14GB) is full.
       # https://docs.github.com/ja/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
       - name: Create binary build environment with Docker

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,40 +56,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
 
-      # - name: Prepare Python for building VOICEVOX engine cache
-      #   uses: actions/cache@v2
-      #   id: venv-build-voicevox-cache
-      #   with:
-      #     path: ${{ env.pythonLocation }}
-      #     key: ${{ runner.os }}-libs-build_voicevox-${{ env.PYTHON_VERSION }}-${{ matrix.python_architecture }}-${{ env.VOICEVOX_CORE_VERSION }}-${{ env.VOICEVOX_CORE_SOURCE_VERSION }}-${{ hashFiles('**/requirements.txt', '**/requirements-dev.txt') }}
-
-      # - name: Prepare Python venv for licenses.json generation cache
-      #   uses: actions/cache@v2
-      #   id: venv-generate-licenses-cache
-      #   with:
-      #     path: generate_licenses
-      #     key: ${{ runner.os }}-venv-libs-generate_licenses-${{ env.PYTHON_VERSION }}-${{ matrix.python_architecture }}-${{ hashFiles('**/requirements.txt', '**/requirements-dev.txt') }}
-
-      # - name: Prepare Python venv for licenses.json generation
-      #   shell: bash
-      #   run: python -m venv generate_licenses
-
-      # - name: Install dependencies for licenses.json generation
-      #   if: steps.venv-generate-licenses-cache.outputs.cache-hit != 'true'
       - name: Install Python dependencies
         shell: bash
         run: |
-          # source generate_licenses/bin/activate
           pip install --upgrade pip setuptools wheel
           pip install -r requirements-dev.txt
-          # deactivate
 
       - name: Generate licenses.json
         shell: bash
         run: |
-          # source generate_licenses/bin/activate
           python generate_licenses.py > licenses.json
-          # deactivate
 
       # Download ONNX Runtime
       - name: Export ONNX Runtime url to calc hash
@@ -175,11 +151,6 @@ jobs:
           ref: ${{ env.VOICEVOX_CORE_SOURCE_VERSION }}
           path: download/voicevox_core_source
 
-      # - name: Install dependencies for building VOICEVOX Core Python package
-      #   shell: bash
-      #   run: |
-      #     pip install -r download/voicevox_core_source/requirements.txt
-
       - name: Install VOICEVOX Core Python package
         shell: bash
         run: |
@@ -201,11 +172,6 @@ jobs:
           cd download/voicevox_core_source
           NUMPY_INCLUDE=`python -c "import numpy; print(numpy.get_include())"`
           CPATH="$NUMPY_INCLUDE:${CPATH:-}" pip install .
-
-      # - name: Install dependencies for building VOICEVOX engine
-      #   shell: bash
-      #   run: |
-      #     pip install -r requirements-dev.txt
 
       - name: Download PyOpenJTalk dictionary
         shell: bash


### PR DESCRIPTION
## TL;DR

- Mac 版ビルドでコアの使用する NumPy と エンジンの使用する NumPy が異なるバージョンとなってしまい、それが原因でエンジンが動作しなくなっていました
- 他の OS 版ではコアの依存関係が全てエンジンの依存関係に含まれていると仮定した処理をしているので、コアとエンジンのNumPy バージョンのずれが起きていませんでした（従って他の OS 版は正常に動作します）。Mac 版でもそれと同様にすることで今回の問題を解決できます
- licenses.json の生成用に venv 環境を構築する workaround が不要になっていました。これを削除する形で今回の問題を解決すると簡潔だったので、合わせて削除しました

## 詳細

### NumPy のバージョンのずれにより Mac 版ビルドが起動しなくなっていた

https://github.com/VOICEVOX/voicevox_engine/actions/runs/1670090121 の Mac 版のアーティファクトを実行すると `ValueError: numpy.ndarray size changed` のエラーが出てエンジンが起動しません。このエラーはバイナリ非互換の NumPy バージョンどうしを同時に使うと発生するもののようです（参考： https://zenn.dev/ymd_h/articles/934a90e1468a05 ）。

原因は build.yml の以下の箇所でコアの依存関係をコアのリポジトリの requirements.txt を用いて先にインストールし、この環境でコアのインストールをしていることでした。

https://github.com/VOICEVOX/voicevox_engine/blob/73e32877dab4b235e07d38a52a5433fb975960f8/.github/workflows/build.yml#L177-L180

コアの requirements.txt では NumPy のバージョンを固定していないため、これにより現在の最新安定版である NumPy `1.22.0` がインストールされます。

一方、エンジンの依存関係はエンジンのリポジトリの requirements-dev.txt によってインストールされます。この requirements-dev.txt では NumPy のバージョンが `1.20.0` に固定されています。そのため、エンジンのための依存関係インストールの際に、コア向けに先にインストールされていた NumPy `1.22.0` は削除され、新たに NumPy `1.20.0` がインストールされます。この結果、コアとエンジンで NumPy のバージョンのミスマッチが起こり、前述のエラーが引き起こされます（ https://github.community/t/valueerror-numpy-ndarray-size-changed-may-indicate-binary-incompatibility-expected-96-from-c-header-got-88-from-pyobject/221052 のような報告を発見したので、`1.22.0` はそれ以前の NumPy バージョンとバイナリ非互換のようです）。

### 解決策

同じタイミングでビルドされた Linux 版は正常に動作することを確認しました。こちらが正常に動作する理由を調査したところ、以下のことがわかりました：

- Windows・Linux 版では、コアのリポジトリの requirements.txt を用いた依存関係のインストールは行われていない
- 代わりに、先にエンジンのリポジトリの requirements-dev.txt を用いて依存関係をインストールし、コアの依存関係はこの中に含まれていると仮定してコアのインストールを行っていた

この手順であれば、確かにコアとエンジンの NumPy のバージョン違いは引き起こされません。従って、Windows 版でもエンジンは正常に起動すると予想されます。Mac 版でも同様の流れとなるようにビルド手順を改変すれば、問題は解決します。

### licenses.json 生成のための venv 環境を作っていた workaround の削除

上記の解決策を実現する簡単な方法は、Mac 版ビルドにおいて licenses.json の生成用に venv 環境を作る workaround を削除し、そのままシステムの Python 環境に依存関係をインストールして licenses.json の生成を行うことです。以後、ここでインストールした依存関係を使うことで、コアとエンジンの NumPy バージョンが同一になります。

この workaround が採用されていた理由は、当初 NumPy 用の OpenBLAS を Homebrew で別途インストールするようにしていた関係で、licenses.json の生成がうまくいかなかったので、licenses.json の生成用に特別に環境を分けたためです（参考： https://github.com/VOICEVOX/voicevox_engine/pull/156#discussion_r738025986 ）。現在は OpenBLAS を別途インストールしなくなっているので、この workaround は不要になっています。今回のエンジンが起動しない問題を解決するために、この workaround を削除する方法が最も簡潔であると判断したので、同時に削除しました。

## その他

今回の不具合がこのタイミングで起きた理由は、 #276 で Python バージョンを `3.8.10` に指定した際、Mac 版と Linux 版のビルドでこれまで `3.8.12` が使われていた関係で、Python 環境のキャッシュが更新されたことによります。NumPy `1.22.0` は最近リリースされたものなので、キャッシュの更新時に新しく降ってきたようです。