### PR TITLE
自動ビルド: コアを0.10.preview.3に更新, #286 の動作修正

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -11,8 +11,8 @@ on:
 env:
   IMAGE_NAME: ${{ secrets.DOCKERHUB_USERNAME }}/voicevox_engine
   PYTHON_VERSION: '3.8.10'
-  VOICEVOX_CORE_VERSION: '0.10.preview.0'
-  VOICEVOX_CORE_SOURCE_VERSION: '0.10.preview.0'
+  VOICEVOX_CORE_VERSION: '0.10.preview.3'
+  VOICEVOX_CORE_SOURCE_VERSION: '0.10.preview.3'
 
 jobs:
   build-docker:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,8 +12,8 @@ env:
   IMAGE_NAME: ${{ secrets.DOCKERHUB_USERNAME }}/voicevox_engine
   PYTHON_VERSION: '3.8.10'
   VOICEVOX_RESOURCE_VERSION: '0.10.preview.2'
-  VOICEVOX_CORE_VERSION: '0.10.preview.0'
-  VOICEVOX_CORE_SOURCE_VERSION: '0.10.preview.0'
+  VOICEVOX_CORE_VERSION: '0.10.preview.3'
+  VOICEVOX_CORE_SOURCE_VERSION: '0.10.preview.3'
 
 jobs:
   # Build Mac binary (x64 arch only)

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN <<EOF
 EOF
 
 # assert VOICEVOX_CORE_VERSION >= 0.10.preview.0 (ONNX)
-ARG VOICEVOX_CORE_VERSION=0.10.preview.0
+ARG VOICEVOX_CORE_VERSION=0.10.preview.3
 ARG VOICEVOX_CORE_LIBRARY_NAME=libcore_cpu_x64.so
 RUN <<EOF
     set -eux
@@ -203,7 +203,7 @@ COPY --from=download-core-env /opt/voicevox_core /opt/voicevox_core
 COPY --from=download-onnxruntime-env /opt/onnxruntime /opt/onnxruntime
 
 # Install VOICEVOX Core Python module
-ARG VOICEVOX_CORE_SOURCE_VERSION=0.10.preview.0
+ARG VOICEVOX_CORE_SOURCE_VERSION=0.10.preview.3
 RUN <<EOF
     set -eux
 

--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ VOICEVOX ENGINEが使う処理能力を調節したい場合は、CPUスレッ�
 
 - 環境変数で指定する
     ```bash
-    export CPU_NUM_THREADS=4
+    export VV_CPU_NUM_THREADS=4
     python run.py --voicevox_dir=$VOICEVOX_DIR
     ```
 

--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ VOICEVOX ENGINEが使う処理能力を調節したい場合は、CPUスレッ�
 
 - 環境変数で指定する
     ```bash
-    CPU_NUM_THREADS=4
+    export CPU_NUM_THREADS=4
     python run.py --voicevox_dir=$VOICEVOX_DIR
     ```
 

--- a/run.py
+++ b/run.py
@@ -500,7 +500,9 @@ if __name__ == "__main__":
     # 引数へcpu_num_threadsの指定がなければ、環境変数をロールします。
     # 環境変数にもない場合は、Noneのままとします。
     # VV_CPU_NUM_THREADSが空文字列でなく数値でもない場合、エラー終了します。
-    parser.add_argument("--cpu_num_threads", type=int, default=os.getenv("VV_CPU_NUM_THREADS"))
+    parser.add_argument(
+        "--cpu_num_threads", type=int, default=os.getenv("VV_CPU_NUM_THREADS")
+    )
 
     args = parser.parse_args()
 

--- a/run.py
+++ b/run.py
@@ -4,6 +4,7 @@ import base64
 import json
 import multiprocessing
 import os
+import traceback
 import zipfile
 from functools import lru_cache
 from pathlib import Path
@@ -503,7 +504,14 @@ if __name__ == "__main__":
     # 引数へcpu_num_threadsの指定がなければ、環境変数をロールします。
     # 環境変数にもない場合は、Noneのままとします。
     if cpu_num_threads is None:
-        cpu_num_threads = os.getenv("CPU_NUM_THREADS", None)
+        cpu_num_threads_env = os.getenv("CPU_NUM_THREADS")
+
+        if cpu_num_threads_env is not None:
+            try:
+                cpu_num_threads = int(cpu_num_threads_env)
+            except ValueError:
+                # 数値でなかった場合、エラーを出力してcpu_num_threads=Noneのまま起動を続行
+                traceback.print_exc()
 
     # voicelib_dir が Noneのとき、音声ライブラリの Python モジュールと同じディレクトリにあるとする
     voicelib_dir: Optional[Path] = args.voicelib_dir

--- a/run.py
+++ b/run.py
@@ -496,22 +496,15 @@ if __name__ == "__main__":
     parser.add_argument("--voicelib_dir", type=Path, default=None)
     parser.add_argument("--enable_cancellable_synthesis", action="store_true")
     parser.add_argument("--init_processes", type=int, default=2)
-    parser.add_argument("--cpu_num_threads", type=int, default=None)
-    args = parser.parse_args()
-
-    cpu_num_threads: Optional[int] = args.cpu_num_threads
 
     # 引数へcpu_num_threadsの指定がなければ、環境変数をロールします。
     # 環境変数にもない場合は、Noneのままとします。
-    if cpu_num_threads is None:
-        cpu_num_threads_env = os.getenv("CPU_NUM_THREADS", None)
+    # VV_CPU_NUM_THREADSが空文字列でなく数値でもない場合、エラー終了します。
+    parser.add_argument("--cpu_num_threads", type=int, default=os.getenv("VV_CPU_NUM_THREADS"))
 
-        if cpu_num_threads_env is not None:
-            try:
-                cpu_num_threads = int(cpu_num_threads_env)
-            except ValueError:
-                # 数値でなかった場合、エラーを出力してcpu_num_threads=Noneのまま起動を続行
-                traceback.print_exc()
+    args = parser.parse_args()
+
+    cpu_num_threads: Optional[int] = args.cpu_num_threads
 
     # voicelib_dir が Noneのとき、音声ライブラリの Python モジュールと同じディレクトリにあるとする
     voicelib_dir: Optional[Path] = args.voicelib_dir

--- a/run.py
+++ b/run.py
@@ -504,7 +504,7 @@ if __name__ == "__main__":
     # 引数へcpu_num_threadsの指定がなければ、環境変数をロールします。
     # 環境変数にもない場合は、Noneのままとします。
     if cpu_num_threads is None:
-        cpu_num_threads_env = os.getenv("CPU_NUM_THREADS")
+        cpu_num_threads_env = os.getenv("CPU_NUM_THREADS", None)
 
         if cpu_num_threads_env is not None:
             try:

--- a/run.py
+++ b/run.py
@@ -4,7 +4,6 @@ import base64
 import json
 import multiprocessing
 import os
-import traceback
 import zipfile
 from functools import lru_cache
 from pathlib import Path

--- a/run.py
+++ b/run.py
@@ -500,7 +500,7 @@ if __name__ == "__main__":
     # 環境変数にもない場合は、Noneのままとします。
     # VV_CPU_NUM_THREADSが空文字列でなく数値でもない場合、エラー終了します。
     parser.add_argument(
-        "--cpu_num_threads", type=int, default=os.getenv("VV_CPU_NUM_THREADS", None)
+        "--cpu_num_threads", type=int, default=os.getenv("VV_CPU_NUM_THREADS") or None
     )
 
     args = parser.parse_args()

--- a/run.py
+++ b/run.py
@@ -501,7 +501,7 @@ if __name__ == "__main__":
     # 環境変数にもない場合は、Noneのままとします。
     # VV_CPU_NUM_THREADSが空文字列でなく数値でもない場合、エラー終了します。
     parser.add_argument(
-        "--cpu_num_threads", type=int, default=os.getenv("VV_CPU_NUM_THREADS")
+        "--cpu_num_threads", type=int, default=os.getenv("VV_CPU_NUM_THREADS", None)
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
## 内容

#286 がマージされたので、自動ビルドに使用するコアをCPUスレッド数を指定する機能が追加された0.10.preview.3に更新して、動作するようにします（忘れてました）。

0.10.preview.2でmetasのスタイル順が入れ替わった（あまあまが先頭に来ていたのを修正）のも反映されます。

- Dockerイメージの自動ビルド: <https://github.com/aoirint/voicevox_engine/actions/runs/1696730065>

```shell
docker pull aoirint/voicevox_engine:cpu-ubuntu18.04-0.10.preview.0-aoirint-13

export VV_CPU_NUM_THREADS=4
docker run --rm -it -p '127.0.0.1:50021:50021' -e VV_CPU_NUM_THREADS aoirint/voicevox_engine:cpu-ubuntu18.04-0.10.preview.0-aoirint-13
# Or
docker run --rm -it -p '127.0.0.1:50021:50021' -e VV_CPU_NUM_THREADS=4 aoirint/voicevox_engine:cpu-ubuntu18.04-0.10.preview.0-aoirint-13
```

<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue

ref #286 

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
