### PR TITLE
onnxruntimeを0.10に

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -11,7 +11,7 @@ on:
 env:
   IMAGE_NAME: ${{ secrets.DOCKERHUB_USERNAME }}/voicevox_engine
   PYTHON_VERSION: '3.8.10'
-  VOICEVOX_CORE_VERSION: '0.10.preview.3'
+  VOICEVOX_CORE_VERSION: '0.10.preview.7'
   VOICEVOX_ENGINE_VERSION: |- # releaseのときはタグが、それ以外はlatestがバージョン名に
     ${{ github.event.release.tag_name != '' && github.event.release.tag_name || 'latest' }}
 
@@ -32,49 +32,49 @@ jobs:
           - nvidia-ubuntu18.04
         include:
           # Ubuntu 20.04
-          - tag: ''
+          - tag: ""
             target: runtime-env
             base_image: ubuntu:focal
             base_runtime_image: ubuntu:focal
             voicevox_core_library_name: libcore_cpu_x64.so
-            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-linux-x64-1.9.0.tgz
+            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.10.0/onnxruntime-linux-x64-1.10.0.tgz
           - tag: cpu
             target: runtime-env
             base_image: ubuntu:focal
             base_runtime_image: ubuntu:focal
             voicevox_core_library_name: libcore_cpu_x64.so
-            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-linux-x64-1.9.0.tgz
+            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.10.0/onnxruntime-linux-x64-1.10.0.tgz
           - tag: cpu-ubuntu20.04
             target: runtime-env
             base_image: ubuntu:focal
             base_runtime_image: ubuntu:focal
             voicevox_core_library_name: libcore_cpu_x64.so
-            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-linux-x64-1.9.0.tgz
+            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.10.0/onnxruntime-linux-x64-1.10.0.tgz
           - tag: nvidia
             target: runtime-nvidia-env
             base_image: ubuntu:focal
             base_runtime_image: nvidia/cuda:11.4.2-cudnn8-runtime-ubuntu20.04
             voicevox_core_library_name: libcore_gpu_x64_nvidia.so
-            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-linux-x64-gpu-1.9.0.tgz
+            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.10.0/onnxruntime-linux-x64-gpu-1.10.0.tgz
           - tag: nvidia-ubuntu20.04
             target: runtime-nvidia-env
             base_image: ubuntu:focal
             base_runtime_image: nvidia/cuda:11.4.2-cudnn8-runtime-ubuntu20.04
             voicevox_core_library_name: libcore_gpu_x64_nvidia.so
-            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-linux-x64-gpu-1.9.0.tgz
+            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.10.0/onnxruntime-linux-x64-gpu-1.10.0.tgz
           # Ubuntu 18.04
           - tag: cpu-ubuntu18.04
             target: runtime-env
             base_image: ubuntu:bionic
             base_runtime_image: ubuntu:bionic
             voicevox_core_library_name: libcore_cpu_x64.so
-            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-linux-x64-1.9.0.tgz
+            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.10.0/onnxruntime-linux-x64-1.10.0.tgz
           - tag: nvidia-ubuntu18.04
             target: runtime-nvidia-env
             base_image: ubuntu:bionic
             base_runtime_image: nvidia/cuda:11.4.2-cudnn8-runtime-ubuntu18.04
             voicevox_core_library_name: libcore_gpu_x64_nvidia.so
-            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-linux-x64-gpu-1.9.0.tgz
+            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.10.0/onnxruntime-linux-x64-gpu-1.10.0.tgz
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,8 +11,8 @@ on:
 env:
   IMAGE_NAME: ${{ secrets.DOCKERHUB_USERNAME }}/voicevox_engine
   PYTHON_VERSION: '3.8.10'
-  VOICEVOX_RESOURCE_VERSION: '0.10.preview.2'
-  VOICEVOX_CORE_VERSION: '0.10.preview.3'
+  VOICEVOX_RESOURCE_VERSION: '0.10.preview.3'
+  VOICEVOX_CORE_VERSION: '0.10.preview.7'
   VOICEVOX_ENGINE_VERSION: |- # releaseのときはタグが、それ以外はlatestがバージョン名に
     ${{ github.event.release.tag_name != '' && github.event.release.tag_name || 'latest' }}
 
@@ -22,12 +22,12 @@ jobs:
     strategy:
       matrix:
         include:
-        - os: macos-11
-          python_architecture: 'x64'
-          pip_cache_path: ~/Library/Caches/pip
-          voicevox_core_library_name: libcore_cpu_x64.dylib
-          onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-osx-x64-1.9.0.tgz
-          artifact_name: macos-x64
+          - os: macos-11
+            python_architecture: "x64"
+            pip_cache_path: ~/Library/Caches/pip
+            voicevox_core_library_name: libcore_cpu_universal2.dylib
+            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.10.0/onnxruntime-osx-universal2-1.10.0.tgz
+            artifact_name: macos-x64
 
     runs-on: ${{ matrix.os }}
 
@@ -229,7 +229,6 @@ jobs:
           name: ${{ matrix.artifact_name }}
           path: build/run.dist/
 
-
   # Build Linux binary (push only buildcache image)
   build-linux:
     strategy:
@@ -245,7 +244,7 @@ jobs:
           base_image: ubuntu:bionic
           base_runtime_image: ubuntu:bionic
           voicevox_core_library_name: libcore_cpu_x64.so
-          onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-linux-x64-1.9.0.tgz
+          onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.10.0/onnxruntime-linux-x64-1.10.0.tgz
           artifact_name: linux-cpu
           nuitka_cache_path: nuitka_cache
         - tag: build-nvidia-ubuntu18.04
@@ -254,7 +253,7 @@ jobs:
           base_image: ubuntu:bionic
           base_runtime_image: nvidia/cuda:11.4.2-cudnn8-runtime-ubuntu18.04
           voicevox_core_library_name: libcore_gpu_x64_nvidia.so
-          onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-linux-x64-gpu-1.9.0.tgz
+          onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.10.0/onnxruntime-linux-x64-gpu-1.10.0.tgz
           artifact_name: linux-nvidia
           nuitka_cache_path: nuitka_cache
 
@@ -358,7 +357,6 @@ jobs:
           name: ${{ matrix.artifact_name }}
           path: build/run.dist/
 
-
   build-windows:
     strategy:
       matrix:
@@ -367,7 +365,7 @@ jobs:
         - os: windows-2019
           python_architecture: 'x64'
           voicevox_core_dll_name: core_cpu_x64.dll
-          onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-win-x64-1.9.0.zip
+          onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.10.0/onnxruntime-win-x64-1.10.0.zip
           ccache_url: https://github.com/ccache/ccache/releases/download/v4.4.1/ccache-4.4.1-windows-64.zip
           artifact_name: windows-cpu
           nuitka_cache_path: nuitka_cache
@@ -376,7 +374,7 @@ jobs:
         - os: windows-2019
           python_architecture: 'x64'
           voicevox_core_dll_name: core_gpu_x64_nvidia.dll
-          onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-win-x64-gpu-1.9.0.zip
+          onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.10.0/onnxruntime-win-x64-gpu-1.10.0.zip
           cuda_version: '11.4.2'
           cudnn_url: https://developer.download.nvidia.com/compute/redist/cudnn/v8.2.4/cudnn-11.4-windows-x64-v8.2.4.15.zip
           ccache_url: https://github.com/ccache/ccache/releases/download/v4.4.1/ccache-4.4.1-windows-64.zip
@@ -635,7 +633,7 @@ jobs:
           NUITKA_CACHE_DIR: ${{ matrix.nuitka_cache_path }}
         run: |
           set -eux
-          
+
           # Replace version
           sed -i "s/__version__ = \"latest\"/__version__ = \"${{ env.VOICEVOX_ENGINE_VERSION }}\"/" voicevox_engine/__init__.py
 
@@ -717,7 +715,6 @@ jobs:
           name: ${{ matrix.artifact_name }}
           path: |
             artifact/
-
 
   upload-to-release:
     if: github.event.release.tag_name != ''

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,12 +22,12 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: macos-11
-            python_architecture: "x64"
-            pip_cache_path: ~/Library/Caches/pip
-            voicevox_core_library_name: libcore_cpu_universal2.dylib
-            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.10.0/onnxruntime-osx-universal2-1.10.0.tgz
-            artifact_name: macos-x64
+        - os: macos-11
+          python_architecture: "x64"
+          pip_cache_path: ~/Library/Caches/pip
+          voicevox_core_library_name: libcore_cpu_universal2.dylib
+          onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.10.0/onnxruntime-osx-universal2-1.10.0.tgz
+          artifact_name: macos-x64
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Install libraries for ubuntu
         if: matrix.os == 'ubuntu-latest'
-        run: sudo apt-get install libsndfile1-dev
+        run: sudo apt-get install libsndfile1
 
       - name: Install dependencies
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN <<EOF
 EOF
 
 # assert VOICEVOX_CORE_VERSION >= 0.10.preview.0 (ONNX)
-ARG VOICEVOX_CORE_VERSION=0.10.preview.3
+ARG VOICEVOX_CORE_VERSION=0.10.preview.7
 ARG VOICEVOX_CORE_LIBRARY_NAME=libcore_cpu_x64.so
 RUN <<EOF
     set -eux
@@ -68,7 +68,7 @@ RUN <<EOF
     rm -rf /var/lib/apt/lists/*
 EOF
 
-ARG ONNXRUNTIME_URL=https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-linux-x64-1.9.0.tgz
+ARG ONNXRUNTIME_URL=https://github.com/microsoft/onnxruntime/releases/download/v1.10.0/onnxruntime-linux-x64-1.10.0.tgz
 RUN <<EOF
     set -eux
 

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ build-linux-docker-ubuntu20.04:
 		--progress plain \
 		--build-arg BASE_IMAGE=ubuntu:focal \
 		--build-arg BASE_RUNTIME_IMAGE=ubuntu:focal \
-		--build-arg ONNXRUNTIME_URL=https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-linux-x64-1.9.0.tgz \
+		--build-arg ONNXRUNTIME_URL=https://github.com/microsoft/onnxruntime/releases/download/v1.10.0/onnxruntime-linux-x64-1.10.0.tgz \
 		--build-arg VOICEVOX_CORE_LIBRARY_NAME=libcore_cpu_x64.so $(ARGS)
 
 .PHONY: run-linux-docker-ubuntu20.04
@@ -32,7 +32,7 @@ build-linux-docker-nvidia-ubuntu20.04:
 		--progress plain \
 		--build-arg BASE_IMAGE=ubuntu:focal \
 		--build-arg BASE_RUNTIME_IMAGE=nvidia/cuda:11.4.2-cudnn8-runtime-ubuntu20.04 \
-		--build-arg ONNXRUNTIME_URL=https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-linux-x64-gpu-1.9.0.tgz \
+		--build-arg ONNXRUNTIME_URL=https://github.com/microsoft/onnxruntime/releases/download/v1.10.0/onnxruntime-linux-x64-gpu-1.10.0.tgz \
 		--build-arg VOICEVOX_CORE_LIBRARY_NAME=libcore_gpu_x64_nvidia.so $(ARGS)
 
 .PHONY: run-linux-docker-nvidia-ubuntu20.04
@@ -52,7 +52,7 @@ build-linux-docker-ubuntu18.04:
 		--progress plain \
 		--build-arg BASE_IMAGE=ubuntu:bionic \
 		--build-arg BASE_RUNTIME_IMAGE=ubuntu:bionic \
-		--build-arg ONNXRUNTIME_URL=https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-linux-x64-1.9.0.tgz \
+		--build-arg ONNXRUNTIME_URL=https://github.com/microsoft/onnxruntime/releases/download/v1.10.0/onnxruntime-linux-x64-1.10.0.tgz \
 		--build-arg VOICEVOX_CORE_LIBRARY_NAME=libcore_cpu_x64.so $(ARGS)
 
 .PHONY: run-linux-docker-ubuntu18.04
@@ -69,7 +69,7 @@ build-linux-docker-nvidia-ubuntu18.04:
 		--progress plain \
 		--build-arg BASE_IMAGE=ubuntu:bionic \
 		--build-arg BASE_RUNTIME_IMAGE=nvidia/cuda:11.4.2-cudnn8-runtime-ubuntu18.04 \
-		--build-arg ONNXRUNTIME_URL=https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-linux-x64-gpu-1.9.0.tgz \
+		--build-arg ONNXRUNTIME_URL=https://github.com/microsoft/onnxruntime/releases/download/v1.10.0/onnxruntime-linux-x64-gpu-1.10.0.tgz \
 		--build-arg VOICEVOX_CORE_LIBRARY_NAME=libcore_gpu_x64_nvidia.so $(ARGS)
 
 .PHONY: run-linux-docker-nvidia-ubuntu18.04
@@ -134,7 +134,7 @@ build-linux-docker-build-ubuntu20.04:
 		--progress plain \
 		--build-arg BASE_IMAGE=ubuntu:focal \
 		--build-arg BASE_RUNTIME_IMAGE=ubuntu:focal \
-		--build-arg ONNXRUNTIME_URL=https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-linux-x64-1.9.0.tgz \
+		--build-arg ONNXRUNTIME_URL=https://github.com/microsoft/onnxruntime/releases/download/v1.10.0/onnxruntime-linux-x64-1.10.0.tgz \
 		--build-arg VOICEVOX_CORE_LIBRARY_NAME=libcore_cpu_x64.so $(ARGS)
 
 .PHONY: run-linux-docker-build-ubuntu20.04
@@ -152,7 +152,7 @@ build-linux-docker-build-nvidia-ubuntu20.04:
 		--progress plain \
 		--build-arg BASE_IMAGE=ubuntu:focal \
 		--build-arg BASE_RUNTIME_IMAGE=nvidia/cuda:11.4.2-cudnn8-runtime-ubuntu20.04 \
-		--build-arg ONNXRUNTIME_URL=https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-linux-x64-gpu-1.9.0.tgz \
+		--build-arg ONNXRUNTIME_URL=https://github.com/microsoft/onnxruntime/releases/download/v1.10.0/onnxruntime-linux-x64-gpu-1.10.0.tgz \
 		--build-arg VOICEVOX_CORE_LIBRARY_NAME=libcore_gpu_x64_nvidia.so $(ARGS)
 
 .PHONY: run-linux-docker-build-nvidia-ubuntu20.04
@@ -171,7 +171,7 @@ build-linux-docker-build-ubuntu18.04:
 		--progress plain \
 		--build-arg BASE_IMAGE=ubuntu:bionic \
 		--build-arg BASE_RUNTIME_IMAGE=ubuntu:bionic \
-		--build-arg ONNXRUNTIME_URL=https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-linux-x64-1.9.0.tgz \
+		--build-arg ONNXRUNTIME_URL=https://github.com/microsoft/onnxruntime/releases/download/v1.10.0/onnxruntime-linux-x64-1.10.0.tgz \
 		--build-arg VOICEVOX_CORE_LIBRARY_NAME=libcore_cpu_x64.so $(ARGS)
 
 .PHONY: run-linux-docker-build-ubuntu18.04
@@ -189,7 +189,7 @@ build-linux-docker-build-nvidia-ubuntu18.04:
 		--progress plain \
 		--build-arg BASE_IMAGE=ubuntu:bionic \
 		--build-arg BASE_RUNTIME_IMAGE=nvidia/cuda:11.4.2-cudnn8-runtime-ubuntu18.04 \
-		--build-arg ONNXRUNTIME_URL=https://github.com/microsoft/onnxruntime/releases/download/v1.9.0/onnxruntime-linux-x64-gpu-1.9.0.tgz \
+		--build-arg ONNXRUNTIME_URL=https://github.com/microsoft/onnxruntime/releases/download/v1.10.0/onnxruntime-linux-x64-gpu-1.10.0.tgz \
 		--build-arg VOICEVOX_CORE_LIBRARY_NAME=libcore_gpu_x64_nvidia.so $(ARGS)
 
 .PHONY: run-linux-docker-build-nvidia-ubuntu18.04

--- a/generate_licenses.py
+++ b/generate_licenses.py
@@ -82,6 +82,19 @@ def generate_licenses() -> List[License]:
             )
         )
 
+    # onnxruntime
+    with urllib.request.urlopen(
+        "https://raw.githubusercontent.com/microsoft/onnxruntime/master/LICENSE"
+    ) as res:
+        licenses.append(
+            License(
+                name="ONNX Runtime",
+                version="1.10.0",
+                license="MIT license",
+                text=res.read().decode(),
+            )
+        )
+
     # Python
     python_version = "3.7.12"
     with urllib.request.urlopen(

--- a/voicevox_engine/synthesis_engine/core_wrapper.py
+++ b/voicevox_engine/synthesis_engine/core_wrapper.py
@@ -100,7 +100,9 @@ def load_core(core_dir: Path, use_gpu: bool) -> CDLL:
         if model_type == "onnxruntime":
             try:
                 return CDLL(
-                    str((core_dir / "libcore_cpu_universal2.dylib").resolve(strict=True))
+                    str(
+                        (core_dir / "libcore_cpu_universal2.dylib").resolve(strict=True)
+                    )
                 )
             except OSError:
                 pass

--- a/voicevox_engine/synthesis_engine/core_wrapper.py
+++ b/voicevox_engine/synthesis_engine/core_wrapper.py
@@ -51,7 +51,7 @@ def check_core_type(core_dir: Path) -> Optional[str]:
         ).is_file():
             return "onnxruntime"
     elif sys.platform == "darwin":
-        if (core_dir / "libcore_cpu_x64.dylib").is_file():
+        if (core_dir / "libcore_cpu_universal2.dylib").is_file():
             return "onnxruntime"
     return None
 
@@ -100,7 +100,7 @@ def load_core(core_dir: Path, use_gpu: bool) -> CDLL:
         if model_type == "onnxruntime":
             try:
                 return CDLL(
-                    str((core_dir / "libcore_cpu_x64.dylib").resolve(strict=True))
+                    str((core_dir / "libcore_cpu_universal2.dylib").resolve(strict=True))
                 )
             except OSError:
                 pass


### PR DESCRIPTION
## 内容

コアのバージョンを上げ、onnxruntimeを1.10に変更します。
ついでにonnxruntimeのライセンス表記も追加します。

## 関連 Issue

- https://github.com/VOICEVOX/voicevox_core/pull/70

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
