### PR TITLE
ユーザ辞書読み込み時のWarningを修正

### DIFF
--- a/voicevox_engine/full_context_label.py
+++ b/voicevox_engine/full_context_label.py
@@ -2,12 +2,17 @@ import re
 import sys
 from dataclasses import dataclass
 from itertools import chain
+from pathlib import Path
 from typing import Dict, List, Optional
 
 import pyopenjtalk
 
 try:
-    pyopenjtalk.set_user_dict("user.dic")
+    if "__compiled__" in globals():
+        root_dir = Path(sys.argv[0]).parent
+    else:
+        root_dir = Path(__file__).parents[1]
+    pyopenjtalk.set_user_dict(str((root_dir / "user.dic").resolve(strict=True)))
 except Exception:
     print("Warning: Failed to read the user dictionary.", file=sys.stderr)
 


### PR DESCRIPTION
## 内容

現在ではパス指定があいまいなため、作業ディレクトリがVVE直下でないとエラーが出て辞書が読み込まれません。
パス指定を厳密にすることでこれを解決します。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
