### PR TITLE
疑似疑問文化をsynthesis APIの直前に移動

### DIFF
--- a/run.py
+++ b/run.py
@@ -38,9 +38,6 @@ from voicevox_engine.morphing import (
 )
 from voicevox_engine.preset import Preset, PresetLoader
 from voicevox_engine.synthesis_engine import SynthesisEngineBase, make_synthesis_engines
-from voicevox_engine.synthesis_engine.synthesis_engine_base import (
-    adjust_interrogative_accent_phrases,
-)
 from voicevox_engine.utility import ConnectBase64WavesException, connect_base64_waves
 
 
@@ -215,7 +212,7 @@ def generate_app(
                 accent_phrases=accent_phrases, speaker_id=speaker
             )
 
-            return adjust_interrogative_accent_phrases(accent_phrases)
+            return accent_phrases
         else:
             return engine.create_accent_phrases(
                 text,

--- a/test/test_kana_parser.py
+++ b/test/test_kana_parser.py
@@ -441,16 +441,6 @@ class TestParseKana(TestCase):
 
         expected_accent_phrases = a_question_mark_accent_phrases()
         expected_accent_phrases[-1].is_interrogative = True
-        expected_accent_phrases[-1].moras.append(
-            Mora(
-                text="ア",
-                consonant=None,
-                consonant_length=None,
-                vowel="a",
-                vowel_length=0.0,
-                pitch=0.0,
-            )
-        )
         self._interrogative_accent_phrase_marks_base(
             text="ア'？",
             enable_interrogative=True,
@@ -519,16 +509,6 @@ class TestParseKana(TestCase):
 
         expected_accent_phrases = gye_gye_gye_question_mark_accent_phrases()
         expected_accent_phrases[-1].is_interrogative = True
-        expected_accent_phrases[-1].moras.append(
-            Mora(
-                text="エ",
-                consonant=None,
-                consonant_length=None,
-                vowel="e",
-                vowel_length=0.0,
-                pitch=0.0,
-            )
-        )
         self._interrogative_accent_phrase_marks_base(
             text="ギェ'、ギェ'/ギェ'？",
             enable_interrogative=True,

--- a/test/test_synthesis_engine_base.py
+++ b/test/test_synthesis_engine_base.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock
 
 import numpy
 
-from voicevox_engine.model import AccentPhrase, Mora
+from voicevox_engine.model import AccentPhrase, AudioQuery, Mora
 from voicevox_engine.synthesis_engine import SynthesisEngine
 
 
@@ -70,6 +70,104 @@ def decode_mock(
     return numpy.array(result)
 
 
+def koreha_arimasuka_base_expected():
+    return [
+        AccentPhrase(
+            moras=[
+                Mora(
+                    text="コ",
+                    consonant="k",
+                    consonant_length=2.44,
+                    vowel="o",
+                    vowel_length=2.88,
+                    pitch=4.38,
+                ),
+                Mora(
+                    text="レ",
+                    consonant="r",
+                    consonant_length=3.06,
+                    vowel="e",
+                    vowel_length=1.88,
+                    pitch=4.0,
+                ),
+                Mora(
+                    text="ワ",
+                    consonant="w",
+                    consonant_length=3.62,
+                    vowel="a",
+                    vowel_length=1.44,
+                    pitch=4.19,
+                ),
+            ],
+            accent=3,
+            pause_mora=None,
+            is_interrogative=False,
+        ),
+        AccentPhrase(
+            moras=[
+                Mora(
+                    text="ア",
+                    consonant=None,
+                    consonant_length=None,
+                    vowel="a",
+                    vowel_length=1.44,
+                    pitch=1.44,
+                ),
+                Mora(
+                    text="リ",
+                    consonant="r",
+                    consonant_length=3.06,
+                    vowel="i",
+                    vowel_length=2.31,
+                    pitch=4.44,
+                ),
+                Mora(
+                    text="マ",
+                    consonant="m",
+                    consonant_length=2.62,
+                    vowel="a",
+                    vowel_length=1.44,
+                    pitch=3.12,
+                ),
+                Mora(
+                    text="ス",
+                    consonant="s",
+                    consonant_length=3.19,
+                    vowel="U",
+                    vowel_length=1.38,
+                    pitch=0.0,
+                ),
+                Mora(
+                    text="カ",
+                    consonant="k",
+                    consonant_length=2.44,
+                    vowel="a",
+                    vowel_length=1.44,
+                    pitch=2.94,
+                ),
+            ],
+            accent=3,
+            pause_mora=None,
+            is_interrogative=False,
+        ),
+    ]
+
+
+def create_mock_query(accent_phrases):
+    return AudioQuery(
+        accent_phrases=accent_phrases,
+        speedScale=1,
+        pitchScale=0,
+        intonationScale=1,
+        volumeScale=1,
+        prePhonemeLength=0.1,
+        postPhonemeLength=0.1,
+        outputSamplingRate=24000,
+        outputStereo=False,
+        kana="",
+    )
+
+
 class TestSynthesisEngineBase(TestCase):
     def setUp(self):
         super().setUp()
@@ -79,6 +177,7 @@ class TestSynthesisEngineBase(TestCase):
             decode_forwarder=Mock(side_effect=decode_mock),
             speakers="",
         )
+        self.synthesis_engine._synthesis_impl = Mock()
 
     def create_accent_phrases_test_base(
         self, text: str, expected: List[AccentPhrase], enable_interrogative: bool
@@ -96,89 +195,43 @@ class TestSynthesisEngineBase(TestCase):
             + ")",
         )
 
-    def test_create_accent_phrases(self):
-        def koreha_arimasuka_base_expected():
-            return [
-                AccentPhrase(
-                    moras=[
-                        Mora(
-                            text="コ",
-                            consonant="k",
-                            consonant_length=2.44,
-                            vowel="o",
-                            vowel_length=2.88,
-                            pitch=4.38,
-                        ),
-                        Mora(
-                            text="レ",
-                            consonant="r",
-                            consonant_length=3.06,
-                            vowel="e",
-                            vowel_length=1.88,
-                            pitch=4.0,
-                        ),
-                        Mora(
-                            text="ワ",
-                            consonant="w",
-                            consonant_length=3.62,
-                            vowel="a",
-                            vowel_length=1.44,
-                            pitch=4.19,
-                        ),
-                    ],
-                    accent=3,
-                    pause_mora=None,
-                    is_interrogative=False,
-                ),
-                AccentPhrase(
-                    moras=[
-                        Mora(
-                            text="ア",
-                            consonant=None,
-                            consonant_length=None,
-                            vowel="a",
-                            vowel_length=1.44,
-                            pitch=1.44,
-                        ),
-                        Mora(
-                            text="リ",
-                            consonant="r",
-                            consonant_length=3.06,
-                            vowel="i",
-                            vowel_length=2.31,
-                            pitch=4.44,
-                        ),
-                        Mora(
-                            text="マ",
-                            consonant="m",
-                            consonant_length=2.62,
-                            vowel="a",
-                            vowel_length=1.44,
-                            pitch=3.12,
-                        ),
-                        Mora(
-                            text="ス",
-                            consonant="s",
-                            consonant_length=3.19,
-                            vowel="U",
-                            vowel_length=1.38,
-                            pitch=0.0,
-                        ),
-                        Mora(
-                            text="カ",
-                            consonant="k",
-                            consonant_length=2.44,
-                            vowel="a",
-                            vowel_length=1.44,
-                            pitch=2.94,
-                        ),
-                    ],
-                    accent=3,
-                    pause_mora=None,
-                    is_interrogative=False,
-                ),
-            ]
+    def create_synthesis_test_base(
+        self, text: str, expected: List[AccentPhrase], enable_interrogative: bool
+    ):
+        """音声合成時に疑問文モーラ処理を行っているかどうかを検証
+        (https://github.com/VOICEVOX/voicevox_engine/issues/272#issuecomment-1022610866)
+        """
+        accent_phrases = self.synthesis_engine.create_accent_phrases(
+            text, 1, enable_interrogative
+        )
+        query = create_mock_query(accent_phrases=accent_phrases)
+        self.synthesis_engine.synthesis(query, 0)
+        # _synthesis_implの第一引数に与えられたqueryを検証
+        actual = self.synthesis_engine._synthesis_impl.call_args[0][0].accent_phrases
 
+        self.assertEqual(
+            expected,
+            actual,
+            "case(text:"
+            + text
+            + ",enable_interrogative:"
+            + str(enable_interrogative)
+            + ")",
+        )
+
+    def test_create_accent_phrases(self):
+        """accent_phrasesの作成時では疑問文モーラ処理を行わない
+        (https://github.com/VOICEVOX/voicevox_engine/issues/272#issuecomment-1022610866)
+        """
+        expected = koreha_arimasuka_base_expected()
+        expected[-1].is_interrogative = True
+        self.create_accent_phrases_test_base(
+            text="これはありますか？",
+            expected=expected,
+            enable_interrogative=True,
+        )
+
+    def test_synthesis_interrogative(self):
         expected = koreha_arimasuka_base_expected()
         expected[-1].is_interrogative = True
         expected[-1].moras += [
@@ -191,21 +244,21 @@ class TestSynthesisEngineBase(TestCase):
                 pitch=expected[-1].moras[-1].pitch + 0.3,
             )
         ]
-        self.create_accent_phrases_test_base(
+        self.create_synthesis_test_base(
             text="これはありますか？",
             expected=expected,
             enable_interrogative=True,
         )
 
         expected = koreha_arimasuka_base_expected()
-        self.create_accent_phrases_test_base(
+        self.create_synthesis_test_base(
             text="これはありますか？",
             expected=expected,
             enable_interrogative=False,
         )
 
         expected = koreha_arimasuka_base_expected()
-        self.create_accent_phrases_test_base(
+        self.create_synthesis_test_base(
             text="これはありますか",
             expected=expected,
             enable_interrogative=True,
@@ -231,7 +284,7 @@ class TestSynthesisEngineBase(TestCase):
             ]
 
         expected = nn_base_expected()
-        self.create_accent_phrases_test_base(
+        self.create_synthesis_test_base(
             text="ん",
             expected=expected,
             enable_interrogative=True,
@@ -249,14 +302,14 @@ class TestSynthesisEngineBase(TestCase):
                 pitch=expected[-1].moras[-1].pitch + 0.3,
             )
         ]
-        self.create_accent_phrases_test_base(
+        self.create_synthesis_test_base(
             text="ん？",
             expected=expected,
             enable_interrogative=True,
         )
 
         expected = nn_base_expected()
-        self.create_accent_phrases_test_base(
+        self.create_synthesis_test_base(
             text="ん？",
             expected=expected,
             enable_interrogative=False,
@@ -282,7 +335,7 @@ class TestSynthesisEngineBase(TestCase):
             ]
 
         expected = ltu_base_expected()
-        self.create_accent_phrases_test_base(
+        self.create_synthesis_test_base(
             text="っ",
             expected=expected,
             enable_interrogative=True,
@@ -290,14 +343,14 @@ class TestSynthesisEngineBase(TestCase):
 
         expected = ltu_base_expected()
         expected[-1].is_interrogative = True
-        self.create_accent_phrases_test_base(
+        self.create_synthesis_test_base(
             text="っ？",
             expected=expected,
             enable_interrogative=True,
         )
 
         expected = ltu_base_expected()
-        self.create_accent_phrases_test_base(
+        self.create_synthesis_test_base(
             text="っ？",
             expected=expected,
             enable_interrogative=False,
@@ -323,7 +376,7 @@ class TestSynthesisEngineBase(TestCase):
             ]
 
         expected = su_base_expected()
-        self.create_accent_phrases_test_base(
+        self.create_synthesis_test_base(
             text="す",
             expected=expected,
             enable_interrogative=True,
@@ -341,14 +394,14 @@ class TestSynthesisEngineBase(TestCase):
                 pitch=expected[-1].moras[-1].pitch + 0.3,
             )
         ]
-        self.create_accent_phrases_test_base(
+        self.create_synthesis_test_base(
             text="す？",
             expected=expected,
             enable_interrogative=True,
         )
 
         expected = su_base_expected()
-        self.create_accent_phrases_test_base(
+        self.create_synthesis_test_base(
             text="す？",
             expected=expected,
             enable_interrogative=False,

--- a/voicevox_engine/cancellable_engine.py
+++ b/voicevox_engine/cancellable_engine.py
@@ -119,7 +119,7 @@ class CancellableEngine:
             # プロセスが死んでいるので新しく作り直す
             self.procs_and_cons.put(self.start_new_proc())
 
-    def synthesis(
+    def _synthesis_impl(
         self, query: AudioQuery, speaker_id: Speaker, request: Request
     ) -> str:
         """

--- a/voicevox_engine/dev/synthesis_engine/mock.py
+++ b/voicevox_engine/dev/synthesis_engine/mock.py
@@ -64,7 +64,7 @@ class MockSynthesisEngine(SynthesisEngineBase):
         """
         return accent_phrases
 
-    def synthesis(self, query: AudioQuery, speaker_id: int) -> np.ndarray:
+    def _synthesis_impl(self, query: AudioQuery, speaker_id: int) -> np.ndarray:
         """
         synthesis voicevox coreを使わずに、音声合成する [Mock]
 

--- a/voicevox_engine/kana_parser.py
+++ b/voicevox_engine/kana_parser.py
@@ -114,17 +114,6 @@ def parse_kana(text: str, enable_interrogative: bool) -> List[AccentPhrase]:
 
     if enable_interrogative and is_interrogative_text:
         last_parsed_result = parsed_results[-1]
-        last_mora = last_parsed_result.moras[-1]
-        last_parsed_result.moras.append(
-            Mora(
-                text=openjtalk_mora2text[last_mora.vowel],
-                consonant=None,
-                consonant_length=None,
-                vowel=last_mora.vowel,
-                vowel_length=last_mora.vowel_length,
-                pitch=0,
-            )
-        )
         last_parsed_result.is_interrogative = True
 
     return parsed_results

--- a/voicevox_engine/synthesis_engine/synthesis_engine.py
+++ b/voicevox_engine/synthesis_engine/synthesis_engine.py
@@ -354,7 +354,7 @@ class SynthesisEngine(SynthesisEngineBase):
 
         return accent_phrases
 
-    def synthesis(self, query: AudioQuery, speaker_id: int):
+    def _synthesis_impl(self, query: AudioQuery, speaker_id: int):
         """
         音声合成クエリから音声合成に必要な情報を構成し、実際に音声合成を行う
         Parameters


### PR DESCRIPTION
## 内容
Mora追加による疑似疑問文化を音声合成の直前部に移動した。
synthesis系のAPI(`/synthesis, /cancellable_synthesis, /multi_synthesis, /synthesis_morphing`)に影響

<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue
ref. #272 
https://github.com/VOICEVOX/voicevox_engine/issues/272#issuecomment-1022610866

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## 懸念点
疑似疑問文化がいい感じにならなかったときユーザーによる語尾音高の調整が出来なくなった