### PR TITLE
Enable interrogativeをsynthesisのみにする

### DIFF
--- a/run.py
+++ b/run.py
@@ -220,10 +220,10 @@ def generate_app(engine: SynthesisEngineBase) -> FastAPI:
     def synthesis(
         query: AudioQuery,
         speaker: int,
-        enable_interrogative_upspeak: bool = Query(
+        enable_interrogative_upspeak: bool = Query(  # noqa: B008
             default=True,
             description="疑問系のテキストが与えられたら語尾を自動調整する",
-        ),  # noqa: B008
+        ),
     ):
         wave = engine.synthesis(
             query=query,

--- a/run.py
+++ b/run.py
@@ -75,31 +75,17 @@ def generate_app(engine: SynthesisEngineBase) -> FastAPI:
             loop = asyncio.get_event_loop()
             _ = loop.create_task(cancellable_engine.catch_disconnection())
 
-    def enable_interrogative_query_param() -> Query:
-        return Query(
-            default=True,
-            description="疑問系のテキストが与えられたら自動調整する機能を有効にする。現在は長音を付け足すことで擬似的に実装される",
-        )
-
     @app.post(
         "/audio_query",
         response_model=AudioQuery,
         tags=["クエリ作成"],
         summary="音声合成用のクエリを作成する",
     )
-    def audio_query(
-        text: str,
-        speaker: int,
-        enable_interrogative: bool = enable_interrogative_query_param(),  # noqa B008,
-    ):
+    def audio_query(text: str, speaker: int):
         """
         クエリの初期値を得ます。ここで得られたクエリはそのまま音声合成に利用できます。各値の意味は`Schemas`を参照してください。
         """
-        accent_phrases = engine.create_accent_phrases(
-            text,
-            speaker_id=speaker,
-            enable_interrogative=enable_interrogative,
-        )
+        accent_phrases = engine.create_accent_phrases(text, speaker_id=speaker)
         return AudioQuery(
             accent_phrases=accent_phrases,
             speedScale=1,
@@ -119,11 +105,7 @@ def generate_app(engine: SynthesisEngineBase) -> FastAPI:
         tags=["クエリ作成"],
         summary="音声合成用のクエリをプリセットを用いて作成する",
     )
-    def audio_query_from_preset(
-        text: str,
-        preset_id: int,
-        enable_interrogative: bool = enable_interrogative_query_param(),  # noqa B008,
-    ):
+    def audio_query_from_preset(text: str, preset_id: int):
         """
         クエリの初期値を得ます。ここで得られたクエリはそのまま音声合成に利用できます。各値の意味は`Schemas`を参照してください。
         """
@@ -138,9 +120,7 @@ def generate_app(engine: SynthesisEngineBase) -> FastAPI:
             raise HTTPException(status_code=422, detail="該当するプリセットIDが見つかりません")
 
         accent_phrases = engine.create_accent_phrases(
-            text,
-            speaker_id=selected_preset.style_id,
-            enable_interrogative=enable_interrogative,
+            text, speaker_id=selected_preset.style_id
         )
         return AudioQuery(
             accent_phrases=accent_phrases,
@@ -167,12 +147,7 @@ def generate_app(engine: SynthesisEngineBase) -> FastAPI:
             }
         },
     )
-    def accent_phrases(
-        text: str,
-        speaker: int,
-        is_kana: bool = False,
-        enable_interrogative: bool = enable_interrogative_query_param(),  # noqa B008,
-    ):
+    def accent_phrases(text: str, speaker: int, is_kana: bool = False):
         """
         テキストからアクセント句を得ます。
         is_kanaが`true`のとき、テキストは次のようなAquesTalkライクな記法に従う読み仮名として処理されます。デフォルトは`false`です。
@@ -196,11 +171,7 @@ def generate_app(engine: SynthesisEngineBase) -> FastAPI:
 
             return accent_phrases
         else:
-            return engine.create_accent_phrases(
-                text,
-                speaker_id=speaker,
-                enable_interrogative=enable_interrogative,
-            )
+            return engine.create_accent_phrases(text, speaker_id=speaker)
 
     @app.post(
         "/mora_data",
@@ -246,8 +217,19 @@ def generate_app(engine: SynthesisEngineBase) -> FastAPI:
         tags=["音声合成"],
         summary="音声合成する",
     )
-    def synthesis(query: AudioQuery, speaker: int):
-        wave = engine.synthesis(query=query, speaker_id=speaker)
+    def synthesis(
+        query: AudioQuery,
+        speaker: int,
+        enable_interrogative_upspeak: bool = Query(
+            default=True,
+            description="疑問系のテキストが与えられたら語尾を自動調整する",
+        ),  # noqa: B008
+    ):
+        wave = engine.synthesis(
+            query=query,
+            speaker_id=speaker,
+            enable_interrogative_upspeak=enable_interrogative_upspeak,
+        )
 
         with NamedTemporaryFile(delete=False) as f:
             soundfile.write(

--- a/test/test_synthesis_engine_base.py
+++ b/test/test_synthesis_engine_base.py
@@ -179,44 +179,35 @@ class TestSynthesisEngineBase(TestCase):
         )
         self.synthesis_engine._synthesis_impl = Mock()
 
-    def create_accent_phrases_test_base(
-        self, text: str, expected: List[AccentPhrase], enable_interrogative: bool
-    ):
-        actual = self.synthesis_engine.create_accent_phrases(
-            text, 1, enable_interrogative
-        )
+    def create_accent_phrases_test_base(self, text: str, expected: List[AccentPhrase]):
+        actual = self.synthesis_engine.create_accent_phrases(text, 1)
         self.assertEqual(
             expected,
             actual,
-            "case(text:"
-            + text
-            + ",enable_interrogative:"
-            + str(enable_interrogative)
-            + ")",
+            "case(text:" + text + ")",
         )
 
     def create_synthesis_test_base(
-        self, text: str, expected: List[AccentPhrase], enable_interrogative: bool
+        self,
+        text: str,
+        expected: List[AccentPhrase],
+        enable_interrogative_upspeak: bool,
     ):
         """音声合成時に疑問文モーラ処理を行っているかどうかを検証
         (https://github.com/VOICEVOX/voicevox_engine/issues/272#issuecomment-1022610866)
         """
-        accent_phrases = self.synthesis_engine.create_accent_phrases(
-            text, 1, enable_interrogative
-        )
+        accent_phrases = self.synthesis_engine.create_accent_phrases(text, 1)
         query = create_mock_query(accent_phrases=accent_phrases)
-        self.synthesis_engine.synthesis(query, 0)
+        self.synthesis_engine.synthesis(
+            query, 0, enable_interrogative_upspeak=enable_interrogative_upspeak
+        )
         # _synthesis_implの第一引数に与えられたqueryを検証
         actual = self.synthesis_engine._synthesis_impl.call_args[0][0].accent_phrases
 
         self.assertEqual(
             expected,
             actual,
-            "case(text:"
-            + text
-            + ",enable_interrogative:"
-            + str(enable_interrogative)
-            + ")",
+            "case(text:" + text + ")",
         )
 
     def test_create_accent_phrases(self):
@@ -225,11 +216,7 @@ class TestSynthesisEngineBase(TestCase):
         """
         expected = koreha_arimasuka_base_expected()
         expected[-1].is_interrogative = True
-        self.create_accent_phrases_test_base(
-            text="これはありますか？",
-            expected=expected,
-            enable_interrogative=True,
-        )
+        self.create_accent_phrases_test_base(text="これはありますか？", expected=expected)
 
     def test_synthesis_interrogative(self):
         expected = koreha_arimasuka_base_expected()
@@ -247,21 +234,22 @@ class TestSynthesisEngineBase(TestCase):
         self.create_synthesis_test_base(
             text="これはありますか？",
             expected=expected,
-            enable_interrogative=True,
+            enable_interrogative_upspeak=True,
         )
 
         expected = koreha_arimasuka_base_expected()
+        expected[-1].is_interrogative = True
         self.create_synthesis_test_base(
             text="これはありますか？",
             expected=expected,
-            enable_interrogative=False,
+            enable_interrogative_upspeak=False,
         )
 
         expected = koreha_arimasuka_base_expected()
         self.create_synthesis_test_base(
             text="これはありますか",
             expected=expected,
-            enable_interrogative=True,
+            enable_interrogative_upspeak=True,
         )
 
         def nn_base_expected():
@@ -287,7 +275,7 @@ class TestSynthesisEngineBase(TestCase):
         self.create_synthesis_test_base(
             text="ん",
             expected=expected,
-            enable_interrogative=True,
+            enable_interrogative_upspeak=True,
         )
 
         expected = nn_base_expected()
@@ -305,14 +293,15 @@ class TestSynthesisEngineBase(TestCase):
         self.create_synthesis_test_base(
             text="ん？",
             expected=expected,
-            enable_interrogative=True,
+            enable_interrogative_upspeak=True,
         )
 
         expected = nn_base_expected()
+        expected[-1].is_interrogative = True
         self.create_synthesis_test_base(
             text="ん？",
             expected=expected,
-            enable_interrogative=False,
+            enable_interrogative_upspeak=False,
         )
 
         def ltu_base_expected():
@@ -338,7 +327,7 @@ class TestSynthesisEngineBase(TestCase):
         self.create_synthesis_test_base(
             text="っ",
             expected=expected,
-            enable_interrogative=True,
+            enable_interrogative_upspeak=True,
         )
 
         expected = ltu_base_expected()
@@ -346,14 +335,15 @@ class TestSynthesisEngineBase(TestCase):
         self.create_synthesis_test_base(
             text="っ？",
             expected=expected,
-            enable_interrogative=True,
+            enable_interrogative_upspeak=True,
         )
 
         expected = ltu_base_expected()
+        expected[-1].is_interrogative = True
         self.create_synthesis_test_base(
             text="っ？",
             expected=expected,
-            enable_interrogative=False,
+            enable_interrogative_upspeak=False,
         )
 
         def su_base_expected():
@@ -379,7 +369,7 @@ class TestSynthesisEngineBase(TestCase):
         self.create_synthesis_test_base(
             text="す",
             expected=expected,
-            enable_interrogative=True,
+            enable_interrogative_upspeak=True,
         )
 
         expected = su_base_expected()
@@ -397,12 +387,13 @@ class TestSynthesisEngineBase(TestCase):
         self.create_synthesis_test_base(
             text="す？",
             expected=expected,
-            enable_interrogative=True,
+            enable_interrogative_upspeak=True,
         )
 
         expected = su_base_expected()
+        expected[-1].is_interrogative = True
         self.create_synthesis_test_base(
             text="す？",
             expected=expected,
-            enable_interrogative=False,
+            enable_interrogative_upspeak=False,
         )

--- a/voicevox_engine/synthesis_engine/synthesis_engine_base.py
+++ b/voicevox_engine/synthesis_engine/synthesis_engine_base.py
@@ -22,7 +22,7 @@ def adjust_interrogative_accent_phrases(
     accent_phrases: List[AccentPhrase],
 ) -> List[AccentPhrase]:
     """
-    enable_interrogativeが有効になっていて与えられたaccent_phrasesに疑問系のものがあった場合、
+    enable_interrogative_upspeakが有効になっていて与えられたaccent_phrasesに疑問系のものがあった場合、
     各accent_phraseの末尾にある疑問系発音用のMoraに対して直前のMoraより少し音を高くすることで疑問文ぽくする
     NOTE: リファクタリング時に適切な場所へ移動させること
     """
@@ -129,9 +129,7 @@ class SynthesisEngineBase(metaclass=ABCMeta):
             speaker_id=speaker_id,
         )
 
-    def create_accent_phrases(
-        self, text: str, speaker_id: int, enable_interrogative: bool
-    ) -> List[AccentPhrase]:
+    def create_accent_phrases(self, text: str, speaker_id: int) -> List[AccentPhrase]:
         if len(text.strip()) == 0:
             return []
 
@@ -159,8 +157,7 @@ class SynthesisEngineBase(metaclass=ABCMeta):
                         )
                         else None
                     ),
-                    is_interrogative=accent_phrase.is_interrogative
-                    and enable_interrogative,
+                    is_interrogative=accent_phrase.is_interrogative,
                 )
                 for i_breath_group, breath_group in enumerate(utterance.breath_groups)
                 for i_accent_phrase, accent_phrase in enumerate(
@@ -171,7 +168,12 @@ class SynthesisEngineBase(metaclass=ABCMeta):
         )
         return accent_phrases
 
-    def synthesis(self, query: AudioQuery, speaker_id: int):
+    def synthesis(
+        self,
+        query: AudioQuery,
+        speaker_id: int,
+        enable_interrogative_upspeak: bool = True,
+    ) -> str:
         """
         音声合成クエリ内の疑問文指定されたMoraを変形した後、
         継承先における実装`_synthesis_impl`を使い音声合成を行う
@@ -181,6 +183,8 @@ class SynthesisEngineBase(metaclass=ABCMeta):
             音声合成クエリ
         speaker_id : int
             話者ID
+        enable_interrogative_upspeak : bool
+            疑問系のテキストの語尾を自動調整する機能を有効にするか
         Returns
         -------
         wave : numpy.ndarray
@@ -188,7 +192,10 @@ class SynthesisEngineBase(metaclass=ABCMeta):
         """
         # モーフィング時などに同一参照のqueryで複数回呼ばれる可能性があるので、元の引数のqueryに破壊的変更を行わない
         query = copy.deepcopy(query)
-        query.accent_phrases = adjust_interrogative_accent_phrases(query.accent_phrases)
+        if enable_interrogative_upspeak:
+            query.accent_phrases = adjust_interrogative_accent_phrases(
+                query.accent_phrases
+            )
         return self._synthesis_impl(query, speaker_id)
 
     @abstractmethod


### PR DESCRIPTION
## 内容

語尾をあげる処理はsynthesisのみに関わり、それまでは語尾を上げるかどうかに関わらず、疑問文を処理できるようにします。

ということで、accent_phrase作成までの`enable_interrogative`はすべてなくしました。
また、synthesisの引数は、疑問文を有効にするというよりは、語尾を上げる機能なので、引数名をわかりやすいもの`enable_interrogative_upspeak`に変更します。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他

一般にはリリースされていない v0.10.0 などから比べると破壊的変更ですが、将来的なことも考えてこちらのほうが良いと判断しました。
