### PR TITLE
共有ライブラリのロードでアーキテクチャを考慮する機能を追加

### DIFF
--- a/voicevox_engine/synthesis_engine/core_wrapper.py
+++ b/voicevox_engine/synthesis_engine/core_wrapper.py
@@ -66,7 +66,7 @@ def check_core_type(core_dir: Path) -> Optional[str]:
 def load_core(core_dir: Path, use_gpu: bool) -> CDLL:
     model_type = check_core_type(core_dir)
     if model_type is None:
-        raise RuntimeError("コアが見つかりません")
+        raise RuntimeError("コアのタイプを判別できませんでした")
     if platform.system() == "Windows":
         if model_type == "libtorch":
             if use_gpu:

--- a/voicevox_engine/synthesis_engine/core_wrapper.py
+++ b/voicevox_engine/synthesis_engine/core_wrapper.py
@@ -77,7 +77,25 @@ def load_core(core_dir: Path, use_gpu: bool) -> CDLL:
                     str((core_dir / "core_gpu_x64_nvidia.dll").resolve(strict=True))
                 )
             except OSError:
-                return CDLL(str((core_dir / "core_cpu_x64.dll").resolve(strict=True)))
+                machine = platform.machine()
+                if machine == "x86_64" or machine == "x64" or machine == "AMD64":
+                    return CDLL(
+                        str((core_dir / "core_cpu_x64.dll").resolve(strict=True))
+                    )
+                elif machine == "i386" or machine == "x86":
+                    return CDLL(
+                        str((core_dir / "core_cpu_x86.dll").resolve(strict=True))
+                    )
+                elif machine == "armv7l":
+                    return CDLL(
+                        str((core_dir / "core_cpu_arm.dll").resolve(strict=True))
+                    )
+                elif machine == "aarch64":
+                    return CDLL(
+                        str((core_dir / "core_cpu_arm64.dll").resolve(strict=True))
+                    )
+                else:
+                    raise RuntimeError(f"このコンピュータのアーキテクチャ {machine} で利用可能なコアがありません")
     elif platform.system() == "Linux":
         if model_type == "libtorch":
             if use_gpu:
@@ -95,7 +113,21 @@ def load_core(core_dir: Path, use_gpu: bool) -> CDLL:
                     str((core_dir / "libcore_gpu_x64_nvidia.so").resolve(strict=True))
                 )
             except OSError:
-                return CDLL(str((core_dir / "libcore_cpu_x64.so").resolve(strict=True)))
+                machine = platform.machine()
+                if machine == "x86_64" or machine == "x64" or machine == "AMD64":
+                    return CDLL(
+                        str((core_dir / "libcore_cpu_x64.so").resolve(strict=True))
+                    )
+                elif machine == "armv7l":
+                    return CDLL(
+                        str((core_dir / "libcore_cpu_armhf.so").resolve(strict=True))
+                    )
+                elif machine == "aarch64":
+                    return CDLL(
+                        str((core_dir / "libcore_cpu_arm64.so").resolve(strict=True))
+                    )
+                else:
+                    raise RuntimeError(f"このコンピュータのアーキテクチャ {machine} で利用可能なコアがありません")
     elif platform.system() == "Darwin":
         if model_type == "onnxruntime":
             try:

--- a/voicevox_engine/synthesis_engine/core_wrapper.py
+++ b/voicevox_engine/synthesis_engine/core_wrapper.py
@@ -37,18 +37,25 @@ def check_core_type(core_dir: Path) -> Optional[str]:
     if platform.system() == "Windows":
         if (core_dir / "core.dll").is_file() or (core_dir / "core_cpu.dll").is_file():
             return "libtorch"
-        elif (core_dir / "core_gpu_x64_nvidia.dll").is_file() or (
-            core_dir / "core_cpu_x64.dll"
-        ).is_file():
+        elif (
+            (core_dir / "core_gpu_x64_nvidia.dll").is_file()
+            or (core_dir / "core_cpu_x64.dll").is_file()
+            or (core_dir / "core_cpu_x86.dll").is_file()
+            or (core_dir / "core_cpu_arm.dll").is_file()
+            or (core_dir / "core_cpu_arm64.dll").is_file()
+        ):
             return "onnxruntime"
     elif platform.system() == "Linux":
         if (core_dir / "libcore.so").is_file() or (
             core_dir / "libcore_cpu.so"
         ).is_file():
             return "libtorch"
-        elif (core_dir / "libcore_gpu_x64_nvidia.so").is_file() or (
-            core_dir / "libcore_cpu_x64.so"
-        ).is_file():
+        elif (
+            (core_dir / "libcore_gpu_x64_nvidia.so").is_file()
+            or (core_dir / "libcore_cpu_x64.so").is_file()
+            or (core_dir / "libcore_cpu_armhf.so").is_file()
+            or (core_dir / "libcore_cpu_arm64.so").is_file()
+        ):
             return "onnxruntime"
     elif platform.system() == "Darwin":
         if (core_dir / "libcore_cpu_universal2.dylib").is_file():

--- a/voicevox_engine/synthesis_engine/core_wrapper.py
+++ b/voicevox_engine/synthesis_engine/core_wrapper.py
@@ -1,5 +1,5 @@
 import os
-import sys
+import platform
 from ctypes import CDLL, POINTER, c_bool, c_char_p, c_float, c_int, c_long
 from ctypes.util import find_library
 from pathlib import Path
@@ -9,13 +9,13 @@ import numpy as np
 
 
 def load_runtime_lib(runtime_dirs: List[Path]):
-    if sys.platform == "win32":
+    if platform.system() == "Windows":
         lib_file_names = ["torch_cpu.dll", "torch_cuda.dll", "onnxruntime.dll"]
         lib_names = ["torch_cpu", "torch_cuda", "onnxruntime"]
-    elif sys.platform == "linux":
+    elif platform.system() == "Linux":
         lib_file_names = ["libtorch.so", "libonnxruntime.so"]
         lib_names = ["torch", "onnxruntime"]
-    elif sys.platform == "darwin":
+    elif platform.system() == "Darwin":
         lib_file_names = ["libonnxruntime.dylib"]
         lib_names = ["onnxruntime"]
     else:
@@ -34,14 +34,14 @@ def load_runtime_lib(runtime_dirs: List[Path]):
 
 
 def check_core_type(core_dir: Path) -> Optional[str]:
-    if sys.platform == "win32":
+    if platform.system() == "Windows":
         if (core_dir / "core.dll").is_file() or (core_dir / "core_cpu.dll").is_file():
             return "libtorch"
         elif (core_dir / "core_gpu_x64_nvidia.dll").is_file() or (
             core_dir / "core_cpu_x64.dll"
         ).is_file():
             return "onnxruntime"
-    elif sys.platform == "linux":
+    elif platform.system() == "Linux":
         if (core_dir / "libcore.so").is_file() or (
             core_dir / "libcore_cpu.so"
         ).is_file():
@@ -50,7 +50,7 @@ def check_core_type(core_dir: Path) -> Optional[str]:
             core_dir / "libcore_cpu_x64.so"
         ).is_file():
             return "onnxruntime"
-    elif sys.platform == "darwin":
+    elif platform.system() == "Darwin":
         if (core_dir / "libcore_cpu_universal2.dylib").is_file():
             return "onnxruntime"
     return None
@@ -60,7 +60,7 @@ def load_core(core_dir: Path, use_gpu: bool) -> CDLL:
     model_type = check_core_type(core_dir)
     if model_type is None:
         raise RuntimeError("コアが見つかりません")
-    if sys.platform == "win32":
+    if platform.system() == "Windows":
         if model_type == "libtorch":
             if use_gpu:
                 try:
@@ -78,7 +78,7 @@ def load_core(core_dir: Path, use_gpu: bool) -> CDLL:
                 )
             except OSError:
                 return CDLL(str((core_dir / "core_cpu_x64.dll").resolve(strict=True)))
-    elif sys.platform == "linux":
+    elif platform.system() == "Linux":
         if model_type == "libtorch":
             if use_gpu:
                 try:
@@ -96,7 +96,7 @@ def load_core(core_dir: Path, use_gpu: bool) -> CDLL:
                 )
             except OSError:
                 return CDLL(str((core_dir / "libcore_cpu_x64.so").resolve(strict=True)))
-    elif sys.platform == "darwin":
+    elif platform.system() == "Darwin":
         if model_type == "onnxruntime":
             try:
                 return CDLL(


### PR DESCRIPTION
## 内容

共有ライブラリのロードの際に、アーキテクチャを考慮することができるように変更しました。

## 関連 Issue

close #324 

## その他

Pythonの`platform`ライブラリを利用しています。
WindowsとLinuxで判定を行います。
Windows arm向けのコアファイル`core_cpu_arm.dll`とLinux arm向けのコアファイル`libcore_cpu_armhf.so`で命名ルールが異なっているようです。