### PR TITLE
Setuptoolsをダウングレード

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -492,7 +492,9 @@ jobs:
       - name: Install Python dependencies
         shell: bash
         run: |
-          python -m pip install --upgrade pip setuptools wheel
+          # FIXME: Nuitka cannot build with setuptools>=60.7.0
+          # https://github.com/Nuitka/Nuitka/issues/1406
+          python -m pip install --upgrade pip setuptools==60.6.0 wheel
           python -m pip install -r requirements-dev.txt
 
           # Download pyopenjtalk dictionary

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,6 +64,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
 
+      # FIXME: Nuitka cannot build with setuptools>=60.7.0
+      # https://github.com/Nuitka/Nuitka/issues/1406
+      - name: Downgrade setuptools
+        shell: bash
+        run: pip install setuptools==60.6.0
+
       - name: Install Python dependencies
         shell: bash
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,16 +64,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
 
-      # FIXME: Nuitka cannot build with setuptools>=60.7.0
-      # https://github.com/Nuitka/Nuitka/issues/1406
-      - name: Downgrade setuptools
-        shell: bash
-        run: pip install setuptools==60.6.0
-
       - name: Install Python dependencies
         shell: bash
         run: |
-          pip install --upgrade pip setuptools wheel
+          # FIXME: Nuitka cannot build with setuptools>=60.7.0
+          # https://github.com/Nuitka/Nuitka/issues/1406
+          pip install --upgrade pip setuptools==60.6.0 wheel
           pip install -r requirements-dev.txt
 
       - name: Generate licenses.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -183,7 +183,9 @@ COPY --from=compile-python-env /opt/python /opt/python
 ADD ./requirements.txt /tmp/
 RUN <<EOF
     # Install requirements
-    gosu user /opt/python/bin/python3 -m pip install --upgrade pip setuptools wheel
+    # FIXME: Nuitka cannot build with setuptools>=60.7.0
+    # https://github.com/Nuitka/Nuitka/issues/1406
+    gosu user /opt/python/bin/python3 -m pip install --upgrade pip setuptools==60.6.0 wheel
     gosu user /opt/python/bin/pip3 install -r /tmp/requirements.txt
 EOF
 


### PR DESCRIPTION
## 内容

setuptoolsにアップデートが入った関係で、nuitkaビルド後のバイナリが実行できないという問題が発生しました。
https://github.com/Nuitka/Nuitka/issues/1406

nuitkaをアップデートしてもよいのですが、0.10のhotfixを入れる可能性があり、nuitkaのバージョンを上げることは何かしら危険な可能性があるため、一旦setuptoolsをダウングレードすることで解決します。

## その他

masterに入れたあと、cherry-pickでrelease-0.10にも適用する予定です。

- [ ] release-0.10にcherry-pick
