### PR TITLE
エンジンのルートフォルダを返す関数を追加

### DIFF
--- a/run.py
+++ b/run.py
@@ -39,7 +39,11 @@ from voicevox_engine.morphing import (
 )
 from voicevox_engine.preset import Preset, PresetLoader
 from voicevox_engine.synthesis_engine import SynthesisEngineBase, make_synthesis_engines
-from voicevox_engine.utility import ConnectBase64WavesException, connect_base64_waves
+from voicevox_engine.utility import (
+    ConnectBase64WavesException,
+    connect_base64_waves,
+    engine_root,
+)
 
 
 def b64encode_str(s):
@@ -49,7 +53,7 @@ def b64encode_str(s):
 def generate_app(
     synthesis_engines: Dict[str, SynthesisEngineBase], latest_core_version: str
 ) -> FastAPI:
-    root_dir = Path(__file__).parent
+    root_dir = engine_root()
 
     default_sampling_rate = synthesis_engines[latest_core_version].default_sampling_rate
 
@@ -489,20 +493,25 @@ def generate_app(
             raise HTTPException(status_code=404, detail="該当する話者が見つかりません")
 
         try:
-            policy = Path(f"speaker_info/{speaker_uuid}/policy.md").read_text("utf-8")
+            policy = (root_dir / f"speaker_info/{speaker_uuid}/policy.md").read_text(
+                "utf-8"
+            )
             portrait = b64encode_str(
-                Path(f"speaker_info/{speaker_uuid}/portrait.png").read_bytes()
+                (root_dir / f"speaker_info/{speaker_uuid}/portrait.png").read_bytes()
             )
             style_infos = []
             for style in speaker["styles"]:
                 id = style["id"]
                 icon = b64encode_str(
-                    Path(f"speaker_info/{speaker_uuid}/icons/{id}.png").read_bytes()
+                    (
+                        root_dir / f"speaker_info/{speaker_uuid}/icons/{id}.png"
+                    ).read_bytes()
                 )
                 voice_samples = [
                     b64encode_str(
-                        Path(
-                            "speaker_info/{}/voice_samples/{}_{}.wav".format(
+                        (
+                            root_dir
+                            / "speaker_info/{}/voice_samples/{}_{}.wav".format(
                                 speaker_uuid, id, str(j + 1).zfill(3)
                             )
                         ).read_bytes()

--- a/voicevox_engine/synthesis_engine/make_synthesis_engines.py
+++ b/voicevox_engine/synthesis_engine/make_synthesis_engines.py
@@ -4,6 +4,7 @@ import traceback
 from pathlib import Path
 from typing import Dict, List, Optional
 
+from ..utility import engine_root
 from .core_wrapper import CoreWrapper, load_runtime_lib
 from .synthesis_engine import SynthesisEngine, SynthesisEngineBase
 
@@ -42,12 +43,7 @@ def make_synthesis_engines(
             + "( The library leaves the decision to the synthesis runtime )",
             file=sys.stderr,
         )
-    # nuitkaビルドをした際はグローバルに__compiled__が含まれる
-    # https://nuitka.net/doc/user-manual.html#detecting-nuitka-at-run-time
-    if "__compiled__" in globals():
-        root_dir = Path(sys.argv[0]).parent
-    else:
-        root_dir = Path(__file__).parents[2]
+    root_dir = engine_root()
 
     if voicevox_dir is not None:
         if voicelib_dirs is not None:

--- a/voicevox_engine/utility/__init__.py
+++ b/voicevox_engine/utility/__init__.py
@@ -3,9 +3,11 @@ from .connect_base64_waves import (
     connect_base64_waves,
     decode_base64_waves,
 )
+from .engine_root import engine_root
 
 __all__ = [
     "ConnectBase64WavesException",
     "connect_base64_waves",
     "decode_base64_waves",
+    "engine_root",
 ]

--- a/voicevox_engine/utility/engine_root.py
+++ b/voicevox_engine/utility/engine_root.py
@@ -1,0 +1,17 @@
+import sys
+from pathlib import Path
+
+
+def engine_root() -> Path:
+    # nuitkaビルドをした際はグローバルに__compiled__が含まれる
+    if "__compiled__" in globals():
+        root_dir = Path(sys.argv[0]).parent
+
+    # pyinstallerでビルドをした際はsys.frozenが設定される
+    elif getattr(sys, "frozen", False):
+        root_dir = Path(sys.argv[0]).parent
+
+    else:
+        root_dir = Path(__file__).parents[2]
+
+    return root_dir.resolve(strict=True)


### PR DESCRIPTION
## 内容

エンジンのルートフォルダを返す関数「engine_root」を追加します。
（make_synthesis_enginesにあったものをutilityに移動）
また、ファイル操作を伴う作業で「engine_root」を使うように変更します。

## 関連 Issue

close #307 

- #307 
- #301 

## その他
#301 にて同様の変更が入っていますが、こちらを優先してください。
（必要に応じてリベースします）