### PR TITLE
READMEの変更漏れを修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ python run.py --voicevox_dir=$VOICEVOX_DIR --voicelib_dir=$VOICELIB_DIR
 
 ```bash
 # モックでサーバー起動
-python run.py
+python run.py --enable_mock
 ```
 
 ### CPU スレッド数を指定する

--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ python -m nuitka \
     --include-data-file=presets.yaml=./ \
     --include-data-file=user.dic=./ \
     --include-data-file=C:/path/to/cuda/*.dll=./ \
-    --include-data-file=C:/path/to/libtorch/*.dll=./ \
+    --include-data-file=C:/path/to/onnxruntime/lib/*.dll=./ \
     --include-data-file=C:/音声ライブラリへのパス/*.bin=./ \
     --include-data-file=C:/音声ライブラリへのパス/metas.json=./ \
     --include-data-dir=.venv/Lib/site-packages/_soundfile_data=./_soundfile_data \


### PR DESCRIPTION
## 内容

#254 にてmockの使用には`--enable_mock`引数が必要になりましたが、readmeを変更するのを忘れていました。
また、ビルド引数も古いままだったので修正します。

## その他
@.PickledChair さんのツイートで気づくことができました、ありがとうございます。
https://twitter.com/pickled_chair/status/1495039654902792198