### PR TITLE
Refactor: コアのロードまわりを整理

### DIFF
--- a/voicevox_engine/synthesis_engine/core_wrapper.py
+++ b/voicevox_engine/synthesis_engine/core_wrapper.py
@@ -48,28 +48,28 @@ CORE_INFOS = [
     CoreInfo(
         name="core.dll",
         platform="Windows",
-        arch="x86_64",
+        arch="x64",
         core_type="libtorch",
         is_gpu_core=True,
     ),
     CoreInfo(
         name="core_cpu.dll",
         platform="Windows",
-        arch="x86_64",
+        arch="x64",
         core_type="libtorch",
         is_gpu_core=False,
     ),
     CoreInfo(
         name="core_gpu_x64_nvidia.dll",
         platform="Windows",
-        arch="x86_64",
+        arch="x64",
         core_type="onnxruntime",
         is_gpu_core=True,
     ),
     CoreInfo(
         name="core_cpu_x64.dll",
         platform="Windows",
-        arch="x86_64",
+        arch="x64",
         core_type="onnxruntime",
         is_gpu_core=False,
     ),
@@ -98,28 +98,28 @@ CORE_INFOS = [
     CoreInfo(
         name="libcore.so",
         platform="Linux",
-        arch="x86_64",
+        arch="x64",
         core_type="libtorch",
         is_gpu_core=True,
     ),
     CoreInfo(
         name="libcore_cpu.so",
         platform="Linux",
-        arch="x86_64",
+        arch="x64",
         core_type="libtorch",
         is_gpu_core=False,
     ),
     CoreInfo(
         name="libcore_gpu_x64_nvidia.so",
         platform="Linux",
-        arch="x86_64",
+        arch="x64",
         core_type="onnxruntime",
         is_gpu_core=True,
     ),
     CoreInfo(
         name="libcore_cpu_x64.so",
         platform="Linux",
-        arch="x86_64",
+        arch="x64",
         core_type="onnxruntime",
         is_gpu_core=False,
     ),
@@ -156,7 +156,7 @@ def get_arch_name() -> Optional[str]:
     """
     machine = platform.machine()
     if machine == "x86_64" or machine == "x64" or machine == "AMD64":
-        return "x86_64"
+        return "x64"
     elif machine == "i386" or machine == "x86":
         return "x86"
     elif machine in ["armv7l", "aarch64"]:
@@ -169,7 +169,7 @@ def get_core_name(
     arch_name: str, platform_name: str, model_type: str, is_gpu_core: bool
 ) -> Optional[str]:
     if platform_name == "Darwin":
-        if (not is_gpu_core) and (arch_name == "x86_64" or arch_name == "aarch64"):
+        if (not is_gpu_core) and (arch_name == "x64" or arch_name == "aarch64"):
             arch_name = "universal"
         else:
             return None

--- a/voicevox_engine/synthesis_engine/core_wrapper.py
+++ b/voicevox_engine/synthesis_engine/core_wrapper.py
@@ -224,14 +224,17 @@ def load_core(core_dir: Path, use_gpu: bool) -> CDLL:
     if core_name:
         try:
             return CDLL(str((core_dir / core_name).resolve(strict=True)))
-        except OSError:
+        except OSError as err:
             if model_type == "libtorch":
                 core_name = get_suitable_core_name(model_type, is_gpu_core=True)
                 if core_name:
-                    return CDLL(str((core_dir / core_name).resolve(strict=True)))
+                    try:
+                        return CDLL(str((core_dir / core_name).resolve(strict=True)))
+                    except OSError as err_:
+                        err = err_
+            raise RuntimeError(f"コアの読み込みに失敗しました：{err}")
     else:
         raise RuntimeError(f"このコンピュータのアーキテクチャ {platform.machine()} で利用可能なコアがありません")
-    raise RuntimeError("コアの読み込みに失敗しました")
 
 
 class CoreWrapper:


### PR DESCRIPTION
## 内容

#327 でエンジンがサポートするアーキテクチャが増えました。
それに伴い、アーキテクチャの判定処理のために if 分岐が増えるなど、複雑なコードになりつつあったので、それを整理してみました。

具体的には `CoreInfo` というデータクラスを定義し、

- `libtorch` 版コア・ `onnxruntime` 版コアの判定（`check_core_type` 関数）
- OS・アーキテクチャ等の情報をもとに適切なコアをロードする処理（`load_core` 関数）

中の一部処理を、`CoreInfo` のリスト中から適切なものを探索する処理として共通化しました。

## 関連 PR

ref #327 
