### PR TITLE
masterにpushされたときもbuild workflowが実行されるのでrelease-testで迂回

### DIFF
--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -24,6 +24,7 @@ env:
 
 jobs:
   test:
+    if: env.VERSION != ''  # masterにpushされたときもbuild workflowが実行されるので迂回
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## 内容

masterにpushされたあとはrelease-testが実行されないようにします

## 関連 Issue

- https://github.com/VOICEVOX/voicevox_engine/pull/329#issuecomment-1046233332

## その他


本当はrelease buildが完了した後のみに実行したいけど、今はrelease作成→buildが自動実行→releaseにバイナリ登録の流れなので判定が作れない。
workflow_dispatchでbuildし、その中でreleaseを作成＆バイナリ登録するようにすればこっちはきれいになりそう。

