### PR TITLE
ユーザー辞書のIDをUUIDに変更

### DIFF
--- a/run.py
+++ b/run.py
@@ -544,7 +544,7 @@ def generate_app(
         ret_data = {"policy": policy, "portrait": portrait, "style_infos": style_infos}
         return ret_data
 
-    @app.get("/user_dict", response_model=Dict[int, UserDictWord], tags=["ユーザー辞書"])
+    @app.get("/user_dict", response_model=Dict[str, UserDictWord], tags=["ユーザー辞書"])
     def get_user_dict_words():
         """
         ユーザ辞書に登録されている単語の一覧を返します。
@@ -552,11 +552,11 @@ def generate_app(
 
         Returns
         -------
-        Dict[int, UserDictWord]
-            単語のIDとその詳細
+        Dict[str, UserDictWord]
+            単語のUUIDとその詳細
         """
         try:
-            return read_dict().words
+            return read_dict()
         except Exception:
             traceback.print_exc()
             raise HTTPException(status_code=422, detail="辞書の読み込みに失敗しました。")
@@ -586,9 +586,9 @@ def generate_app(
             traceback.print_exc()
             raise HTTPException(status_code=422, detail="ユーザ辞書への追加に失敗しました。")
 
-    @app.put("/user_dict_word/{id}", status_code=204, tags=["ユーザー辞書"])
+    @app.put("/user_dict_word/{word_uuid}", status_code=204, tags=["ユーザー辞書"])
     def rewrite_user_dict_word(
-        surface: str, pronunciation: str, accent_type: int, id: int
+        surface: str, pronunciation: str, accent_type: int, word_uuid: str
     ):
         """
         ユーザ辞書に登録されている言葉を更新します。
@@ -601,15 +601,15 @@ def generate_app(
             言葉の発音（カタカナ）
         accent_type: int
             アクセント型（音が下がる場所を指す）
-        id: int
-            更新する言葉のID
+        word_uuid: str
+            更新する言葉のUUID
         """
         try:
             rewrite_word(
                 surface=surface,
                 pronunciation=pronunciation,
                 accent_type=accent_type,
-                id=id,
+                word_uuid=word_uuid,
             )
             return Response(status_code=204)
         except HTTPException:
@@ -620,18 +620,18 @@ def generate_app(
             traceback.print_exc()
             raise HTTPException(status_code=422, detail="ユーザ辞書の更新に失敗しました。")
 
-    @app.delete("/user_dict_word/{id}", status_code=204, tags=["ユーザー辞書"])
-    def delete_user_dict_word(id: int):
+    @app.delete("/user_dict_word/{word_uuid}", status_code=204, tags=["ユーザー辞書"])
+    def delete_user_dict_word(word_uuid: str):
         """
         ユーザ辞書に登録されている言葉を削除します。
 
         Parameters
         ----------
-        id: int
-            削除する言葉のID
+        word_uuid: str
+            削除する言葉のUUID
         """
         try:
-            delete_word(id=id)
+            delete_word(word_uuid=word_uuid)
             return Response(status_code=204)
         except HTTPException:
             raise

--- a/voicevox_engine/model.py
+++ b/voicevox_engine/model.py
@@ -217,15 +217,6 @@ class UserDictWord(BaseModel):
         return mora_count
 
 
-class UserDictJson(BaseModel):
-    """
-    ユーザ辞書機能に使われるjsonファイルのフォーマット
-    """
-
-    next_id: int = Field(title="次に割り当てられるID")
-    words: Dict[int, UserDictWord] = Field(title="辞書のコンパイルに使われるワードの情報")
-
-
 class SupportedDevicesInfo(BaseModel):
     """
     対応しているデバイスの情報

--- a/voicevox_engine/user_dict.py
+++ b/voicevox_engine/user_dict.py
@@ -1,6 +1,5 @@
 import json
 import sys
-import traceback
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import Dict
@@ -96,14 +95,10 @@ def read_dict(user_dict_path: Path = user_dict_path) -> Dict[str, UserDictWord]:
     if not user_dict_path.is_file():
         return {}
     with user_dict_path.open(encoding="utf-8") as f:
-        try:
-            return {
-                str(UUID(word_uuid)): UserDictWord(**word)
-                for word_uuid, word in json.load(f).items()
-            }
-        except json.decoder.JSONDecodeError:
-            traceback.print_exc()
-            return {}
+        return {
+            str(UUID(word_uuid)): UserDictWord(**word)
+            for word_uuid, word in json.load(f).items()
+        }
 
 
 def create_word(surface: str, pronunciation: str, accent_type: int) -> UserDictWord:

--- a/voicevox_engine/user_dict.py
+++ b/voicevox_engine/user_dict.py
@@ -27,9 +27,9 @@ compiled_dict_path = save_dir / "user.dic"
 
 def write_to_json(user_dict: Dict[str, UserDictWord], user_dict_path: Path):
     user_dict = {word_uuid: word.dict() for word_uuid, word in user_dict.items()}
-    json.dump(
-        user_dict, user_dict_path.open(mode="w", encoding="utf-8"), ensure_ascii=False
-    )
+    # 予めjsonに変換できることを確かめる
+    user_dict_json = json.dumps(user_dict, ensure_ascii=False)
+    user_dict_path.write_text(user_dict_json, encoding="utf-8")
 
 
 def user_dict_startup_processing(


### PR DESCRIPTION
## 内容

今までユーザ辞書ではID（数字）で管理を行っていましたがUUIDに変更します。
これに伴いjsonファイルのフォーマットに破壊的変更が入ります。

https://github.com/VOICEVOX/voicevox_engine/pull/338#discussion_r814850487

## 関連Issue
- https://github.com/VOICEVOX/voicevox/issues/709
- https://github.com/VOICEVOX/voicevox/pull/711

APIに変更が入っているのでエディタ側にも変更が必要そうです。
ご確認お願いします。 @y-chan 

## その他
バージョンを跨ぐとマイグレーションを行う必要が出てきてめんどくさいので0.11のリリースよりも前にマージしたいです。