### PR TITLE
単語登録時に、登録されたUUIDを返すように変更する

### DIFF
--- a/run.py
+++ b/run.py
@@ -561,7 +561,7 @@ def generate_app(
             traceback.print_exc()
             raise HTTPException(status_code=422, detail="辞書の読み込みに失敗しました。")
 
-    @app.post("/user_dict_word", status_code=204, tags=["ユーザー辞書"])
+    @app.post("/user_dict_word", response_model=str, tags=["ユーザー辞書"])
     def add_user_dict_word(surface: str, pronunciation: str, accent_type: int):
         """
         ユーザ辞書に言葉を追加します。
@@ -576,10 +576,10 @@ def generate_app(
             アクセント型（音が下がる場所を指す）
         """
         try:
-            apply_word(
+            word_uuid = apply_word(
                 surface=surface, pronunciation=pronunciation, accent_type=accent_type
             )
-            return Response(status_code=204)
+            return Response(content=word_uuid)
         except ValidationError as e:
             raise HTTPException(status_code=422, detail="パラメータに誤りがあります。\n" + str(e))
         except Exception:

--- a/voicevox_engine/user_dict.py
+++ b/voicevox_engine/user_dict.py
@@ -125,14 +125,16 @@ def apply_word(
     accent_type: int,
     user_dict_path: Path = user_dict_path,
     compiled_dict_path: Path = compiled_dict_path,
-):
+) -> str:
     word = create_word(
         surface=surface, pronunciation=pronunciation, accent_type=accent_type
     )
     user_dict = read_dict(user_dict_path=user_dict_path)
-    user_dict[str(uuid4())] = word
+    word_uuid = str(uuid4())
+    user_dict[word_uuid] = word
     write_to_json(user_dict, user_dict_path)
     update_dict(compiled_dict_path=compiled_dict_path)
+    return word_uuid
 
 
 def rewrite_word(


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->
題の通り。これがなければ辞書UI作成においてすごく不便なため、追加しました。
また、新規作成したキーを返すといったAPIはよく見られると思うので、特に問題はないと思っています。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->
ref #340 

