### PR TITLE
release-testをworkflow_callで実装

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -765,6 +765,8 @@ jobs:
           file: ${{ matrix.artifact_name }}.7z.*
 
   run-release-test-workflow:
+    if: github.event.release.tag_name != ''
+    needs: [upload-to-release]
     uses: ./.github/workflows/release-test.yml
     with:
       version: ${{ github.ref }} # == github.event.release.tag_name

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -763,3 +763,9 @@ jobs:
           tag: ${{ github.ref }} # == github.event.release.tag_name
           file_glob: true
           file: ${{ matrix.artifact_name }}.7z.*
+
+      - name: Run release test workflow
+        uses: ./.github/workflows/release-test.yml
+        with:
+          version: ${{ github.ref }} # == github.event.release.tag_name
+          repo_url: ${{ format('{0}/{1}', github.server_url, github.repository) }}  # このリポジトリのURL

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -764,8 +764,8 @@ jobs:
           file_glob: true
           file: ${{ matrix.artifact_name }}.7z.*
 
-      - name: Run release test workflow
-        uses: ./.github/workflows/release-test.yml
-        with:
-          version: ${{ github.ref }} # == github.event.release.tag_name
-          repo_url: ${{ format('{0}/{1}', github.server_url, github.repository) }}  # このリポジトリのURL
+  run-release-test-workflow:
+    uses: ./.github/workflows/release-test.yml
+    with:
+      version: ${{ github.ref }} # == github.event.release.tag_name
+      repo_url: ${{ format('{0}/{1}', github.server_url, github.repository) }}  # このリポジトリのURL

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -1,30 +1,34 @@
 name: Test Release Build
 
 on:
-  workflow_run:
-    workflows:
-      - build
-    types:
-      - completed
+  workflow_call:
+    inputs:
+      version:
+        type: string
+        required: true
+      repo_url:
+        type: string
+        required: false
   workflow_dispatch:
     inputs:
       version:
+        type: string
         description: "テストしたいタグ名"
         required: true
       repo_url:
+        type: string
         description: "リポジトリのURL（省略可能）"
         required: false
 
 env:
   REPO_URL:
     |- # repo_url指定時はrepo_urlを、それ以外はgithubのリポジトリURLを使用
-    ${{ github.event.inputs.repo_url || format('{0}/{1}', github.server_url, github.repository) }}
+    ${{ (github.event.inputs || inputs).repo_url || format('{0}/{1}', github.server_url, github.repository) }}
   VERSION: |- # version指定時はversionを、それ以外はタグ名を使用
-    ${{ github.event.inputs.version || github.event.release.tag_name }}
+    ${{ (github.event.inputs || inputs).version }}
 
 jobs:
   test:
-    if: github.event.inputs.version != '' || github.event.release.tag_name != '' # env.VERSIONはここでは使えない
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## 内容

github actionsでbuildしたあと、そのbuildが正しく動くかをチェックするrelease-testというworkflowがあります。

が、どのrelease tagでアップロードされたかを検知する手段がありませんでした。
（`release.tag_name`はworkflowの開始がreleaseフックじゃないので変数に値が入っていなかった）

そこで`workflow_call`を用いて他のworkflowから引数を受け取れるようにし、build workflowの最後で実行するようにしました。
dockerhubのアカウントを写せていない関係でbuildを試せていないのですが、たぶん動く気がします。。

## 関連 Issue

- https://github.com/VOICEVOX/voicevox_engine/issues/176

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
