### PR TITLE
release-testのcallのバージョン指定の修正

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -769,5 +769,5 @@ jobs:
     needs: [upload-to-release]
     uses: ./.github/workflows/release-test.yml
     with:
-      version: ${{ github.ref }} # == github.event.release.tag_name
-      repo_url: ${{ format('{0}/{1}', github.server_url, github.repository) }}  # このリポジトリのURL
+      version: ${{ env.VOICEVOX_ENGINE_VERSION }}
+      repo_url: ${{ format('{0}/{1}', github.server_url, github.repository) }} # このリポジトリのURL

--- a/build_util/check_release_build.py
+++ b/build_util/check_release_build.py
@@ -22,7 +22,7 @@ def test_release_build(dist_dir: Path) -> None:
 
     # 起動
     process = Popen([run_file.absolute()], cwd=dist_dir)
-    time.sleep(60)  # 待機
+    time.sleep(120)  # 待機
 
     # バージョン取得テスト
     req = Request(base_url + "version")


### PR DESCRIPTION
## 内容

release-testのcallのバージョン指定の修正方法が間違っていたので修正です。
ついでにサーバーの待機時間を伸ばしています。（辞書のビルドの分だけ時間が増えていた）

