### PR TITLE
build workflow が走らない問題を解決

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -769,5 +769,5 @@ jobs:
     needs: [upload-to-release]
     uses: ./.github/workflows/release-test.yml
     with:
-      version: ${{ env.VOICEVOX_ENGINE_VERSION }}
+      version: ${{ github.event.release.tag_name }}
       repo_url: ${{ format('{0}/{1}', github.server_url, github.repository) }} # このリポジトリのURL


### PR DESCRIPTION
## 内容

https://github.com/VOICEVOX/voicevox_engine/actions/runs/1906904458 で build workflow が実行されていませんでした。エラー内容を見ると、

> The workflow is not valid. .github/workflows/build.yml (Line: 772, Col: 16): Unrecognized named-value: 'env'. Located at position 1 within expression: env.VOICEVOX_ENGINE_VERSION

というように、`env` という名前が `run-release-test-workflow` ジョブ内で認識されていないことが原因のようでした。実際に https://docs.github.com/ja/actions/using-workflows/reusing-workflows#limitations には、workflow_call の制限事項として

> Any environment variables set in an env context defined at the workflow level in the caller workflow are not propagated to the called workflow. 
> 呼び出し側の workflow の workflow level で定義された env コンテキストに設定された環境変数は、呼び出される側の workflow に伝搬されない。

ということが記載されていました。また、似たような事例が https://github.community/t/using-environment-in-workflow-call/222321/5 でも報告されていました。

回避策としては単純に env コンテキストを使わないことが簡単な方法であると考えたため、`env.VOICEVOX_ENGINE_VERSION` の代わりに `github.event.release.tag_name` を用いる方法を取りました（if で `!= ''` であることが保証されているため、両者は同じ文字列になるはずです）。

メモですが、他の方法として、直前に実行されたジョブの output 経由でバージョンの文字列を渡す方法もありそうでした（変更が冗長になりそうだったので今回は採用しませんでした）。
参考： https://github.community/t/using-environment-in-workflow-call/222321/6

## 関連 PR

ref #343 
ref #347 
