### PR TITLE
ユーザ辞書機能：名詞以外の品詞を追加

### DIFF
--- a/run.py
+++ b/run.py
@@ -590,7 +590,7 @@ def generate_app(
         accent_type: int
             アクセント型（音が下がる場所を指す）
         part_of_speech: str, optional
-            固有名詞、動詞、形容詞、語尾のいずれか
+            固有名詞、普通名詞、動詞、形容詞、語尾のいずれか
         """
         try:
             word_uuid = apply_word(
@@ -628,7 +628,7 @@ def generate_app(
         word_uuid: str
             更新する言葉のUUID
         part_of_speech: str, optional
-            固有名詞、動詞、形容詞、語尾のいずれか
+            固有名詞、普通名詞、動詞、形容詞、語尾のいずれか
         """
         try:
             rewrite_word(

--- a/run.py
+++ b/run.py
@@ -572,7 +572,12 @@ def generate_app(
             raise HTTPException(status_code=422, detail="辞書の読み込みに失敗しました。")
 
     @app.post("/user_dict_word", response_model=str, tags=["ユーザー辞書"])
-    def add_user_dict_word(surface: str, pronunciation: str, accent_type: int):
+    def add_user_dict_word(
+        surface: str,
+        pronunciation: str,
+        accent_type: int,
+        part_of_speech: Optional[str] = None,
+    ):
         """
         ユーザ辞書に言葉を追加します。
 
@@ -584,10 +589,15 @@ def generate_app(
             言葉の発音（カタカナ）
         accent_type: int
             アクセント型（音が下がる場所を指す）
+        part_of_speech: str, optional
+            固有名詞、動詞、形容詞、語尾のいずれか
         """
         try:
             word_uuid = apply_word(
-                surface=surface, pronunciation=pronunciation, accent_type=accent_type
+                surface=surface,
+                pronunciation=pronunciation,
+                accent_type=accent_type,
+                part_of_speech=part_of_speech,
             )
             return Response(content=word_uuid)
         except ValidationError as e:
@@ -598,7 +608,11 @@ def generate_app(
 
     @app.put("/user_dict_word/{word_uuid}", status_code=204, tags=["ユーザー辞書"])
     def rewrite_user_dict_word(
-        surface: str, pronunciation: str, accent_type: int, word_uuid: str
+        surface: str,
+        pronunciation: str,
+        accent_type: int,
+        word_uuid: str,
+        part_of_speech: Optional[str] = None,
     ):
         """
         ユーザ辞書に登録されている言葉を更新します。
@@ -613,6 +627,8 @@ def generate_app(
             アクセント型（音が下がる場所を指す）
         word_uuid: str
             更新する言葉のUUID
+        part_of_speech: str, optional
+            固有名詞、動詞、形容詞、語尾のいずれか
         """
         try:
             rewrite_word(
@@ -620,6 +636,7 @@ def generate_app(
                 pronunciation=pronunciation,
                 accent_type=accent_type,
                 word_uuid=word_uuid,
+                part_of_speech=part_of_speech,
             )
             return Response(status_code=204)
         except HTTPException:

--- a/run.py
+++ b/run.py
@@ -35,6 +35,7 @@ from voicevox_engine.model import (
     SpeakerInfo,
     SupportedDevicesInfo,
     UserDictWord,
+    WordTypes,
 )
 from voicevox_engine.morphing import synthesis_morphing
 from voicevox_engine.morphing import (
@@ -576,7 +577,7 @@ def generate_app(
         surface: str,
         pronunciation: str,
         accent_type: int,
-        word_type: Optional[str] = None,
+        word_type: Optional[WordTypes] = None,
     ):
         """
         ユーザ辞書に言葉を追加します。
@@ -612,7 +613,7 @@ def generate_app(
         pronunciation: str,
         accent_type: int,
         word_uuid: str,
-        word_type: Optional[str] = None,
+        word_type: Optional[WordTypes] = None,
     ):
         """
         ユーザ辞書に登録されている言葉を更新します。

--- a/run.py
+++ b/run.py
@@ -576,7 +576,7 @@ def generate_app(
         surface: str,
         pronunciation: str,
         accent_type: int,
-        part_of_speech: Optional[str] = None,
+        word_type: Optional[str] = None,
     ):
         """
         ユーザ辞書に言葉を追加します。
@@ -589,7 +589,7 @@ def generate_app(
             言葉の発音（カタカナ）
         accent_type: int
             アクセント型（音が下がる場所を指す）
-        part_of_speech: str, optional
+        word_type: str, optional
             固有名詞、普通名詞、動詞、形容詞、語尾のいずれか
         """
         try:
@@ -597,7 +597,7 @@ def generate_app(
                 surface=surface,
                 pronunciation=pronunciation,
                 accent_type=accent_type,
-                part_of_speech=part_of_speech,
+                word_type=word_type,
             )
             return Response(content=word_uuid)
         except ValidationError as e:
@@ -612,7 +612,7 @@ def generate_app(
         pronunciation: str,
         accent_type: int,
         word_uuid: str,
-        part_of_speech: Optional[str] = None,
+        word_type: Optional[str] = None,
     ):
         """
         ユーザ辞書に登録されている言葉を更新します。
@@ -627,7 +627,7 @@ def generate_app(
             アクセント型（音が下がる場所を指す）
         word_uuid: str
             更新する言葉のUUID
-        part_of_speech: str, optional
+        word_type: str, optional
             固有名詞、普通名詞、動詞、形容詞、語尾のいずれか
         """
         try:
@@ -636,7 +636,7 @@ def generate_app(
                 pronunciation=pronunciation,
                 accent_type=accent_type,
                 word_uuid=word_uuid,
-                part_of_speech=part_of_speech,
+                word_type=word_type,
             )
             return Response(status_code=204)
         except HTTPException:

--- a/test/test_word_types.py
+++ b/test/test_word_types.py
@@ -1,0 +1,9 @@
+from unittest import TestCase
+
+from voicevox_engine.part_of_speech_data import part_of_speech_data
+from voicevox_engine.model import WordTypes
+
+
+class TestWordTypes(TestCase):
+    def test_word_types(self):
+        self.assertCountEqual(list(WordTypes), list(part_of_speech_data.keys()))

--- a/test/test_word_types.py
+++ b/test/test_word_types.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 
-from voicevox_engine.part_of_speech_data import part_of_speech_data
 from voicevox_engine.model import WordTypes
+from voicevox_engine.part_of_speech_data import part_of_speech_data
 
 
 class TestWordTypes(TestCase):

--- a/voicevox_engine/model.py
+++ b/voicevox_engine/model.py
@@ -235,6 +235,8 @@ class PartOfSpeechDetail(BaseModel):
     part_of_speech_detail_1: str = Field(title="品詞細分類1")
     part_of_speech_detail_2: str = Field(title="品詞細分類2")
     part_of_speech_detail_3: str = Field(title="品詞細分類3")
+    # context_idは辞書の左・右文脈IDのこと
+    # https://github.com/VOICEVOX/open_jtalk/blob/427cfd761b78efb6094bea3c5bb8c968f0d711ab/src/mecab-naist-jdic/_left-id.def # noqa
     context_id: int = Field(title="文脈ID")
 
 

--- a/voicevox_engine/model.py
+++ b/voicevox_engine/model.py
@@ -151,6 +151,7 @@ class UserDictWord(BaseModel):
 
     surface: str = Field(title="表層形")
     cost: int = Field(title="コストの値")
+    context_id: int = Field(title="文脈ID", default=1348)
     part_of_speech: str = Field(title="品詞")
     part_of_speech_detail_1: str = Field(title="品詞細分類1")
     part_of_speech_detail_2: str = Field(title="品詞細分類2")
@@ -223,6 +224,18 @@ class UserDictWord(BaseModel):
                 )
             )
         return mora_count
+
+
+class PartOfSpeechDetail(BaseModel):
+    """
+    品詞ごとの情報
+    """
+
+    part_of_speech: str = Field(title="品詞")
+    part_of_speech_detail_1: str = Field(title="品詞細分類1")
+    part_of_speech_detail_2: str = Field(title="品詞細分類2")
+    part_of_speech_detail_3: str = Field(title="品詞細分類3")
+    context_id: int = Field(title="文脈ID")
 
 
 class SupportedDevicesInfo(BaseModel):

--- a/voicevox_engine/model.py
+++ b/voicevox_engine/model.py
@@ -240,6 +240,18 @@ class PartOfSpeechDetail(BaseModel):
     context_id: int = Field(title="文脈ID")
 
 
+class WordTypes(str, Enum):
+    """
+    fastapiでword_type引数を検証する時に使用するクラス
+    """
+
+    PROPER_NOUN = "固有名詞"
+    COMMON_NOUN = "普通名詞"
+    VERB = "動詞"
+    ADJECTIVE = "形容詞"
+    SUFFIX = "語尾"
+
+
 class SupportedDevicesInfo(BaseModel):
     """
     対応しているデバイスの情報

--- a/voicevox_engine/part_of_speech_data.py
+++ b/voicevox_engine/part_of_speech_data.py
@@ -1,0 +1,34 @@
+from typing import Dict
+
+from .model import PartOfSpeechDetail
+
+part_of_speech_data: Dict[str, PartOfSpeechDetail] = {
+    "固有名詞": PartOfSpeechDetail(
+        part_of_speech="名詞",
+        part_of_speech_detail_1="固有名詞",
+        part_of_speech_detail_2="一般",
+        part_of_speech_detail_3="*",
+        context_id=1348,
+    ),
+    "動詞": PartOfSpeechDetail(
+        part_of_speech="動詞",
+        part_of_speech_detail_1="自立",
+        part_of_speech_detail_2="一般",
+        part_of_speech_detail_3="*",
+        context_id=642,
+    ),
+    "形容詞": PartOfSpeechDetail(
+        part_of_speech="形容詞",
+        part_of_speech_detail_1="自立",
+        part_of_speech_detail_2="*",
+        part_of_speech_detail_3="*",
+        context_id=20,
+    ),
+    "語尾": PartOfSpeechDetail(
+        part_of_speech="名詞",
+        part_of_speech_detail_1="接尾",
+        part_of_speech_detail_2="一般",
+        part_of_speech_detail_3="*",
+        context_id=1358,
+    ),
+}

--- a/voicevox_engine/part_of_speech_data.py
+++ b/voicevox_engine/part_of_speech_data.py
@@ -10,6 +10,13 @@ part_of_speech_data: Dict[str, PartOfSpeechDetail] = {
         part_of_speech_detail_3="*",
         context_id=1348,
     ),
+    "普通名詞": PartOfSpeechDetail(
+        part_of_speech="名詞",
+        part_of_speech_detail_1="一般",
+        part_of_speech_detail_2="*",
+        part_of_speech_detail_3="*",
+        context_id=1345,
+    ),
     "動詞": PartOfSpeechDetail(
         part_of_speech="動詞",
         part_of_speech_detail_1="自立",

--- a/voicevox_engine/user_dict.py
+++ b/voicevox_engine/user_dict.py
@@ -108,13 +108,13 @@ def create_word(
     surface: str,
     pronunciation: str,
     accent_type: int,
-    part_of_speech: Optional[str] = None,
+    word_type: Optional[str] = None,
 ) -> UserDictWord:
-    if part_of_speech is None:
-        part_of_speech = "固有名詞"
-    if part_of_speech not in part_of_speech_data.keys():
+    if word_type is None:
+        word_type = "固有名詞"
+    if word_type not in part_of_speech_data.keys():
         raise HTTPException(status_code=422, detail="不明な品詞です")
-    pos_detail = part_of_speech_data[part_of_speech]
+    pos_detail = part_of_speech_data[word_type]
     return UserDictWord(
         surface=surface,
         context_id=pos_detail.context_id,
@@ -137,7 +137,7 @@ def apply_word(
     surface: str,
     pronunciation: str,
     accent_type: int,
-    part_of_speech: Optional[str] = None,
+    word_type: Optional[str] = None,
     user_dict_path: Path = user_dict_path,
     compiled_dict_path: Path = compiled_dict_path,
 ) -> str:
@@ -145,7 +145,7 @@ def apply_word(
         surface=surface,
         pronunciation=pronunciation,
         accent_type=accent_type,
-        part_of_speech=part_of_speech,
+        word_type=word_type,
     )
     user_dict = read_dict(user_dict_path=user_dict_path)
     word_uuid = str(uuid4())
@@ -160,7 +160,7 @@ def rewrite_word(
     surface: str,
     pronunciation: str,
     accent_type: int,
-    part_of_speech: Optional[str] = None,
+    word_type: Optional[str] = None,
     user_dict_path: Path = user_dict_path,
     compiled_dict_path: Path = compiled_dict_path,
 ):
@@ -168,7 +168,7 @@ def rewrite_word(
         surface=surface,
         pronunciation=pronunciation,
         accent_type=accent_type,
-        part_of_speech=part_of_speech,
+        word_type=word_type,
     )
     user_dict = read_dict(user_dict_path=user_dict_path)
     if word_uuid not in user_dict:

--- a/voicevox_engine/user_dict.py
+++ b/voicevox_engine/user_dict.py
@@ -2,7 +2,7 @@ import json
 import sys
 from pathlib import Path
 from tempfile import NamedTemporaryFile
-from typing import Dict
+from typing import Dict, Optional
 from uuid import UUID, uuid4
 
 import pyopenjtalk
@@ -10,6 +10,7 @@ from appdirs import user_data_dir
 from fastapi import HTTPException
 
 from .model import UserDictWord
+from .part_of_speech_data import part_of_speech_data
 from .utility import engine_root
 
 root_dir = engine_root()
@@ -59,8 +60,10 @@ def update_dict(
         for word_uuid in user_dict:
             word = user_dict[word_uuid]
             f.write(
-                "{},1348,1348,{},{},{},{},{},{},{},{},{},{},{}/{},{}\n".format(
+                "{},{},{},{},{},{},{},{},{},{},{},{},{},{}/{},{}\n".format(
                     word.surface,
+                    word.context_id,
+                    word.context_id,
                     word.cost,
                     word.part_of_speech,
                     word.part_of_speech_detail_1,
@@ -101,14 +104,25 @@ def read_dict(user_dict_path: Path = user_dict_path) -> Dict[str, UserDictWord]:
         }
 
 
-def create_word(surface: str, pronunciation: str, accent_type: int) -> UserDictWord:
+def create_word(
+    surface: str,
+    pronunciation: str,
+    accent_type: int,
+    part_of_speech: Optional[str] = None,
+) -> UserDictWord:
+    if part_of_speech is None:
+        part_of_speech = "固有名詞"
+    if part_of_speech not in part_of_speech_data.keys():
+        raise HTTPException(status_code=422, detail="不明な品詞です")
+    pos_detail = part_of_speech_data[part_of_speech]
     return UserDictWord(
         surface=surface,
+        context_id=pos_detail.context_id,
         cost=8600,
-        part_of_speech="名詞",
-        part_of_speech_detail_1="固有名詞",
-        part_of_speech_detail_2="一般",
-        part_of_speech_detail_3="*",
+        part_of_speech=pos_detail.part_of_speech,
+        part_of_speech_detail_1=pos_detail.part_of_speech_detail_1,
+        part_of_speech_detail_2=pos_detail.part_of_speech_detail_2,
+        part_of_speech_detail_3=pos_detail.part_of_speech_detail_3,
         inflectional_type="*",
         inflectional_form="*",
         stem="*",
@@ -123,11 +137,15 @@ def apply_word(
     surface: str,
     pronunciation: str,
     accent_type: int,
+    part_of_speech: Optional[str] = None,
     user_dict_path: Path = user_dict_path,
     compiled_dict_path: Path = compiled_dict_path,
 ) -> str:
     word = create_word(
-        surface=surface, pronunciation=pronunciation, accent_type=accent_type
+        surface=surface,
+        pronunciation=pronunciation,
+        accent_type=accent_type,
+        part_of_speech=part_of_speech,
     )
     user_dict = read_dict(user_dict_path=user_dict_path)
     word_uuid = str(uuid4())
@@ -142,11 +160,15 @@ def rewrite_word(
     surface: str,
     pronunciation: str,
     accent_type: int,
+    part_of_speech: Optional[str] = None,
     user_dict_path: Path = user_dict_path,
     compiled_dict_path: Path = compiled_dict_path,
 ):
     word = create_word(
-        surface=surface, pronunciation=pronunciation, accent_type=accent_type
+        surface=surface,
+        pronunciation=pronunciation,
+        accent_type=accent_type,
+        part_of_speech=part_of_speech,
     )
     user_dict = read_dict(user_dict_path=user_dict_path)
     if word_uuid not in user_dict:


### PR DESCRIPTION
## 内容

現在ユーザ辞書では単語が固有名詞として扱われますが、別の品詞も使えるように変更します。
- 固有名詞
- 動詞
- 形容詞
- 語尾

の四種類を利用可能にします。

## 関連 Issue

- https://github.com/VOICEVOX/voicevox_project/issues/6

## その他
`/user_dict`で返されるUserDictWordクラスの定義に変更（追加）が入っています。
デフォルト値が設定されているため既存の辞書の読み込みには問題ありません。