### PR TITLE
Hotfix: pyopenjtalkのバージョンが巻き戻っているのを修正

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -72,7 +72,7 @@ pycparser==2.20
     # via cffi
 pydantic==1.8.2
     # via fastapi
-pyopenjtalk @ git+https://github.com/VOICEVOX/pyopenjtalk@de0aafc16ec762a159c1ddfcb92488053f49191c
+pyopenjtalk @ git+https://github.com/VOICEVOX/pyopenjtalk@a85521a0a0f298f08d9e9b24987b3c77eb4aaff5
     # via -r requirements.in
 python-multipart==0.0.5
     # via -r requirements.in

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -104,7 +104,7 @@ pydantic==1.8.2
     # via fastapi
 pyflakes==2.3.1
     # via flake8
-pyopenjtalk @ git+https://github.com/VOICEVOX/pyopenjtalk@de0aafc16ec762a159c1ddfcb92488053f49191c
+pyopenjtalk @ git+https://github.com/VOICEVOX/pyopenjtalk@a85521a0a0f298f08d9e9b24987b3c77eb4aaff5
     # via -r requirements.in
 pyparsing==3.0.1
     # via packaging

--- a/requirements.in
+++ b/requirements.in
@@ -8,4 +8,4 @@ scipy
 PyYAML
 pyworld
 appdirs
-git+https://github.com/VOICEVOX/pyopenjtalk@de0aafc16ec762a159c1ddfcb92488053f49191c#egg=pyopenjtalk
+git+https://github.com/VOICEVOX/pyopenjtalk@a85521a0a0f298f08d9e9b24987b3c77eb4aaff5#egg=pyopenjtalk

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ pycparser==2.20
     # via cffi
 pydantic==1.8.2
     # via fastapi
-pyopenjtalk @ git+https://github.com/VOICEVOX/pyopenjtalk@de0aafc16ec762a159c1ddfcb92488053f49191c
+pyopenjtalk @ git+https://github.com/VOICEVOX/pyopenjtalk@a85521a0a0f298f08d9e9b24987b3c77eb4aaff5
     # via -r requirements.in
 python-multipart==0.0.5
     # via -r requirements.in


### PR DESCRIPTION
## 内容

PRのマージの順番（文中疑問符の挙動修正 #318 #319 → ユーザ辞書機能 #301 ）によって、pyopenjtalkのバージョン（OpenJTalkのバージョンを1.11に更新した変更）が巻き戻ってしまったようです。

VOICEVOX 0.11.3で #318 が再発するようになった（0.10.4では修正されていた）ため、Hotfixを作成しました。

- 現在: <https://github.com/VOICEVOX/pyopenjtalk/tree/de0aafc16ec762a159c1ddfcb92488053f49191c>
- 更新先: <https://github.com/VOICEVOX/pyopenjtalk/tree/a85521a0a0f298f08d9e9b24987b3c77eb4aaff5>

<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue

- ref #318

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
