### PR TITLE
master に push するとドキュメントを GitHub Pages にアップロードする設定の追加

### DIFF
--- a/.github/workflows/upload-gh-pages.yml
+++ b/.github/workflows/upload-gh-pages.yml
@@ -28,7 +28,7 @@ jobs:
         id: pip-cache
         with:
           path: ${{ env.PIP_CACHE_PATH }}
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt', '**/requirements-dev.txt') }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
           restore-keys: |
             ${{ runner.os }}-pip-
 

--- a/.github/workflows/upload-gh-pages.yml
+++ b/.github/workflows/upload-gh-pages.yml
@@ -1,0 +1,59 @@
+name: upload-docs
+
+on:
+  push:
+    branches:
+      - "master"
+
+env:
+  PIP_CACHE_PATH: "~/.cache/pip"
+  PYTHON_VERSION: "3.8.10"
+  PUBLISH_DIR: "./docs/api"
+  PUBLISH_BRANCH: "gh-pages"
+  PYTHON_ARCHITECTURE: "x64"
+
+jobs:
+  upload-doc:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Python
+        id: setup-python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          architecture: ${{ env.PYTHON_ARCHITECTURE }}
+
+      - name: Prepare Python dependencies cache
+        uses: actions/cache@v2
+        id: pip-cache
+        with:
+          path: ${{ env.PIP_CACHE_PATH }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt', '**/requirements-dev.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install libraries for ubuntu
+        if: ${{ runner.os }} == 'ubuntu-latest'
+        run: sudo apt-get install libsndfile1
+
+      - name: Install Python dependencies
+        shell: bash
+        run: |
+          # FIXME: Nuitka cannot build with setuptools>=60.7.0
+          # https://github.com/Nuitka/Nuitka/issues/1406
+          pip install --upgrade pip setuptools==60.6.0 wheel
+          pip install -r requirements-dev.txt
+
+      - name: Make documents
+        shell: bash
+        run: |
+          python make_docs.py
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ${{ env.PUBLISH_DIR }}
+          publish_branch: ${{ env.PUBLISH_BRANCH }}

--- a/.github/workflows/upload-gh-pages.yml
+++ b/.github/workflows/upload-gh-pages.yml
@@ -10,7 +10,6 @@ env:
   PYTHON_VERSION: "3.8.10"
   PUBLISH_DIR: "./docs/api"
   PUBLISH_BRANCH: "gh-pages"
-  PYTHON_ARCHITECTURE: "x64"
 
 jobs:
   upload-doc:
@@ -23,7 +22,6 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-          architecture: ${{ env.PYTHON_ARCHITECTURE }}
 
       - name: Prepare Python dependencies cache
         uses: actions/cache@v2
@@ -35,16 +33,12 @@ jobs:
             ${{ runner.os }}-pip-
 
       - name: Install libraries for ubuntu
-        if: ${{ runner.os }} == 'ubuntu-latest'
         run: sudo apt-get install libsndfile1
 
       - name: Install Python dependencies
         shell: bash
         run: |
-          # FIXME: Nuitka cannot build with setuptools>=60.7.0
-          # https://github.com/Nuitka/Nuitka/issues/1406
-          pip install --upgrade pip setuptools==60.6.0 wheel
-          pip install -r requirements-dev.txt
+          pip install -r requirements.txt
 
       - name: Make documents
         shell: bash


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->

master に push すると自動で APIドキュメント を生成し，gh-pages ブランチにドキュメントを追加，更新する CI を書いた．



## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

close #304 

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

- fork先の master で実行された CI
https://github.com/Issei0804-ie/voicevox_engine/runs/5522731209?check_suite_focus=true

- Pages のリンク
https://issei0804-ie.github.io/voicevox_engine/


## その他

APIドキュメントを追加するブランチが存在しない場合，
勝手に空ブランチを新しく作るため，merge を行う前に特別な作業は必要ありません．

しかし，merge を行った後は Pages の設定が必要なため，下記の画像を参考に設定をお願いします．

(Settings => Code and automation/Pages から設定可能です)

![image](https://user-images.githubusercontent.com/52270000/158042114-5b9f25b0-3383-499e-a044-af93566d5b83.png)
