### PR TITLE
一時的に変更していたAPIドキュメントのリンクを再修正

### DIFF
--- a/.github/workflows/upload-gh-pages.yml
+++ b/.github/workflows/upload-gh-pages.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - "master"
-      - "modify-api-doc-link"
 
 env:
   PIP_CACHE_PATH: "~/.cache/pip"

--- a/.github/workflows/upload-gh-pages.yml
+++ b/.github/workflows/upload-gh-pages.yml
@@ -4,12 +4,14 @@ on:
   push:
     branches:
       - "master"
+      - "modify-api-doc-link"
 
 env:
   PIP_CACHE_PATH: "~/.cache/pip"
   PYTHON_VERSION: "3.8.10"
   PUBLISH_DIR: "./docs/api"
   PUBLISH_BRANCH: "gh-pages"
+  DESTINATION_DIR: "API"
 
 jobs:
   upload-doc:
@@ -51,3 +53,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ${{ env.PUBLISH_DIR }}
           publish_branch: ${{ env.PUBLISH_BRANCH }}
+          destination_dir: ${{ env.DESTINATION_DIR }}

--- a/.github/workflows/upload-gh-pages.yml
+++ b/.github/workflows/upload-gh-pages.yml
@@ -11,7 +11,7 @@ env:
   PYTHON_VERSION: "3.8.10"
   PUBLISH_DIR: "./docs/api"
   PUBLISH_BRANCH: "gh-pages"
-  DESTINATION_DIR: "API"
+  DESTINATION_DIR: "api"
 
 jobs:
   upload-doc:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 ## API ドキュメント
 
-[API ドキュメント](https://voicevox.github.io/voicevox_engine/)をご参照ください。
+[API ドキュメント](https://voicevox.github.io/voicevox_engine/api/)をご参照ください。
 
 VOICEVOX エンジンもしくはエディタを起動した状態で http://localhost:50021/docs にアクセスすると、起動中のエンジンのドキュメントも確認できます。  
 今後の方針などについては [VOICEVOX 音声合成エンジンとの連携](./docs/VOICEVOX音声合成エンジンとの連携.md) も参考になるかもしれません。
@@ -412,7 +412,7 @@ pysen run format lint
 
 ## API ドキュメントの更新
 
-[API ドキュメント](https://voicevox.github.io/voicevox_engine/)（実体は`docs/api/index.html`）の内容を更新します。
+[API ドキュメント](https://voicevox.github.io/voicevox_engine/api/)（実体は`docs/api/index.html`）の内容を更新します。
 
 ```bash
 python make_docs.py


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->

#304, #364 で API ドキュメントのリンクが予期せず変更されてしまったため，
README.md に掲載されているリンクを一時的に修正していた(#369)．

この issue では正しいリンク先からAPI ドキュメントを閲覧できるように CI の設定を書き直し，
一時的に修正していた README.md をもとに戻した．


- 一時的なリンク: https://voicevox.github.io/voicevox_engine/ 
- 正しいリンク: 　https://voicevox.github.io/voicevox_engine/api/



## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

close #368 


## その他

fork先で生成したAPIドキュメントのリンク(正しいリンク)
- https://issei0804-ie.github.io/voicevox_engine/api/

また，現在 gh-pages にある index.html, .nojekyll は削除していただきたいです．
新しくAPI ドキュメントが生成され，リンクも変更されたタイミングで削除していただきたいため，
merge後に削除をお願いします!!