### PR TITLE
エンジン情報に関するmodelを追加

### DIFF
--- a/voicevox_engine/model.py
+++ b/voicevox_engine/model.py
@@ -261,3 +261,52 @@ class SupportedDevicesInfo(BaseModel):
     cpu: bool = Field(title="CPUに対応しているか")
     cuda: bool = Field(title="CUDA(Nvidia GPU)に対応しているか")
     dml: bool = Field(title="DirectML(Nvidia GPU/Radeon GPU等)に対応しているか")
+
+
+class SupportedFunctionsInfo(BaseModel):
+    """
+    エンジンの機能の情報
+    """
+
+    support_adjust_mora: bool = Field(title="モーラが調整可能かどうか")
+    support_adjust_speed_scale: bool = Field(title="話速が調整可能かどうか")
+    support_adjust_pitch_scale: bool = Field(title="音高が調整可能かどうか")
+    support_adjust_intonation_scale: bool = Field(title="抑揚が調整可能かどうか")
+    support_adjust_volume_scale: bool = Field(title="音量が調整可能かどうか")
+    support_adjust_silence_scale: bool = Field(title="前後の無音時間が調節可能かどうか")
+    support_interrogative_upspeak: bool = Field(title="疑似疑問文に対応しているかどうか")
+    support_switch_device: bool = Field(title="CPU/GPUの切り替えが可能かどうか")
+
+
+class UpdateInfo(BaseModel):
+    """
+    エンジンのアップデート情報
+    """
+
+    version: str = Field(title="エンジンのバージョン名")
+    descriptions: List[str] = Field(title="アップデートの詳細についての説明")
+    contributors: List[str] = Field(title="貢献者名")
+
+
+class LicenseInfo(BaseModel):
+    """
+    依存ライブラリのライセンス情報
+    """
+
+    name: str = Field(title="依存ライブラリ名")
+    version: Optional[str] = Field(title="依存ライブラリのバージョン")
+    license: Optional[str] = Field(title="依存ライブラリのライセンス名")
+    text: str = Field(title="依存ライブラリのライセンス本文")
+
+
+class EngineInfo(BaseModel):
+    """
+    エンジン自体に関する情報
+    """
+
+    name: str = Field(title="エンジン名")
+    icon: str = Field(title="エンジンのアイコンをBASE64エンコードしたもの")
+    default_sampling_rate: int = Field(title="デフォルトのサンプリング周波数")
+    engine_tos: str = Field(title="エンジンの利用規約")
+    update_info: List[UpdateInfo] = Field(title="エンジンのアップデート情報")
+    dependencies_license: List[LicenseInfo] = Field(title="依存関係のライセンス情報")

--- a/voicevox_engine/model.py
+++ b/voicevox_engine/model.py
@@ -263,7 +263,7 @@ class SupportedDevicesInfo(BaseModel):
     dml: bool = Field(title="DirectML(Nvidia GPU/Radeon GPU等)に対応しているか")
 
 
-class SupportedFunctionsInfo(BaseModel):
+class SupportedFeaturesInfo(BaseModel):
     """
     エンジンの機能の情報
     """

--- a/voicevox_engine/model.py
+++ b/voicevox_engine/model.py
@@ -268,14 +268,14 @@ class SupportedFunctionsInfo(BaseModel):
     エンジンの機能の情報
     """
 
-    support_adjust_mora: bool = Field(title="モーラが調整可能かどうか")
-    support_adjust_speed_scale: bool = Field(title="話速が調整可能かどうか")
-    support_adjust_pitch_scale: bool = Field(title="音高が調整可能かどうか")
-    support_adjust_intonation_scale: bool = Field(title="抑揚が調整可能かどうか")
-    support_adjust_volume_scale: bool = Field(title="音量が調整可能かどうか")
-    support_adjust_silence_scale: bool = Field(title="前後の無音時間が調節可能かどうか")
+    support_adjusting_mora: bool = Field(title="モーラが調整可能かどうか")
+    support_adjusting_speed_scale: bool = Field(title="話速が調整可能かどうか")
+    support_adjusting_pitch_scale: bool = Field(title="音高が調整可能かどうか")
+    support_adjusting_intonation_scale: bool = Field(title="抑揚が調整可能かどうか")
+    support_adjusting_volume_scale: bool = Field(title="音量が調整可能かどうか")
+    support_adjusting_silence_scale: bool = Field(title="前後の無音時間が調節可能かどうか")
     support_interrogative_upspeak: bool = Field(title="疑似疑問文に対応しているかどうか")
-    support_switch_device: bool = Field(title="CPU/GPUの切り替えが可能かどうか")
+    support_switching_device: bool = Field(title="CPU/GPUの切り替えが可能かどうか")
 
 
 class UpdateInfo(BaseModel):

--- a/voicevox_engine/model.py
+++ b/voicevox_engine/model.py
@@ -307,6 +307,6 @@ class EngineInfo(BaseModel):
     name: str = Field(title="エンジン名")
     icon: str = Field(title="エンジンのアイコンをBASE64エンコードしたもの")
     default_sampling_rate: int = Field(title="デフォルトのサンプリング周波数")
-    engine_tos: str = Field(title="エンジンの利用規約")
+    term_of_service: str = Field(title="エンジンの利用規約")
     update_info: List[UpdateInfo] = Field(title="エンジンのアップデート情報")
     dependencies_license: List[LicenseInfo] = Field(title="依存関係のライセンス情報")

--- a/voicevox_engine/model.py
+++ b/voicevox_engine/model.py
@@ -308,5 +308,5 @@ class EngineInfo(BaseModel):
     icon: str = Field(title="エンジンのアイコンをBASE64エンコードしたもの")
     default_sampling_rate: int = Field(title="デフォルトのサンプリング周波数")
     term_of_service: str = Field(title="エンジンの利用規約")
-    update_info: List[UpdateInfo] = Field(title="エンジンのアップデート情報")
-    dependencies_license: List[LicenseInfo] = Field(title="依存関係のライセンス情報")
+    update_infos: List[UpdateInfo] = Field(title="エンジンのアップデート情報")
+    dependency_licenses: List[LicenseInfo] = Field(title="依存関係のライセンス情報")

--- a/voicevox_engine/model.py
+++ b/voicevox_engine/model.py
@@ -308,6 +308,6 @@ class EngineManifest(BaseModel):
     name: str = Field(title="エンジン名")
     icon: str = Field(title="エンジンのアイコンをBASE64エンコードしたもの")
     default_sampling_rate: int = Field(title="デフォルトのサンプリング周波数")
-    term_of_service: str = Field(title="エンジンの利用規約")
+    terms_of_service: str = Field(title="エンジンの利用規約")
     update_infos: List[UpdateInfo] = Field(title="エンジンのアップデート情報")
     dependency_licenses: List[LicenseInfo] = Field(title="依存関係のライセンス情報")

--- a/voicevox_engine/model.py
+++ b/voicevox_engine/model.py
@@ -304,7 +304,7 @@ class EngineManifest(BaseModel):
     エンジン自体に関する情報
     """
 
-    manifest_version: int = Field(title="マニフェストのバージョン")
+    manifest_version: str = Field(title="マニフェストのバージョン")
     name: str = Field(title="エンジン名")
     icon: str = Field(title="エンジンのアイコンをBASE64エンコードしたもの")
     default_sampling_rate: int = Field(title="デフォルトのサンプリング周波数")

--- a/voicevox_engine/model.py
+++ b/voicevox_engine/model.py
@@ -304,6 +304,7 @@ class EngineManifest(BaseModel):
     エンジン自体に関する情報
     """
 
+    manifest_version: int = Field(title="マニフェストのバージョン")
     name: str = Field(title="エンジン名")
     icon: str = Field(title="エンジンのアイコンをBASE64エンコードしたもの")
     default_sampling_rate: int = Field(title="デフォルトのサンプリング周波数")

--- a/voicevox_engine/model.py
+++ b/voicevox_engine/model.py
@@ -299,7 +299,7 @@ class LicenseInfo(BaseModel):
     text: str = Field(title="依存ライブラリのライセンス本文")
 
 
-class EngineInfo(BaseModel):
+class EngineManifest(BaseModel):
     """
     エンジン自体に関する情報
     """

--- a/voicevox_engine/model.py
+++ b/voicevox_engine/model.py
@@ -285,7 +285,7 @@ class UpdateInfo(BaseModel):
 
     version: str = Field(title="エンジンのバージョン名")
     descriptions: List[str] = Field(title="アップデートの詳細についての説明")
-    contributors: List[str] = Field(title="貢献者名")
+    contributors: Optional[List[str]] = Field(title="貢献者名")
 
 
 class LicenseInfo(BaseModel):


### PR DESCRIPTION
## 内容

題の通りです。
実際に情報を返す部分まで実装するとPRが大きくなるため、modelのみのPRとしています。
もっと良さそうな命名や追加した方が良い情報があればコメント等お願いします。

`GET /engine_info`、`GET /supported_functions_info`で情報を取得できるようにしようと考えています。

## 関連 Issue

- https://github.com/VOICEVOX/voicevox_engine/issues/362
- https://github.com/VOICEVOX/voicevox_project/issues/2