### PR TITLE
dockerhubのURLをHiroshibaからvoicevoxに移動

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ endif
 .PHONY: build-linux-docker-ubuntu20.04
 build-linux-docker-ubuntu20.04:
 	docker buildx build . \
-		-t hiroshiba/voicevox_engine:cpu-ubuntu20.04-latest \
+		-t voicevox/voicevox_engine:cpu-ubuntu20.04-latest \
 		--target runtime-env \
 		--progress plain \
 		--build-arg BASE_IMAGE=ubuntu:focal \
@@ -22,12 +22,12 @@ build-linux-docker-ubuntu20.04:
 run-linux-docker-ubuntu20.04:
 	docker run --rm -it \
 		-p '127.0.0.1:50021:50021' $(ARGS) \
-		hiroshiba/voicevox_engine:cpu-ubuntu20.04-latest $(CMD)
+		voicevox/voicevox_engine:cpu-ubuntu20.04-latest $(CMD)
 
 .PHONY: build-linux-docker-nvidia-ubuntu20.04
 build-linux-docker-nvidia-ubuntu20.04:
 	docker buildx build . \
-		-t hiroshiba/voicevox_engine:nvidia-ubuntu20.04-latest \
+		-t voicevox/voicevox_engine:nvidia-ubuntu20.04-latest \
 		--target runtime-nvidia-env \
 		--progress plain \
 		--build-arg BASE_IMAGE=ubuntu:focal \
@@ -40,14 +40,14 @@ run-linux-docker-nvidia-ubuntu20.04:
 	docker run --rm -it \
 		--gpus all \
 		-p '127.0.0.1:50021:50021' $(ARGS) \
-		hiroshiba/voicevox_engine:nvidia-ubuntu20.04-latest $(CMD)
+		voicevox/voicevox_engine:nvidia-ubuntu20.04-latest $(CMD)
 
 
 # Ubuntu 18.04
 .PHONY: build-linux-docker-ubuntu18.04
 build-linux-docker-ubuntu18.04:
 	docker buildx build . \
-		-t hiroshiba/voicevox_engine:cpu-ubuntu18.04-latest \
+		-t voicevox/voicevox_engine:cpu-ubuntu18.04-latest \
 		--target runtime-env \
 		--progress plain \
 		--build-arg BASE_IMAGE=ubuntu:bionic \
@@ -59,12 +59,12 @@ build-linux-docker-ubuntu18.04:
 run-linux-docker-ubuntu18.04:
 	docker run --rm -it \
 		-p '127.0.0.1:50021:50021' $(ARGS) \
-		hiroshiba/voicevox_engine:cpu-ubuntu18.04-latest $(CMD)
+		voicevox/voicevox_engine:cpu-ubuntu18.04-latest $(CMD)
 
 .PHONY: build-linux-docker-nvidia-ubuntu18.04
 build-linux-docker-nvidia-ubuntu18.04:
 	docker buildx build . \
-		-t hiroshiba/voicevox_engine:nvidia-ubuntu18.04-latest \
+		-t voicevox/voicevox_engine:nvidia-ubuntu18.04-latest \
 		--target runtime-nvidia-env \
 		--progress plain \
 		--build-arg BASE_IMAGE=ubuntu:bionic \
@@ -77,14 +77,14 @@ run-linux-docker-nvidia-ubuntu18.04:
 	docker run --rm -it \
 		--gpus all \
 		-p '127.0.0.1:50021:50021' $(ARGS) \
-		hiroshiba/voicevox_engine:nvidia-ubuntu18.04-latest $(CMD)
+		voicevox/voicevox_engine:nvidia-ubuntu18.04-latest $(CMD)
 
 
 # VOICEVOX Core env for test
 .PHONY: build-linux-docker-download-core-env-ubuntu18.04
 build-linux-docker-download-core-env-ubuntu18.04:
 	docker buildx build . \
-		-t hiroshiba/voicevox_engine:download-core-env-ubuntu18.04 \
+		-t voicevox/voicevox_engine:download-core-env-ubuntu18.04 \
 		--target download-core-env \
 		--progress plain \
 		--build-arg BASE_IMAGE=ubuntu:bionic $(ARGS)
@@ -92,13 +92,13 @@ build-linux-docker-download-core-env-ubuntu18.04:
 .PHONY: run-linux-docker-download-core-env-ubuntu18.04
 run-linux-docker-download-core-env-ubuntu18.04:
 	docker run --rm -it $(ARGS) \
-		hiroshiba/voicevox_engine:download-core-env-ubuntu18.04 $(CMD)
+		voicevox/voicevox_engine:download-core-env-ubuntu18.04 $(CMD)
 
 # ONNX Runtime env for test
 .PHONY: build-linux-docker-download-onnxruntime-env-ubuntu18.04
 build-linux-docker-download-onnxruntime-env-ubuntu18.04:
 	docker buildx build . \
-		-t hiroshiba/voicevox_engine:download-onnxruntime-env-ubuntu18.04 \
+		-t voicevox/voicevox_engine:download-onnxruntime-env-ubuntu18.04 \
 		--target download-onnxruntime-env \
 		--progress plain \
 		--build-arg BASE_IMAGE=ubuntu:bionic $(ARGS)
@@ -106,14 +106,14 @@ build-linux-docker-download-onnxruntime-env-ubuntu18.04:
 .PHONY: run-linux-docker-download-onnxruntime-env-ubuntu18.04
 run-linux-docker-download-onnxruntime-env-ubuntu18.04:
 	docker run --rm -it $(ARGS) \
-		hiroshiba/voicevox_engine:download-onnxruntime-env-ubuntu18.04 $(CMD)
+		voicevox/voicevox_engine:download-onnxruntime-env-ubuntu18.04 $(CMD)
 
 
 # Python env for test
 .PHONY: build-linux-docker-compile-python-env
 build-linux-docker-compile-python-env:
 	docker buildx build . \
-		-t hiroshiba/voicevox_engine:compile-python-env \
+		-t voicevox/voicevox_engine:compile-python-env \
 		--target compile-python-env \
 		--progress plain \
 		--build-arg BASE_IMAGE=ubuntu:focal $(ARGS)
@@ -121,7 +121,7 @@ build-linux-docker-compile-python-env:
 .PHONY: run-linux-docker-compile-python-env
 run-linux-docker-compile-python-env:
 	docker run --rm -it $(ARGS) \
-		hiroshiba/voicevox_engine:compile-python-env $(CMD)
+		voicevox/voicevox_engine:compile-python-env $(CMD)
 
 
 # Build linux binary in Docker
@@ -129,7 +129,7 @@ run-linux-docker-compile-python-env:
 .PHONY: build-linux-docker-build-ubuntu20.04
 build-linux-docker-build-ubuntu20.04:
 	docker buildx build . \
-		-t hiroshiba/voicevox_engine:build-cpu-ubuntu20.04-latest \
+		-t voicevox/voicevox_engine:build-cpu-ubuntu20.04-latest \
 		--target build-env \
 		--progress plain \
 		--build-arg BASE_IMAGE=ubuntu:focal \
@@ -142,12 +142,12 @@ run-linux-docker-build-ubuntu20.04:
 	docker run --rm -it \
 		-v "$(shell pwd)/cache/Nuitka:/home/user/.cache/Nuitka" \
 		-v "$(shell pwd)/build:/opt/voicevox_engine_build" $(ARGS) \
-		hiroshiba/voicevox_engine:build-cpu-ubuntu20.04-latest $(CMD)
+		voicevox/voicevox_engine:build-cpu-ubuntu20.04-latest $(CMD)
 
 .PHONY: build-linux-docker-build-nvidia-ubuntu20.04
 build-linux-docker-build-nvidia-ubuntu20.04:
 	docker buildx build . \
-		-t hiroshiba/voicevox_engine:build-nvidia-ubuntu20.04-latest \
+		-t voicevox/voicevox_engine:build-nvidia-ubuntu20.04-latest \
 		--target build-env \
 		--progress plain \
 		--build-arg BASE_IMAGE=ubuntu:focal \
@@ -160,13 +160,13 @@ run-linux-docker-build-nvidia-ubuntu20.04:
 	docker run --rm -it \
 		-v "$(shell pwd)/cache/Nuitka:/home/user/.cache/Nuitka" \
 		-v "$(shell pwd)/build:/opt/voicevox_engine_build" $(ARGS) \
-		hiroshiba/voicevox_engine:build-nvidia-ubuntu20.04-latest $(CMD)
+		voicevox/voicevox_engine:build-nvidia-ubuntu20.04-latest $(CMD)
 
 ## Ubuntu 18.04
 .PHONY: build-linux-docker-build-ubuntu18.04
 build-linux-docker-build-ubuntu18.04:
 	docker buildx build . \
-		-t hiroshiba/voicevox_engine:build-cpu-ubuntu18.04-latest \
+		-t voicevox/voicevox_engine:build-cpu-ubuntu18.04-latest \
 		--target build-env \
 		--progress plain \
 		--build-arg BASE_IMAGE=ubuntu:bionic \
@@ -179,12 +179,12 @@ run-linux-docker-build-ubuntu18.04:
 	docker run --rm -it \
 		-v "$(shell pwd)/cache/Nuitka:/home/user/.cache/Nuitka" \
 		-v "$(shell pwd)/build:/opt/voicevox_engine_build" $(ARGS) \
-		hiroshiba/voicevox_engine:build-cpu-ubuntu18.04-latest $(CMD)
+		voicevox/voicevox_engine:build-cpu-ubuntu18.04-latest $(CMD)
 
 .PHONY: build-linux-docker-build-nvidia-ubuntu18.04
 build-linux-docker-build-nvidia-ubuntu18.04:
 	docker buildx build . \
-		-t hiroshiba/voicevox_engine:build-nvidia-ubuntu18.04-latest \
+		-t voicevox/voicevox_engine:build-nvidia-ubuntu18.04-latest \
 		--target build-env \
 		--progress plain \
 		--build-arg BASE_IMAGE=ubuntu:bionic \
@@ -197,4 +197,4 @@ run-linux-docker-build-nvidia-ubuntu18.04:
 	docker run --rm -it \
 		-v "$(shell pwd)/cache/Nuitka:/home/user/.cache/Nuitka" \
 		-v "$(shell pwd)/build:/opt/voicevox_engine_build" $(ARGS) \
-		hiroshiba/voicevox_engine:build-nvidia-ubuntu18.04-latest $(CMD)
+		voicevox/voicevox_engine:build-nvidia-ubuntu18.04-latest $(CMD)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/VOICEVOX/voicevox_engine/badge.svg)](https://coveralls.io/github/VOICEVOX/voicevox_engine)
 
 [![build-docker](https://github.com/VOICEVOX/voicevox_engine/actions/workflows/build-docker.yml/badge.svg)](https://github.com/VOICEVOX/voicevox_engine/actions/workflows/build-docker.yml)
-[![docker](https://img.shields.io/docker/pulls/hiroshiba/voicevox_engine)](https://hub.docker.com/r/hiroshiba/voicevox_engine)
+[![docker](https://img.shields.io/docker/pulls/voicevox/voicevox_engine)](https://hub.docker.com/r/voicevox/voicevox_engine)
 
 [VOICEVOX](https://voicevox.hiroshiba.jp/) のエンジンです。  
 実態は HTTP サーバーなので、リクエストを送信すればテキスト音声合成できます。
@@ -299,15 +299,15 @@ curl -s -X GET "localhost:50021/speaker_info?speaker_uuid=7ffcb7ce-00ec-4bdc-82c
 ### CPU
 
 ```bash
-docker pull hiroshiba/voicevox_engine:cpu-ubuntu20.04-latest
-docker run --rm -it -p '127.0.0.1:50021:50021' hiroshiba/voicevox_engine:cpu-ubuntu20.04-latest
+docker pull voicevox/voicevox_engine:cpu-ubuntu20.04-latest
+docker run --rm -it -p '127.0.0.1:50021:50021' voicevox/voicevox_engine:cpu-ubuntu20.04-latest
 ```
 
 ### GPU
 
 ```bash
-docker pull hiroshiba/voicevox_engine:nvidia-ubuntu20.04-latest
-docker run --rm --gpus all -p '127.0.0.1:50021:50021' hiroshiba/voicevox_engine:nvidia-ubuntu20.04-latest
+docker pull voicevox/voicevox_engine:nvidia-ubuntu20.04-latest
+docker run --rm --gpus all -p '127.0.0.1:50021:50021' voicevox/voicevox_engine:nvidia-ubuntu20.04-latest
 ```
 
 ## 貢献者の方へ


### PR DESCRIPTION
## 内容

dockerhubのURLをHiroshibaからvoicevoxに移動します。

- https://github.com/VOICEVOX/voicevox_engine/issues/361

## 関連 Issue

close #361 

## その他

hiroshiba/voicevox　を　voicevox/voicevox　にリプレイスしました。
ついでにdockerhubの説明も変えておきたいと思います。
