### PR TITLE
ユーザー辞書機能：辞書インポート時の検証を厳密化

### DIFF
--- a/test/test_user_dict.py
+++ b/test/test_user_dict.py
@@ -1,4 +1,5 @@
 import json
+from copy import deepcopy
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Dict
@@ -274,4 +275,39 @@ class TestUserDict(TestCase):
         self.assertEqual(
             read_dict(user_dict_path)["aab7dda2-0d97-43c8-8cb7-3f440dab9b4e"],
             import_word,
+        )
+
+    def test_import_invalid_word(self):
+        user_dict_path = self.tmp_dir_path / "test_import_invalid_dict.json"
+        compiled_dict_path = self.tmp_dir_path / "test_import_invalid_dict.dic"
+        invalid_accent_associative_rule_word = deepcopy(import_word)
+        invalid_accent_associative_rule_word.accent_associative_rule = "invalid"
+        user_dict_path.write_text(
+            json.dumps(valid_dict_dict, ensure_ascii=False), encoding="utf-8"
+        )
+        self.assertRaises(
+            AssertionError,
+            import_user_dict,
+            {
+                "aab7dda2-0d97-43c8-8cb7-3f440dab9b4e": invalid_accent_associative_rule_word
+            },
+            override=True,
+            user_dict_path=user_dict_path,
+            compiled_dict_path=compiled_dict_path,
+        )
+        invalid_pos_word = deepcopy(import_word)
+        invalid_pos_word.context_id = 2
+        invalid_pos_word.part_of_speech = "フィラー"
+        invalid_pos_word.part_of_speech_detail_1 = "*"
+        invalid_pos_word.part_of_speech_detail_2 = "*"
+        invalid_pos_word.part_of_speech_detail_3 = "*"
+        self.assertRaises(
+            ValueError,
+            import_user_dict,
+            {
+                "aab7dda2-0d97-43c8-8cb7-3f440dab9b4e": invalid_pos_word
+            },
+            override=True,
+            user_dict_path=user_dict_path,
+            compiled_dict_path=compiled_dict_path,
         )

--- a/test/test_user_dict.py
+++ b/test/test_user_dict.py
@@ -304,9 +304,7 @@ class TestUserDict(TestCase):
         self.assertRaises(
             ValueError,
             import_user_dict,
-            {
-                "aab7dda2-0d97-43c8-8cb7-3f440dab9b4e": invalid_pos_word
-            },
+            {"aab7dda2-0d97-43c8-8cb7-3f440dab9b4e": invalid_pos_word},
             override=True,
             user_dict_path=user_dict_path,
             compiled_dict_path=compiled_dict_path,

--- a/voicevox_engine/model.py
+++ b/voicevox_engine/model.py
@@ -239,6 +239,7 @@ class PartOfSpeechDetail(BaseModel):
     # https://github.com/VOICEVOX/open_jtalk/blob/427cfd761b78efb6094bea3c5bb8c968f0d711ab/src/mecab-naist-jdic/_left-id.def # noqa
     context_id: int = Field(title="文脈ID")
     cost_candidates: List[int] = Field(title="コストのパーセンタイル")
+    accent_associative_rules: List[str] = Field(title="アクセント結合規則の一覧")
 
 
 class WordTypes(str, Enum):

--- a/voicevox_engine/part_of_speech_data.py
+++ b/voicevox_engine/part_of_speech_data.py
@@ -25,6 +25,14 @@ part_of_speech_data: Dict[str, PartOfSpeechDetail] = {
             9110,
             14176,
         ],
+        accent_associative_rules=[
+            "*",
+            "C1",
+            "C2",
+            "C3",
+            "C4",
+            "C5",
+        ],
     ),
     "普通名詞": PartOfSpeechDetail(
         part_of_speech="名詞",
@@ -44,6 +52,14 @@ part_of_speech_data: Dict[str, PartOfSpeechDetail] = {
             8170,
             8979,
             15001,
+        ],
+        accent_associative_rules=[
+            "*",
+            "C1",
+            "C2",
+            "C3",
+            "C4",
+            "C5",
         ],
     ),
     "動詞": PartOfSpeechDetail(
@@ -65,6 +81,9 @@ part_of_speech_data: Dict[str, PartOfSpeechDetail] = {
             8771,
             13433,
         ],
+        accent_associative_rules=[
+            "*",
+        ],
     ),
     "形容詞": PartOfSpeechDetail(
         part_of_speech="形容詞",
@@ -85,6 +104,9 @@ part_of_speech_data: Dict[str, PartOfSpeechDetail] = {
             7250,
             10001,
         ],
+        accent_associative_rules=[
+            "*",
+        ],
     ),
     "語尾": PartOfSpeechDetail(
         part_of_speech="名詞",
@@ -104,6 +126,14 @@ part_of_speech_data: Dict[str, PartOfSpeechDetail] = {
             12228,
             13622,
             15847,
+        ],
+        accent_associative_rules=[
+            "*",
+            "C1",
+            "C2",
+            "C3",
+            "C4",
+            "C5",
         ],
     ),
 }

--- a/voicevox_engine/user_dict.py
+++ b/voicevox_engine/user_dict.py
@@ -216,6 +216,14 @@ def import_user_dict(
     for word_uuid, word in dict_data.items():
         UUID(word_uuid)
         assert type(word) == UserDictWord
+        for pos_detail in part_of_speech_data.values():
+            if pos_detail.context_id == word.context_id:
+                assert (
+                    word.accent_associative_rule in pos_detail.accent_associative_rules
+                )
+                break
+        else:
+            raise ValueError("対応していない品詞です")
     old_dict = read_dict(user_dict_path=user_dict_path)
     if override:
         new_dict = {**old_dict, **dict_data}

--- a/voicevox_engine/user_dict.py
+++ b/voicevox_engine/user_dict.py
@@ -217,7 +217,7 @@ def import_user_dict(
         UUID(word_uuid)
         assert type(word) == UserDictWord
         for pos_detail in part_of_speech_data.values():
-            if pos_detail.context_id == word.context_id:
+            if word.context_id == pos_detail.context_id:
                 assert word.part_of_speech == pos_detail.part_of_speech
                 assert (
                     word.part_of_speech_detail_1 == pos_detail.part_of_speech_detail_1

--- a/voicevox_engine/user_dict.py
+++ b/voicevox_engine/user_dict.py
@@ -218,6 +218,16 @@ def import_user_dict(
         assert type(word) == UserDictWord
         for pos_detail in part_of_speech_data.values():
             if pos_detail.context_id == word.context_id:
+                assert word.part_of_speech == pos_detail.part_of_speech
+                assert (
+                    word.part_of_speech_detail_1 == pos_detail.part_of_speech_detail_1
+                )
+                assert (
+                    word.part_of_speech_detail_2 == pos_detail.part_of_speech_detail_2
+                )
+                assert (
+                    word.part_of_speech_detail_3 == pos_detail.part_of_speech_detail_3
+                )
                 assert (
                     word.accent_associative_rule in pos_detail.accent_associative_rules
                 )


### PR DESCRIPTION
## 内容

題の通りです。
`part_of_speech_data.py`に含まれている品詞かどうかをチェックします。
また、有効なアクセント結合規則であるかをチェックします。

## 関連 Issue
- https://github.com/VOICEVOX/voicevox_project/issues/6

## その他
本来は、`model.py`の中でチェックしたいのですが、`part_of_speech_data.py`と`model.py`で循環インポートになってしまいます。
いい感じに解決したかったのですが、思いつかなかったので取り合えず辞書のインポート時にチェックするようにしました。

アクセント結合規則についてはunidicのマニュアルを参照しました。
https://ccd.ninjal.ac.jp/unidic/UNIDIC_manual.pdf