### PR TITLE
ユーザー辞書機能：コストの値を制限する

### DIFF
--- a/voicevox_engine/model.py
+++ b/voicevox_engine/model.py
@@ -2,7 +2,7 @@ from enum import Enum
 from re import findall, fullmatch
 from typing import Dict, List, Optional
 
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, Field, conint, validator
 
 
 class Mora(BaseModel):
@@ -150,7 +150,7 @@ class UserDictWord(BaseModel):
     """
 
     surface: str = Field(title="表層形")
-    cost: int = Field(title="コストの値")
+    cost: conint(ge=-32768, le=32767) = Field(title="コストの値")
     context_id: int = Field(title="文脈ID", default=1348)
     part_of_speech: str = Field(title="品詞")
     part_of_speech_detail_1: str = Field(title="品詞細分類1")


### PR DESCRIPTION
## 内容
mecabの辞書の制限で、コストはshort intの範囲に収める必要があるようです。
https://taku910.github.io/mecab/dic-detail.html
範囲外の値でも一応動作はしましたが、予期せぬエラーが発生することも考えられるため、範囲外の値を制限します。

## 関連 Issue

- https://github.com/VOICEVOX/voicevox_project/issues/6