### PR TITLE
M1 Macで起動できない問題の修正(arm64 archの挙動修正)

### DIFF
--- a/voicevox_engine/synthesis_engine/core_wrapper.py
+++ b/voicevox_engine/synthesis_engine/core_wrapper.py
@@ -203,6 +203,8 @@ def get_arch_name() -> Optional[str]:
         return "x64"
     elif machine == "i386" or machine == "x86":
         return "x86"
+    elif machine == "arm64":
+        return "aarch64"
     elif machine in ["armv7l", "aarch64"]:
         return machine
     else:


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->
題の通り
`platform.machine()`の返り値として`arm64`が返ってくるため、`コアが見つかりません`といったエラーに遭遇することがあったので、それに対して修正です。
他のOSでも、`arm64`表記が返ってくる可能性があったため、既存実装の`aarch64`を活用できるような変更を加えることにしました。
