### PR TITLE
cudnnの要らないファイルを除外

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -744,7 +744,8 @@ jobs:
 
             # cuDNN
             ln -sf "$(pwd)/download/cudnn/bin"/cudnn64_*.dll artifact/
-            ln -sf "$(pwd)/download/cudnn/bin"/cudnn_*_infer64*.dll artifact/
+            ln -sf "$(pwd)/download/cudnn/bin"/cudnn_cnn_infer64*.dll artifact/
+            ln -sf "$(pwd)/download/cudnn/bin"/cudnn_ops_infer64*.dll artifact/
           fi
 
           if [[ ${{ matrix.artifact_name }} == *-directml ]]; then


### PR DESCRIPTION
## 内容

`cudnn_adv_infer64_8`というファイルはなくても動くっぽいので、除外してみました。
110kB程度のダイエットになります。


## その他

他のCUDA関連ファイルは全部必要そうでした。
