### PR TITLE
ユーザー辞書操作系の優先度の扱いをpriorityで統一

### DIFF
--- a/test/test_user_dict.py
+++ b/test/test_user_dict.py
@@ -1,4 +1,3 @@
-from copy import deepcopy
 import json
 from copy import deepcopy
 from pathlib import Path

--- a/test/test_user_dict.py
+++ b/test/test_user_dict.py
@@ -289,7 +289,7 @@ class TestUserDict(TestCase):
         invalid_accent_associative_rule_word = deepcopy(import_word)
         invalid_accent_associative_rule_word.accent_associative_rule = "invalid"
         user_dict_path.write_text(
-            json.dumps(valid_dict_dict, ensure_ascii=False), encoding="utf-8"
+            json.dumps(valid_dict_dict_json, ensure_ascii=False), encoding="utf-8"
         )
         self.assertRaises(
             AssertionError,

--- a/test/test_user_dict.py
+++ b/test/test_user_dict.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 import json
 from copy import deepcopy
 from pathlib import Path
@@ -19,10 +20,11 @@ from voicevox_engine.user_dict import (
     rewrite_word,
 )
 
-valid_dict_dict = {
+# jsonとして保存される正しい形式の辞書データ
+valid_dict_dict_json = {
     "aab7dda2-0d97-43c8-8cb7-3f440dab9b4e": {
         "surface": "ｔｅｓｔ",
-        "cost": 8600,
+        "cost": part_of_speech_data["固有名詞"].cost_candidates[5],
         "part_of_speech": "名詞",
         "part_of_speech_detail_1": "固有名詞",
         "part_of_speech_detail_2": "一般",
@@ -37,9 +39,14 @@ valid_dict_dict = {
     },
 }
 
+# APIでやり取りされる正しい形式の辞書データ
+valid_dict_dict_api = deepcopy(valid_dict_dict_json)
+del valid_dict_dict_api["aab7dda2-0d97-43c8-8cb7-3f440dab9b4e"]["cost"]
+valid_dict_dict_api["aab7dda2-0d97-43c8-8cb7-3f440dab9b4e"]["priority"] = 5
+
 import_word = UserDictWord(
     surface="ｔｅｓｔ２",
-    cost=5000,
+    priority=5,
     part_of_speech="名詞",
     part_of_speech_detail_1="固有名詞",
     part_of_speech_detail_2="一般",
@@ -86,7 +93,7 @@ class TestUserDict(TestCase):
             create_word(surface="test", pronunciation="テスト", accent_type=1),
             UserDictWord(
                 surface="ｔｅｓｔ",
-                cost=part_of_speech_data["固有名詞"].cost_candidates[5],
+                priority=5,
                 part_of_speech="名詞",
                 part_of_speech_detail_1="固有名詞",
                 part_of_speech_detail_2="一般",
@@ -125,7 +132,7 @@ class TestUserDict(TestCase):
     def test_apply_word_with_json(self):
         user_dict_path = self.tmp_dir_path / "test_apply_word_with_json.json"
         user_dict_path.write_text(
-            json.dumps(valid_dict_dict, ensure_ascii=False), encoding="utf-8"
+            json.dumps(valid_dict_dict_json, ensure_ascii=False), encoding="utf-8"
         )
         apply_word(
             surface="test2",
@@ -149,7 +156,7 @@ class TestUserDict(TestCase):
     def test_rewrite_word_invalid_id(self):
         user_dict_path = self.tmp_dir_path / "test_rewrite_word_invalid_id.json"
         user_dict_path.write_text(
-            json.dumps(valid_dict_dict, ensure_ascii=False), encoding="utf-8"
+            json.dumps(valid_dict_dict_json, ensure_ascii=False), encoding="utf-8"
         )
         self.assertRaises(
             HTTPException,
@@ -165,7 +172,7 @@ class TestUserDict(TestCase):
     def test_rewrite_word_valid_id(self):
         user_dict_path = self.tmp_dir_path / "test_rewrite_word_valid_id.json"
         user_dict_path.write_text(
-            json.dumps(valid_dict_dict, ensure_ascii=False), encoding="utf-8"
+            json.dumps(valid_dict_dict_json, ensure_ascii=False), encoding="utf-8"
         )
         rewrite_word(
             word_uuid="aab7dda2-0d97-43c8-8cb7-3f440dab9b4e",
@@ -186,7 +193,7 @@ class TestUserDict(TestCase):
     def test_delete_word_invalid_id(self):
         user_dict_path = self.tmp_dir_path / "test_delete_word_invalid_id.json"
         user_dict_path.write_text(
-            json.dumps(valid_dict_dict, ensure_ascii=False), encoding="utf-8"
+            json.dumps(valid_dict_dict_json, ensure_ascii=False), encoding="utf-8"
         )
         self.assertRaises(
             HTTPException,
@@ -199,7 +206,7 @@ class TestUserDict(TestCase):
     def test_delete_word_valid_id(self):
         user_dict_path = self.tmp_dir_path / "test_delete_word_valid_id.json"
         user_dict_path.write_text(
-            json.dumps(valid_dict_dict, ensure_ascii=False), encoding="utf-8"
+            json.dumps(valid_dict_dict_json, ensure_ascii=False), encoding="utf-8"
         )
         delete_word(
             word_uuid="aab7dda2-0d97-43c8-8cb7-3f440dab9b4e",
@@ -218,15 +225,15 @@ class TestUserDict(TestCase):
                         accent_type=1,
                         word_type=pos,
                         priority=i,
-                    ).cost,
-                    part_of_speech_data[pos].cost_candidates[MAX_PRIORITY - i],
+                    ).priority,
+                    i,
                 )
 
     def test_import_dict(self):
         user_dict_path = self.tmp_dir_path / "test_import_dict.json"
         compiled_dict_path = self.tmp_dir_path / "test_import_dict.dic"
         user_dict_path.write_text(
-            json.dumps(valid_dict_dict, ensure_ascii=False), encoding="utf-8"
+            json.dumps(valid_dict_dict_json, ensure_ascii=False), encoding="utf-8"
         )
         import_user_dict(
             {"b1affe2a-d5f0-4050-926c-f28e0c1d9a98": import_word},
@@ -240,14 +247,14 @@ class TestUserDict(TestCase):
         )
         self.assertEqual(
             read_dict(user_dict_path)["aab7dda2-0d97-43c8-8cb7-3f440dab9b4e"],
-            UserDictWord(**valid_dict_dict["aab7dda2-0d97-43c8-8cb7-3f440dab9b4e"]),
+            UserDictWord(**valid_dict_dict_api["aab7dda2-0d97-43c8-8cb7-3f440dab9b4e"]),
         )
 
     def test_import_dict_no_override(self):
         user_dict_path = self.tmp_dir_path / "test_import_dict_no_override.json"
         compiled_dict_path = self.tmp_dir_path / "test_import_dict_no_override.dic"
         user_dict_path.write_text(
-            json.dumps(valid_dict_dict, ensure_ascii=False), encoding="utf-8"
+            json.dumps(valid_dict_dict_json, ensure_ascii=False), encoding="utf-8"
         )
         import_user_dict(
             {"aab7dda2-0d97-43c8-8cb7-3f440dab9b4e": import_word},
@@ -257,14 +264,14 @@ class TestUserDict(TestCase):
         )
         self.assertEqual(
             read_dict(user_dict_path)["aab7dda2-0d97-43c8-8cb7-3f440dab9b4e"],
-            UserDictWord(**valid_dict_dict["aab7dda2-0d97-43c8-8cb7-3f440dab9b4e"]),
+            UserDictWord(**valid_dict_dict_api["aab7dda2-0d97-43c8-8cb7-3f440dab9b4e"]),
         )
 
     def test_import_dict_override(self):
         user_dict_path = self.tmp_dir_path / "test_import_dict_override.json"
         compiled_dict_path = self.tmp_dir_path / "test_import_dict_override.dic"
         user_dict_path.write_text(
-            json.dumps(valid_dict_dict, ensure_ascii=False), encoding="utf-8"
+            json.dumps(valid_dict_dict_json, ensure_ascii=False), encoding="utf-8"
         )
         import_user_dict(
             {"aab7dda2-0d97-43c8-8cb7-3f440dab9b4e": import_word},

--- a/test/test_user_dict_model.py
+++ b/test/test_user_dict_model.py
@@ -11,7 +11,7 @@ class TestUserDictWords(TestCase):
     def setUp(self):
         self.test_model = {
             "surface": "テスト",
-            "cost": 0,
+            "priority": 0,
             "part_of_speech": "名詞",
             "part_of_speech_detail_1": "固有名詞",
             "part_of_speech_detail_2": "一般",

--- a/voicevox_engine/model.py
+++ b/voicevox_engine/model.py
@@ -144,6 +144,10 @@ class SpeakerInfo(BaseModel):
     style_infos: List[StyleInfo] = Field(title="スタイルの追加情報")
 
 
+USER_DICT_MIN_PRIORITY = 0
+USER_DICT_MAX_PRIORITY = 10
+
+
 class UserDictWord(BaseModel):
     """
     辞書のコンパイルに使われる情報

--- a/voicevox_engine/model.py
+++ b/voicevox_engine/model.py
@@ -154,7 +154,9 @@ class UserDictWord(BaseModel):
     """
 
     surface: str = Field(title="表層形")
-    cost: conint(ge=-32768, le=32767) = Field(title="コストの値")
+    priority: conint(ge=USER_DICT_MIN_PRIORITY, le=USER_DICT_MAX_PRIORITY) = Field(
+        title="優先度"
+    )
     context_id: int = Field(title="文脈ID", default=1348)
     part_of_speech: str = Field(title="品詞")
     part_of_speech_detail_1: str = Field(title="品詞細分類1")

--- a/voicevox_engine/part_of_speech_data.py
+++ b/voicevox_engine/part_of_speech_data.py
@@ -1,9 +1,9 @@
 from typing import Dict
 
-from .model import PartOfSpeechDetail
+from .model import USER_DICT_MAX_PRIORITY, USER_DICT_MIN_PRIORITY, PartOfSpeechDetail
 
-MIN_PRIORITY = 0
-MAX_PRIORITY = 10
+MIN_PRIORITY = USER_DICT_MIN_PRIORITY
+MAX_PRIORITY = USER_DICT_MAX_PRIORITY
 
 part_of_speech_data: Dict[str, PartOfSpeechDetail] = {
     "固有名詞": PartOfSpeechDetail(

--- a/voicevox_engine/user_dict.py
+++ b/voicevox_engine/user_dict.py
@@ -273,6 +273,7 @@ def cost2priority(context_id: int, cost: conint(ge=-32768, le=32767)) -> int:
     cost_candidates = search_cost_candidates(context_id)
     # cost_candidatesの中にある値で最も近い値を元にpriorityを返す
     # 参考: https://qiita.com/Krypf/items/2eada91c37161d17621d
+    # この関数とpriority2cost関数によって、辞書ファイルのcostを操作しても最も近いpriorityのcostに上書きされる
     return MAX_PRIORITY - np.argmin(np.abs(np.array(cost_candidates) - cost))
 
 

--- a/voicevox_engine/user_dict.py
+++ b/voicevox_engine/user_dict.py
@@ -113,10 +113,9 @@ def read_dict(user_dict_path: Path = user_dict_path) -> Dict[str, UserDictWord]:
     with user_dict_path.open(encoding="utf-8") as f:
         result = {}
         for word_uuid, word in json.load(f).items():
-            # 0.12以前の辞書はcontext_idがハードコーディングされており、1348(固有名詞)で固定であった
-            # UserDictWordに値をdictの内容を代入すれば、defaultの値として1348が補完されるが、
-            # そのあとにcostをpriorityに変換することは出来ない(バリデーションエラーに引っかかるため)
-            # そのため、この時点で固有名詞のcontext_idを代入してしまうようにする
+            # cost2priorityで変換を行う際にcontext_idが必要となるが、
+            # 0.12以前の辞書は、context_idがハードコーディングされていたためにユーザー辞書内に保管されていない
+            # ハードコーディングされていたcontext_idは固有名詞を意味するものなので、固有名詞のcontext_idを補完する
             if word.get("context_id") is None:
                 word["context_id"] = part_of_speech_data["固有名詞"].context_id
             word["priority"] = cost2priority(word["context_id"], word["cost"])

--- a/voicevox_engine/user_dict.py
+++ b/voicevox_engine/user_dict.py
@@ -269,7 +269,7 @@ def search_cost_candidates(context_id: int) -> List[int]:
     raise HTTPException(status_code=422, detail="品詞IDが不正です")
 
 
-def cost2priority(context_id: int, cost: conint(ge=-32768, le=32768)) -> int:
+def cost2priority(context_id: int, cost: conint(ge=-32768, le=32767)) -> int:
     cost_candidates = search_cost_candidates(context_id)
     # コストのパーセンタイルは確実に低いもの順で並んでいるので、低いものから比較し、値が近い・もしくは同じcostをpriorityとする
     # OpenJTalk側の辞書の更新が入ることでcostのパーセンタイルが変わり得る・そもそもVOICEVOXとして8600をデフォルト値としていたことから、


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->
題の通り、json/csvにおいては、`cost`を残さざるを得ない(既存のユーザー辞書が壊れるかもしれない)ので、操作系のみを`priority`で統一しました。
これにより、エディタ側・ユーザーは`priority`という単位以外を意識しなくて済むようになります。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->
close #390 

