### PR TITLE
voicevox_core 0.12.0-preview.3 の読み込みに対応

### DIFF
--- a/voicevox_engine/synthesis_engine/core_wrapper.py
+++ b/voicevox_engine/synthesis_engine/core_wrapper.py
@@ -331,12 +331,8 @@ def load_core(core_dir: Path, use_gpu: bool) -> CDLL:
 
 class CoreWrapper:
     def __init__(self, use_gpu: bool, core_dir: Path, cpu_num_threads: int = 0) -> None:
-        if is_version_0_12_core_or_later(core_dir):
-            model_type = "onnxruntime"
-        else:
-            model_type = check_core_type(core_dir)
+
         self.core = load_core(core_dir, use_gpu)
-        assert model_type is not None
 
         self.core.initialize.restype = c_bool
         self.core.metas.restype = c_char_p
@@ -348,6 +344,13 @@ class CoreWrapper:
         self.exist_suppoted_devices = False
         self.exist_finalize = False
         exist_cpu_num_threads = False
+
+        if is_version_0_12_core_or_later(core_dir):
+            model_type = "onnxruntime"
+        else:
+            model_type = check_core_type(core_dir)
+        assert model_type is not None
+
         if model_type == "onnxruntime":
             self.core.supported_devices.restype = c_char_p
             self.core.finalize.restype = None

--- a/voicevox_engine/synthesis_engine/core_wrapper.py
+++ b/voicevox_engine/synthesis_engine/core_wrapper.py
@@ -330,7 +330,13 @@ def load_core(core_dir: Path, use_gpu: bool) -> CDLL:
 
 
 class CoreWrapper:
-    def __init__(self, use_gpu: bool, core_dir: Path, cpu_num_threads: int = 0) -> None:
+    def __init__(
+        self,
+        use_gpu: bool,
+        core_dir: Path,
+        cpu_num_threads: int = 0,
+        load_all_models: bool = True,
+    ) -> None:
 
         self.core = load_core(core_dir, use_gpu)
 
@@ -344,9 +350,12 @@ class CoreWrapper:
         self.exist_suppoted_devices = False
         self.exist_finalize = False
         exist_cpu_num_threads = False
+        # TODO: version 0.12 から追加された load_model, is_model_loaded 関数に対応するため、
+        #       self.exist_load_model, self.exist_is_model_loaded 変数を定義する
 
         if is_version_0_12_core_or_later(core_dir):
             model_type = "onnxruntime"
+            # TODO: self.exist_load_model, self.exist_is_model_loaded 両方を True にする
         else:
             model_type = check_core_type(core_dir)
         assert model_type is not None
@@ -388,7 +397,7 @@ class CoreWrapper:
         os.chdir(core_dir)
         try:
             if is_version_0_12_core_or_later(core_dir):
-                if not self.core.initialize(use_gpu, cpu_num_threads):
+                if not self.core.initialize(use_gpu, cpu_num_threads, load_all_models):
                     raise Exception(self.core.last_error_message().decode("utf-8"))
             elif exist_cpu_num_threads:
                 if not self.core.initialize(".", use_gpu, cpu_num_threads):


### PR DESCRIPTION
## 内容

[voicevox_core 0.12.0-preview.3](https://github.com/VOICEVOX/voicevox_core/releases/tag/0.12.0-preview.3) の読み込みに対応します。この対応に伴い、0.12.0-preview.2 までの 0.12.0 系の プレビュービルドには非対応になります。

新しいコアライブラリはモデルの遅延読み込みに対応していますが、この PR ではエンジンの自動ビルドを voicevox_core 0.12.0-preview.3 に対応させるための作業 (#396) の一部として、簡易的な対応にとどめています（これまでのエンジンと同様に、コアの初期化時に全モデルを読み込むようにしています）。

エンジンの起動引数や API でキャラクター別のモデル読み込みに対応する作業は #394 で進行中です。

## 関連 Issue

ref #396 
ref #394 
