### PR TITLE
ビルド時のコアのバージョンを 0.12.0-preview.3 に上げる

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -11,7 +11,7 @@ on:
 env:
   IMAGE_NAME: ${{ secrets.DOCKERHUB_USERNAME }}/voicevox_engine
   PYTHON_VERSION: "3.8.10"
-  VOICEVOX_CORE_VERSION: "0.11.4"
+  VOICEVOX_CORE_VERSION: "0.12.0-preview.3"
   VOICEVOX_ENGINE_VERSION:
     |- # releaseのときはタグが、それ以外はlatestがバージョン名に
     ${{ github.event.release.tag_name != '' && github.event.release.tag_name || 'latest' }}
@@ -37,44 +37,44 @@ jobs:
             target: runtime-env
             base_image: ubuntu:focal
             base_runtime_image: ubuntu:focal
-            voicevox_core_library_name: libcore_cpu_x64.so
+            voicevox_core_asset_prefix: voicevox_core-linux-x64-cpu
             onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.10.0/onnxruntime-linux-x64-1.10.0.tgz
           - tag: cpu
             target: runtime-env
             base_image: ubuntu:focal
             base_runtime_image: ubuntu:focal
-            voicevox_core_library_name: libcore_cpu_x64.so
+            voicevox_core_asset_prefix: voicevox_core-linux-x64-cpu
             onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.10.0/onnxruntime-linux-x64-1.10.0.tgz
           - tag: cpu-ubuntu20.04
             target: runtime-env
             base_image: ubuntu:focal
             base_runtime_image: ubuntu:focal
-            voicevox_core_library_name: libcore_cpu_x64.so
+            voicevox_core_asset_prefix: voicevox_core-linux-x64-cpu
             onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.10.0/onnxruntime-linux-x64-1.10.0.tgz
           - tag: nvidia
             target: runtime-nvidia-env
             base_image: ubuntu:focal
             base_runtime_image: nvidia/cuda:11.4.2-cudnn8-runtime-ubuntu20.04
-            voicevox_core_library_name: libcore_gpu_x64_nvidia.so
+            voicevox_core_asset_prefix: voicevox_core-linux-x64-gpu
             onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.10.0/onnxruntime-linux-x64-gpu-1.10.0.tgz
           - tag: nvidia-ubuntu20.04
             target: runtime-nvidia-env
             base_image: ubuntu:focal
             base_runtime_image: nvidia/cuda:11.4.2-cudnn8-runtime-ubuntu20.04
-            voicevox_core_library_name: libcore_gpu_x64_nvidia.so
+            voicevox_core_asset_prefix: voicevox_core-linux-x64-gpu
             onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.10.0/onnxruntime-linux-x64-gpu-1.10.0.tgz
           # Ubuntu 18.04
           - tag: cpu-ubuntu18.04
             target: runtime-env
             base_image: ubuntu:bionic
             base_runtime_image: ubuntu:bionic
-            voicevox_core_library_name: libcore_cpu_x64.so
+            voicevox_core_asset_prefix: voicevox_core-linux-x64-cpu
             onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.10.0/onnxruntime-linux-x64-1.10.0.tgz
           - tag: nvidia-ubuntu18.04
             target: runtime-nvidia-env
             base_image: ubuntu:bionic
             base_runtime_image: nvidia/cuda:11.4.2-cudnn8-runtime-ubuntu18.04
-            voicevox_core_library_name: libcore_gpu_x64_nvidia.so
+            voicevox_core_asset_prefix: voicevox_core-linux-x64-gpu
             onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.10.0/onnxruntime-linux-x64-gpu-1.10.0.tgz
 
     steps:
@@ -100,6 +100,7 @@ jobs:
                 format('{0}:{1}-{2}', env.IMAGE_NAME, matrix.tag, env.VOICEVOX_ENGINE_VERSION)
               ) || format('{0}:{1}', env.IMAGE_NAME, env.VOICEVOX_ENGINE_VERSION)
             ) }}
+          VOICEVOX_CORE_ASSET_NAME: ${{ matrix.voicevox_core_asset_prefix }}-${{ env.VOICEVOX_CORE_VERSION }}
         with:
           context: .
           builder: ${{ steps.buildx.outputs.name }}
@@ -109,8 +110,8 @@ jobs:
             BASE_RUNTIME_IMAGE=${{ matrix.base_runtime_image }}
             PYTHON_VERSION=${{ env.PYTHON_VERSION }}
             VOICEVOX_ENGINE_VERSION=${{ env.VOICEVOX_ENGINE_VERSION }}
+            VOICEVOX_CORE_ASSET_NAME=${{ env.VOICEVOX_CORE_ASSET_NAME }}
             VOICEVOX_CORE_VERSION=${{ env.VOICEVOX_CORE_VERSION }}
-            VOICEVOX_CORE_LIBRARY_NAME=${{ matrix.voicevox_core_library_name }}
             ONNXRUNTIME_URL=${{ matrix.onnxruntime_url }}
           target: ${{ matrix.target }}
           push: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,6 @@ jobs:
             python_architecture: "x64"
             pip_cache_path: ~/Library/Caches/pip
             voicevox_core_asset_prefix: voicevox_core-osx-universal2-cpu
-            voicevox_core_library_name: libcore_cpu_universal2.dylib
             onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.10.0/onnxruntime-osx-universal2-1.10.0.tgz
             artifact_name: macos-x64
 
@@ -148,10 +147,10 @@ jobs:
         if: steps.voicevox-core-cache.outputs.cache-hit != 'true'
         shell: bash
         run: |
-          # extracted like download/core/metas.json
+          # extracted like download/core/libcore.dylib
           curl -L "https://github.com/VOICEVOX/voicevox_core/releases/download/${{ env.VOICEVOX_CORE_VERSION }}/${{ env.VOICEVOX_CORE_ASSET_NAME }}.zip" > download/core.zip
-          ditto -x -k --sequesterRsrc --rsrc download/${{ env.VOICEVOX_CORE_ASSET_NAME }}.zip download/
-          rm download/${{ env.VOICEVOX_CORE_ASSET_NAME }}.zip
+          ditto -x -k --sequesterRsrc --rsrc download/core.zip download/
+          rm download/core.zip
 
       - name: Download PyOpenJTalk dictionary
         shell: bash
@@ -197,9 +196,7 @@ jobs:
             --include-data-file=../licenses.json=./ \
             --include-data-file=../presets.yaml=./ \
             --include-data-file=../default.csv=./ \
-            --include-data-file=../download/core/*.bin=./ \
-            --include-data-file=../download/core/metas.json=./ \
-            --include-data-file=../download/core/${{ matrix.voicevox_core_library_name }}=./ \
+            --include-data-file=../download/core/libcore.dylib=./ \
             --include-data-file=../download/onnxruntime/lib/libonnxruntime.dylib=./ \
             --include-data-file=${{ env.pythonLocation }}/lib/python*/site-packages/scipy/.dylibs/*.dylib=./scipy/.dylibs/ \
             --include-data-file=${{ env.pythonLocation }}/lib/python*/site-packages/_soundfile_data/*=./_soundfile_data/ \
@@ -255,7 +252,6 @@ jobs:
             base_image: ubuntu:bionic
             base_runtime_image: ubuntu:bionic
             voicevox_core_asset_prefix: voicevox_core-linux-x64-cpu
-            voicevox_core_library_name: libcore_cpu_x64.so
             onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.10.0/onnxruntime-linux-x64-1.10.0.tgz
             artifact_name: linux-cpu
             nuitka_cache_path: nuitka_cache
@@ -265,7 +261,6 @@ jobs:
             base_image: ubuntu:bionic
             base_runtime_image: nvidia/cuda:11.4.2-cudnn8-runtime-ubuntu18.04
             voicevox_core_asset_prefix: voicevox_core-linux-x64-gpu
-            voicevox_core_library_name: libcore_gpu_x64_nvidia.so
             onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.10.0/onnxruntime-linux-x64-gpu-1.10.0.tgz
             artifact_name: linux-nvidia
             nuitka_cache_path: nuitka_cache
@@ -331,7 +326,6 @@ jobs:
             VOICEVOX_ENGINE_VERSION=${{ env.VOICEVOX_ENGINE_VERSION }}
             VOICEVOX_CORE_ASSET_NAME=${{ env.VOICEVOX_CORE_ASSET_NAME }}
             VOICEVOX_CORE_VERSION=${{ env.VOICEVOX_CORE_VERSION }}
-            VOICEVOX_CORE_LIBRARY_NAME=${{ matrix.voicevox_core_library_name }}
             ONNXRUNTIME_URL=${{ matrix.onnxruntime_url }}
           target: ${{ matrix.target }}
           load: true
@@ -383,7 +377,6 @@ jobs:
           - os: windows-2019
             architecture: "x64"
             voicevox_core_asset_prefix: voicevox_core-windows-x64-cpu
-            voicevox_core_dll_name: core_cpu_x64.dll
             onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.10.0/onnxruntime-win-x64-1.10.0.zip
             ccache_url: https://github.com/ccache/ccache/releases/download/v4.4.1/ccache-4.4.1-windows-64.zip
             artifact_name: windows-cpu
@@ -393,7 +386,6 @@ jobs:
           - os: windows-2019
             architecture: "x64"
             voicevox_core_asset_prefix: voicevox_core-windows-x64-directml
-            voicevox_core_dll_name: core_gpu_x64_directml.dll
             onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.10.0/Microsoft.ML.OnnxRuntime.DirectML.1.10.0.zip
             directml_url: https://www.nuget.org/api/v2/package/Microsoft.AI.DirectML/1.8.0
             ccache_url: https://github.com/ccache/ccache/releases/download/v4.4.1/ccache-4.4.1-windows-64.zip
@@ -404,7 +396,6 @@ jobs:
           - os: windows-2019
             architecture: "x64"
             voicevox_core_asset_prefix: voicevox_core-windows-x64-cuda
-            voicevox_core_dll_name: core_gpu_x64_nvidia.dll
             onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.10.0/onnxruntime-win-x64-gpu-1.10.0.zip
             cuda_version: "11.4.2"
             cudnn_url: https://developer.download.nvidia.com/compute/redist/cudnn/v8.2.4/cudnn-11.4-windows-x64-v8.2.4.15.zip
@@ -677,8 +668,8 @@ jobs:
         shell: bash
         run: |
           curl -L "https://github.com/VOICEVOX/voicevox_core/releases/download/${{ env.VOICEVOX_CORE_VERSION }}/${{ env.VOICEVOX_CORE_ASSET_NAME }}.zip" > download/core.zip
-          unzip download/${{ env.VOICEVOX_CORE_ASSET_NAME }}.zip -d download/
-          rm download/${{ env.VOICEVOX_CORE_ASSET_NAME }}.zip
+          unzip download/core.zip -d download/
+          rm download/core.zip
 
       - name: Generate licenses.json
         shell: bash
@@ -725,10 +716,8 @@ jobs:
             --include-data-file="licenses.json=./" \
             --include-data-file="default.csv=./" \
             --include-data-file="presets.yaml=./" \
-            --include-data-file=download/core/*.bin=./ \
-            --include-data-file="download/core/metas.json=./" \
             --include-data-file="download/onnxruntime/lib/onnxruntime.dll=./" \
-            --include-data-file="download/core/${{ matrix.voicevox_core_dll_name }}=./" \
+            --include-data-file="download/core/core.dll=./" \
             --include-data-dir="speaker_info=./speaker_info" \
             --include-data-dir="manifest_assets=./manifest_assets" \
             --msvc=14.2 \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -144,7 +144,7 @@ jobs:
         if: steps.voicevox-core-cache.outputs.cache-hit != 'true'
         shell: bash
         env:
-          VOICEVOX_CORE_ASSET_NAME: "${{ matrix.voicevox_core_asset_prefix }}-${{ env.VOICEVOX_CORE_VERSION }}"
+          VOICEVOX_CORE_ASSET_NAME: ${{ matrix.voicevox_core_asset_prefix }}-${{ env.VOICEVOX_CORE_VERSION }}
         run: |
           # extracted like download/core/libcore.dylib
           curl -L "https://github.com/VOICEVOX/voicevox_core/releases/download/${{ env.VOICEVOX_CORE_VERSION }}/${{ env.VOICEVOX_CORE_ASSET_NAME }}.zip" > download/core.zip
@@ -311,7 +311,7 @@ jobs:
         env:
           IMAGE_TAG: ${{ env.IMAGE_NAME }}:${{ matrix.tag }}${{ (matrix.tag != '' && '-') || '' }}latest
           RUNTIME_IMAGE_TAG: ${{ env.IMAGE_NAME }}:${{ matrix.runtime_tag }}${{ (matrix.runtime_tag != '' && '-') || '' }}latest
-          VOICEVOX_CORE_ASSET_NAME: "${{ matrix.voicevox_core_asset_prefix }}-${{ env.VOICEVOX_CORE_VERSION }}"
+          VOICEVOX_CORE_ASSET_NAME: ${{ matrix.voicevox_core_asset_prefix }}-${{ env.VOICEVOX_CORE_VERSION }}
         with:
           context: .
           builder: ${{ steps.buildx.outputs.name }}
@@ -661,7 +661,7 @@ jobs:
         if: steps.voicevox-core-cache.outputs.cache-hit != 'true'
         shell: bash
         env:
-          VOICEVOX_CORE_ASSET_NAME: "${{ matrix.voicevox_core_asset_prefix }}-${{ env.VOICEVOX_CORE_VERSION }}"
+          VOICEVOX_CORE_ASSET_NAME: ${{ matrix.voicevox_core_asset_prefix }}-${{ env.VOICEVOX_CORE_VERSION }}
         run: |
           curl -L "https://github.com/VOICEVOX/voicevox_core/releases/download/${{ env.VOICEVOX_CORE_VERSION }}/${{ env.VOICEVOX_CORE_ASSET_NAME }}.zip" > download/core.zip
           unzip download/core.zip -d download/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,9 +32,6 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
-    env:
-      VOICEVOX_CORE_ASSET_NAME: "${{ matrix.voicevox_core_asset_prefix }}-${{ env.VOICEVOX_CORE_VERSION }}"
-
     steps:
       - uses: actions/checkout@v2
 
@@ -146,6 +143,8 @@ jobs:
       - name: Download VOICEVOX Core release
         if: steps.voicevox-core-cache.outputs.cache-hit != 'true'
         shell: bash
+        env:
+          VOICEVOX_CORE_ASSET_NAME: "${{ matrix.voicevox_core_asset_prefix }}-${{ env.VOICEVOX_CORE_VERSION }}"
         run: |
           # extracted like download/core/libcore.dylib
           curl -L "https://github.com/VOICEVOX/voicevox_core/releases/download/${{ env.VOICEVOX_CORE_VERSION }}/${{ env.VOICEVOX_CORE_ASSET_NAME }}.zip" > download/core.zip
@@ -267,9 +266,6 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
-    env:
-      VOICEVOX_CORE_ASSET_NAME: "${{ matrix.voicevox_core_asset_prefix }}-${{ env.VOICEVOX_CORE_VERSION }}"
-
     steps:
       - uses: actions/checkout@v2
 
@@ -315,6 +311,7 @@ jobs:
         env:
           IMAGE_TAG: ${{ env.IMAGE_NAME }}:${{ matrix.tag }}${{ (matrix.tag != '' && '-') || '' }}latest
           RUNTIME_IMAGE_TAG: ${{ env.IMAGE_NAME }}:${{ matrix.runtime_tag }}${{ (matrix.runtime_tag != '' && '-') || '' }}latest
+          VOICEVOX_CORE_ASSET_NAME: "${{ matrix.voicevox_core_asset_prefix }}-${{ env.VOICEVOX_CORE_VERSION }}"
         with:
           context: .
           builder: ${{ steps.buildx.outputs.name }}
@@ -405,9 +402,6 @@ jobs:
             pip_cache_path: ~\AppData\Local\pip\Cache
 
     runs-on: ${{ matrix.os }}
-
-    env:
-      VOICEVOX_CORE_ASSET_NAME: "${{ matrix.voicevox_core_asset_prefix }}-${{ env.VOICEVOX_CORE_VERSION }}"
 
     steps:
       - uses: actions/checkout@v2
@@ -666,6 +660,8 @@ jobs:
       - name: Download VOICEVOX Core
         if: steps.voicevox-core-cache.outputs.cache-hit != 'true'
         shell: bash
+        env:
+          VOICEVOX_CORE_ASSET_NAME: "${{ matrix.voicevox_core_asset_prefix }}-${{ env.VOICEVOX_CORE_VERSION }}"
         run: |
           curl -L "https://github.com/VOICEVOX/voicevox_core/releases/download/${{ env.VOICEVOX_CORE_VERSION }}/${{ env.VOICEVOX_CORE_ASSET_NAME }}.zip" > download/core.zip
           unzip download/core.zip -d download/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ env:
   IMAGE_NAME: ${{ secrets.DOCKERHUB_USERNAME }}/voicevox_engine
   PYTHON_VERSION: "3.8.10"
   VOICEVOX_RESOURCE_VERSION: "0.11.4"
-  VOICEVOX_CORE_VERSION: "0.12.0-preview.2"
+  VOICEVOX_CORE_VERSION: "0.12.0-preview.3"
   VOICEVOX_ENGINE_VERSION:
     |- # releaseのときはタグが、それ以外はlatestがバージョン名に
     ${{ github.event.release.tag_name != '' && github.event.release.tag_name || 'latest' }}
@@ -26,11 +26,15 @@ jobs:
           - os: macos-11
             python_architecture: "x64"
             pip_cache_path: ~/Library/Caches/pip
+            voicevox_core_asset_prefix: voicevox_core-osx-universal2-cpu
             voicevox_core_library_name: libcore_cpu_universal2.dylib
             onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.10.0/onnxruntime-osx-universal2-1.10.0.tgz
             artifact_name: macos-x64
 
     runs-on: ${{ matrix.os }}
+
+    env:
+      VOICEVOX_CORE_ASSET_NAME: "${{ matrix.voicevox_core_asset_prefix }}-${{ env.VOICEVOX_CORE_VERSION }}"
 
     steps:
       - uses: actions/checkout@v2
@@ -145,9 +149,9 @@ jobs:
         shell: bash
         run: |
           # extracted like download/core/metas.json
-          curl -L "https://github.com/VOICEVOX/voicevox_core/releases/download/${{ env.VOICEVOX_CORE_VERSION }}/core.zip" > download/core.zip
-          ditto -x -k --sequesterRsrc --rsrc download/core.zip download/
-          rm download/core.zip
+          curl -L "https://github.com/VOICEVOX/voicevox_core/releases/download/${{ env.VOICEVOX_CORE_VERSION }}/${{ env.VOICEVOX_CORE_ASSET_NAME }}.zip" > download/core.zip
+          ditto -x -k --sequesterRsrc --rsrc download/${{ env.VOICEVOX_CORE_ASSET_NAME }}.zip download/
+          rm download/${{ env.VOICEVOX_CORE_ASSET_NAME }}.zip
 
       - name: Download PyOpenJTalk dictionary
         shell: bash
@@ -250,6 +254,7 @@ jobs:
             target: build-env
             base_image: ubuntu:bionic
             base_runtime_image: ubuntu:bionic
+            voicevox_core_asset_prefix: voicevox_core-linux-x64-cpu
             voicevox_core_library_name: libcore_cpu_x64.so
             onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.10.0/onnxruntime-linux-x64-1.10.0.tgz
             artifact_name: linux-cpu
@@ -259,12 +264,16 @@ jobs:
             target: build-env
             base_image: ubuntu:bionic
             base_runtime_image: nvidia/cuda:11.4.2-cudnn8-runtime-ubuntu18.04
+            voicevox_core_asset_prefix: voicevox_core-linux-x64-gpu
             voicevox_core_library_name: libcore_gpu_x64_nvidia.so
             onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.10.0/onnxruntime-linux-x64-gpu-1.10.0.tgz
             artifact_name: linux-nvidia
             nuitka_cache_path: nuitka_cache
 
     runs-on: ${{ matrix.os }}
+
+    env:
+      VOICEVOX_CORE_ASSET_NAME: "${{ matrix.voicevox_core_asset_prefix }}-${{ env.VOICEVOX_CORE_VERSION }}"
 
     steps:
       - uses: actions/checkout@v2
@@ -320,6 +329,7 @@ jobs:
             BASE_RUNTIME_IMAGE=${{ matrix.base_runtime_image }}
             PYTHON_VERSION=${{ env.PYTHON_VERSION }}
             VOICEVOX_ENGINE_VERSION=${{ env.VOICEVOX_ENGINE_VERSION }}
+            VOICEVOX_CORE_ASSET_NAME=${{ env.VOICEVOX_CORE_ASSET_NAME }}
             VOICEVOX_CORE_VERSION=${{ env.VOICEVOX_CORE_VERSION }}
             VOICEVOX_CORE_LIBRARY_NAME=${{ matrix.voicevox_core_library_name }}
             ONNXRUNTIME_URL=${{ matrix.onnxruntime_url }}
@@ -372,6 +382,7 @@ jobs:
           # Windows CPU
           - os: windows-2019
             architecture: "x64"
+            voicevox_core_asset_prefix: voicevox_core-windows-x64-cpu
             voicevox_core_dll_name: core_cpu_x64.dll
             onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.10.0/onnxruntime-win-x64-1.10.0.zip
             ccache_url: https://github.com/ccache/ccache/releases/download/v4.4.1/ccache-4.4.1-windows-64.zip
@@ -381,6 +392,7 @@ jobs:
           # Windows DirectML
           - os: windows-2019
             architecture: "x64"
+            voicevox_core_asset_prefix: voicevox_core-windows-x64-directml
             voicevox_core_dll_name: core_gpu_x64_directml.dll
             onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.10.0/Microsoft.ML.OnnxRuntime.DirectML.1.10.0.zip
             directml_url: https://www.nuget.org/api/v2/package/Microsoft.AI.DirectML/1.8.0
@@ -391,6 +403,7 @@ jobs:
           # Windows NVIDIA GPU
           - os: windows-2019
             architecture: "x64"
+            voicevox_core_asset_prefix: voicevox_core-windows-x64-cuda
             voicevox_core_dll_name: core_gpu_x64_nvidia.dll
             onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.10.0/onnxruntime-win-x64-gpu-1.10.0.zip
             cuda_version: "11.4.2"
@@ -401,6 +414,9 @@ jobs:
             pip_cache_path: ~\AppData\Local\pip\Cache
 
     runs-on: ${{ matrix.os }}
+
+    env:
+      VOICEVOX_CORE_ASSET_NAME: "${{ matrix.voicevox_core_asset_prefix }}-${{ env.VOICEVOX_CORE_VERSION }}"
 
     steps:
       - uses: actions/checkout@v2
@@ -660,9 +676,9 @@ jobs:
         if: steps.voicevox-core-cache.outputs.cache-hit != 'true'
         shell: bash
         run: |
-          curl -L "https://github.com/VOICEVOX/voicevox_core/releases/download/${{ env.VOICEVOX_CORE_VERSION }}/core.zip" > download/core.zip
-          unzip download/core.zip -d download/
-          rm download/core.zip
+          curl -L "https://github.com/VOICEVOX/voicevox_core/releases/download/${{ env.VOICEVOX_CORE_VERSION }}/${{ env.VOICEVOX_CORE_ASSET_NAME }}.zip" > download/core.zip
+          unzip download/${{ env.VOICEVOX_CORE_ASSET_NAME }}.zip -d download/
+          rm download/${{ env.VOICEVOX_CORE_ASSET_NAME }}.zip
 
       - name: Generate licenses.json
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -147,9 +147,12 @@ jobs:
           VOICEVOX_CORE_ASSET_NAME: ${{ matrix.voicevox_core_asset_prefix }}-${{ env.VOICEVOX_CORE_VERSION }}
         run: |
           # extracted like download/core/libcore.dylib
-          curl -L "https://github.com/VOICEVOX/voicevox_core/releases/download/${{ env.VOICEVOX_CORE_VERSION }}/${{ env.VOICEVOX_CORE_ASSET_NAME }}.zip" > download/core.zip
-          ditto -x -k --sequesterRsrc --rsrc download/core.zip download/
-          rm download/core.zip
+          curl -L "https://github.com/VOICEVOX/voicevox_core/releases/download/${{ env.VOICEVOX_CORE_VERSION }}/${{ env.VOICEVOX_CORE_ASSET_NAME }}.zip" > download/${{ env.VOICEVOX_CORE_ASSET_NAME }}.zip
+          ditto -x -k --sequesterRsrc --rsrc download/${{ env.VOICEVOX_CORE_ASSET_NAME }}.zip download/
+          mkdir -p download/core
+          mv download/${{ env.VOICEVOX_CORE_ASSET_NAME }}/* download/core
+          rm -rf download/${{ env.VOICEVOX_CORE_ASSET_NAME }}
+          rm download/${{ env.VOICEVOX_CORE_ASSET_NAME }}.zip
 
       - name: Download PyOpenJTalk dictionary
         shell: bash
@@ -663,9 +666,12 @@ jobs:
         env:
           VOICEVOX_CORE_ASSET_NAME: ${{ matrix.voicevox_core_asset_prefix }}-${{ env.VOICEVOX_CORE_VERSION }}
         run: |
-          curl -L "https://github.com/VOICEVOX/voicevox_core/releases/download/${{ env.VOICEVOX_CORE_VERSION }}/${{ env.VOICEVOX_CORE_ASSET_NAME }}.zip" > download/core.zip
-          unzip download/core.zip -d download/
-          rm download/core.zip
+          curl -L "https://github.com/VOICEVOX/voicevox_core/releases/download/${{ env.VOICEVOX_CORE_VERSION }}/${{ env.VOICEVOX_CORE_ASSET_NAME }}.zip" > download/${{ env.VOICEVOX_CORE_ASSET_NAME }}.zip
+          unzip download/${{ env.VOICEVOX_CORE_ASSET_NAME }}.zip -d download/
+          mkdir -p download/core
+          mv download/${{ env.VOICEVOX_CORE_ASSET_NAME }}/* download/core
+          rm -rf download/${{ env.VOICEVOX_CORE_ASSET_NAME }}
+          rm download/${{ env.VOICEVOX_CORE_ASSET_NAME }}.zip
 
       - name: Generate licenses.json
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -667,6 +667,10 @@ jobs:
           VOICEVOX_CORE_ASSET_NAME: ${{ matrix.voicevox_core_asset_prefix }}-${{ env.VOICEVOX_CORE_VERSION }}
         run: |
           curl -L "https://github.com/VOICEVOX/voicevox_core/releases/download/${{ env.VOICEVOX_CORE_VERSION }}/${{ env.VOICEVOX_CORE_ASSET_NAME }}.zip" > download/${{ env.VOICEVOX_CORE_ASSET_NAME }}.zip
+          # NOTE: Windows 版コアのみ PowerShell の Compress-Archive コマンドレットを用いて zip を作成している（デフォルト状態では zip コマンドが存在していないため）。
+          #       このコマンドはバージョンによっては作成した zip 内のパスの区切り文字がバックスラッシュになる。 (cf. https://github.com/PowerShell/Microsoft.PowerShell.Archive/issues/48)
+          #       unzip コマンドはこのような zip ファイルを解凍できるものの、終了コード 1 を報告して CI が落ちてしまう。
+          #       回避策として、unzip コマンドの代わりに 7z コマンドを用いて zip ファイルを解凍する。
           # unzip download/${{ env.VOICEVOX_CORE_ASSET_NAME }}.zip -d download/
           7z x -o"download" download/${{ env.VOICEVOX_CORE_ASSET_NAME }}.zip
           mkdir -p download/core

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -667,7 +667,8 @@ jobs:
           VOICEVOX_CORE_ASSET_NAME: ${{ matrix.voicevox_core_asset_prefix }}-${{ env.VOICEVOX_CORE_VERSION }}
         run: |
           curl -L "https://github.com/VOICEVOX/voicevox_core/releases/download/${{ env.VOICEVOX_CORE_VERSION }}/${{ env.VOICEVOX_CORE_ASSET_NAME }}.zip" > download/${{ env.VOICEVOX_CORE_ASSET_NAME }}.zip
-          unzip download/${{ env.VOICEVOX_CORE_ASSET_NAME }}.zip -d download/
+          # unzip download/${{ env.VOICEVOX_CORE_ASSET_NAME }}.zip -d download/
+          7z x -o"download" download/${{ env.VOICEVOX_CORE_ASSET_NAME }}.zip
           mkdir -p download/core
           mv download/${{ env.VOICEVOX_CORE_ASSET_NAME }}/* download/core
           rm -rf download/${{ env.VOICEVOX_CORE_ASSET_NAME }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,9 @@ RUN <<EOF
     mkdir /opt/voicevox_core
     mv "./core/libcore.so" /opt/voicevox_core/
 
+    # Move documents to /opt/voicevox_core/
+    mv ./core/VERSION /opt/voicevox_core/
+
     rm -rf ./core
 
     # Add /opt/voicevox_core to dynamic library search path

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,24 +23,17 @@ EOF
 # assert VOICEVOX_CORE_VERSION >= 0.11.0 (ONNX)
 ARG VOICEVOX_CORE_ASSET_NAME=voicevox_core-linux-x64-cpu-0.12.0-preview.3
 ARG VOICEVOX_CORE_VERSION=0.12.0-preview.3
-ARG VOICEVOX_CORE_LIBRARY_NAME=libcore_cpu_x64.so
 RUN <<EOF
     set -eux
 
     # Download Core
     wget -nv --show-progress -c -O "./core.zip" "https://github.com/VOICEVOX/voicevox_core/releases/download/${VOICEVOX_CORE_VERSION}/${VOICEVOX_CORE_ASSET_NAME}.zip"
-    unzip "./${VOICEVOX_CORE_ASSET_NAME}.zip"
-    rm ./$VOICEVOX_CORE_ASSET_NAME.zip
+    unzip "./core.zip"
+    rm ./core.zip
 
     # Move Core Library to /opt/voicevox_core/
     mkdir /opt/voicevox_core
-    mv "./core/${VOICEVOX_CORE_LIBRARY_NAME}" /opt/voicevox_core/
-
-    # Move Voice Library to /opt/voicevox_core/
-    mv ./core/*.bin ./core/metas.json /opt/voicevox_core/
-
-    # Move documents to /opt/voicevox_core/
-    mv ./core/README.txt ./core/VERSION /opt/voicevox_core/
+    mv "./core/libcore.so" /opt/voicevox_core/
 
     rm -rf ./core
 
@@ -334,8 +327,6 @@ RUN <<EOF
             --include-data-file=/opt/voicevox_engine/licenses.json=./ \
             --include-data-file=/opt/voicevox_engine/presets.yaml=./ \
             --include-data-file=/opt/voicevox_engine/default.csv=./ \
-            --include-data-file=/opt/voicevox_core/*.bin=./ \
-            --include-data-file=/opt/voicevox_core/metas.json=./ \
             --include-data-file=/opt/voicevox_core/*.so=./ \
             --include-data-file=/opt/onnxruntime/lib/libonnxruntime.so=./ \
             --include-data-dir=/opt/voicevox_engine/speaker_info=./speaker_info \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,15 +21,16 @@ RUN <<EOF
 EOF
 
 # assert VOICEVOX_CORE_VERSION >= 0.11.0 (ONNX)
-ARG VOICEVOX_CORE_VERSION=0.12.0-preview.2
+ARG VOICEVOX_CORE_ASSET_NAME=voicevox_core-linux-x64-cpu-0.12.0-preview.3
+ARG VOICEVOX_CORE_VERSION=0.12.0-preview.3
 ARG VOICEVOX_CORE_LIBRARY_NAME=libcore_cpu_x64.so
 RUN <<EOF
     set -eux
 
     # Download Core
-    wget -nv --show-progress -c -O "./core.zip" "https://github.com/VOICEVOX/voicevox_core/releases/download/${VOICEVOX_CORE_VERSION}/core.zip"
-    unzip "./core.zip"
-    rm ./core.zip
+    wget -nv --show-progress -c -O "./core.zip" "https://github.com/VOICEVOX/voicevox_core/releases/download/${VOICEVOX_CORE_VERSION}/${VOICEVOX_CORE_ASSET_NAME}.zip"
+    unzip "./${VOICEVOX_CORE_ASSET_NAME}.zip"
+    rm ./$VOICEVOX_CORE_ASSET_NAME.zip
 
     # Move Core Library to /opt/voicevox_core/
     mkdir /opt/voicevox_core

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN <<EOF
     wget -nv --show-progress -c -O "./${VOICEVOX_CORE_ASSET_NAME}.zip" "https://github.com/VOICEVOX/voicevox_core/releases/download/${VOICEVOX_CORE_VERSION}/${VOICEVOX_CORE_ASSET_NAME}.zip"
     unzip "./${VOICEVOX_CORE_ASSET_NAME}.zip"
     mkdir -p core
-    mv "${VOICEVOX_CORE_ASSET_NAME}/*" core
+    mv "${VOICEVOX_CORE_ASSET_NAME}"/* core
     rm -rf $VOICEVOX_CORE_ASSET_NAME
     rm "./${VOICEVOX_CORE_ASSET_NAME}.zip"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,8 @@ RUN <<EOF
     mv "./core/libcore.so" /opt/voicevox_core/
 
     # Move documents to /opt/voicevox_core/
+    # TODO: add README into /opt/voicevox_core
+    # mv ./core/README.txt ./core/VERSION /opt/voicevox_core/
     mv ./core/VERSION /opt/voicevox_core/
 
     rm -rf ./core
@@ -248,6 +250,9 @@ EOF
 COPY --chmod=775 <<EOF /entrypoint.sh
 #!/bin/bash
 set -eux
+
+# TODO: Display README for engine (remember to add README into /opt/voicevox_core)
+# cat /opt/voicevox_core/README.txt > /dev/stderr
 
 exec "\$@"
 EOF

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,9 +27,12 @@ RUN <<EOF
     set -eux
 
     # Download Core
-    wget -nv --show-progress -c -O "./core.zip" "https://github.com/VOICEVOX/voicevox_core/releases/download/${VOICEVOX_CORE_VERSION}/${VOICEVOX_CORE_ASSET_NAME}.zip"
-    unzip "./core.zip"
-    rm ./core.zip
+    wget -nv --show-progress -c -O "./${VOICEVOX_CORE_ASSET_NAME}.zip" "https://github.com/VOICEVOX/voicevox_core/releases/download/${VOICEVOX_CORE_VERSION}/${VOICEVOX_CORE_ASSET_NAME}.zip"
+    unzip "./${VOICEVOX_CORE_ASSET_NAME}.zip"
+    mkdir -p core
+    mv "${VOICEVOX_CORE_ASSET_NAME}/*" core
+    rm -rf $VOICEVOX_CORE_ASSET_NAME
+    rm "./${VOICEVOX_CORE_ASSET_NAME}.zip"
 
     # Move Core Library to /opt/voicevox_core/
     mkdir /opt/voicevox_core

--- a/Dockerfile
+++ b/Dockerfile
@@ -249,8 +249,6 @@ COPY --chmod=775 <<EOF /entrypoint.sh
 #!/bin/bash
 set -eux
 
-cat /opt/voicevox_core/README.txt > /dev/stderr
-
 exec "\$@"
 EOF
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,8 +39,6 @@ RUN <<EOF
     mv "./core/libcore.so" /opt/voicevox_core/
 
     # Move documents to /opt/voicevox_core/
-    # TODO: add README into /opt/voicevox_core
-    # mv ./core/README.txt ./core/VERSION /opt/voicevox_core/
     mv ./core/VERSION /opt/voicevox_core/
 
     rm -rf ./core
@@ -251,7 +249,7 @@ COPY --chmod=775 <<EOF /entrypoint.sh
 #!/bin/bash
 set -eux
 
-# TODO: Display README for engine (remember to add README into /opt/voicevox_core)
+# TODO: Display README for engine
 # cat /opt/voicevox_core/README.txt > /dev/stderr
 
 exec "\$@"

--- a/README.md
+++ b/README.md
@@ -457,8 +457,6 @@ python -m nuitka \
     --include-data-file=default.csv=./ \
     --include-data-file=C:/path/to/cuda/*.dll=./ \
     --include-data-file=C:/path/to/onnxruntime/lib/*.dll=./ \
-    --include-data-file=C:/音声ライブラリへのパス/*.bin=./ \
-    --include-data-file=C:/音声ライブラリへのパス/metas.json=./ \
     --include-data-dir=.venv/Lib/site-packages/_soundfile_data=./_soundfile_data \
     --include-data-dir=speaker_info=./speaker_info \
     --msvc=14.2 \

--- a/voicevox_engine/synthesis_engine/core_wrapper.py
+++ b/voicevox_engine/synthesis_engine/core_wrapper.py
@@ -292,6 +292,7 @@ def check_core_type(core_dir: Path) -> Optional[str]:
 def load_core(core_dir: Path, use_gpu: bool) -> CDLL:
     if is_version_0_12_core_or_later(core_dir):
         try:
+            # NOTE: CDLL クラスのコンストラクタの引数 name には文字列を渡す必要がある
             return CDLL(
                 str((core_dir / CORENAME_DICT[platform.system()]).resolve(strict=True))
             )

--- a/voicevox_engine/synthesis_engine/core_wrapper.py
+++ b/voicevox_engine/synthesis_engine/core_wrapper.py
@@ -292,7 +292,9 @@ def check_core_type(core_dir: Path) -> Optional[str]:
 def load_core(core_dir: Path, use_gpu: bool) -> CDLL:
     if is_version_0_12_core_or_later(core_dir):
         try:
-            return CDLL(str((core_dir / CORENAME_DICT[platform.system()]).resolve(strict=True)))
+            return CDLL(
+                str((core_dir / CORENAME_DICT[platform.system()]).resolve(strict=True))
+            )
         except OSError as err:
             raise RuntimeError(f"コアの読み込みに失敗しました：{err}")
 

--- a/voicevox_engine/synthesis_engine/core_wrapper.py
+++ b/voicevox_engine/synthesis_engine/core_wrapper.py
@@ -292,7 +292,8 @@ def check_core_type(core_dir: Path) -> Optional[str]:
 def load_core(core_dir: Path, use_gpu: bool) -> CDLL:
     if is_version_0_12_core_or_later(core_dir):
         try:
-            # NOTE: CDLL クラスのコンストラクタの引数 name には文字列を渡す必要がある
+            # NOTE: CDLL クラスのコンストラクタの引数 name には文字列を渡す必要がある。
+            #       Windows 環境では PathLike オブジェクトを引数として渡すと初期化に失敗する。
             return CDLL(
                 str((core_dir / CORENAME_DICT[platform.system()]).resolve(strict=True))
             )

--- a/voicevox_engine/synthesis_engine/core_wrapper.py
+++ b/voicevox_engine/synthesis_engine/core_wrapper.py
@@ -292,7 +292,7 @@ def check_core_type(core_dir: Path) -> Optional[str]:
 def load_core(core_dir: Path, use_gpu: bool) -> CDLL:
     if is_version_0_12_core_or_later(core_dir):
         try:
-            return CDLL((core_dir / CORENAME_DICT[platform.system()]).resolve(True))
+            return CDLL(str((core_dir / CORENAME_DICT[platform.system()]).resolve(strict=True)))
         except OSError as err:
             raise RuntimeError(f"コアの読み込みに失敗しました：{err}")
 


### PR DESCRIPTION
## 内容

タイトルの通りです。

コアのバージョン `0.12.0-preview.2`, `0.12.0-preview.3` で以下の変更が加えられました：

- voicevox_core リポジトリで提供されている、バイナリを含む zip ファイルがアーキテクチャごとに分かれるようになった
- 共有ライブラリの名称が全てのアーキテクチャで統一 (Windows: `core.dll`, Linux: `libcore.so`, macOS: `libcore.dylib`) されるようになった
- `metas.json` やモデルファイルが共有ライブラリに埋め込まれるようになった

これらの変更に対応します。

テストリリースはこちらです: https://github.com/PickledChair/voicevox_engine/releases/tag/0.12.3-pickledchair-preview.6

## 関連 Issue

close #396 
