### PR TITLE
READMEのコマンド例を実行可能な形に修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ curl -s \
     -H "Content-Type: application/json" \
     -X POST \
     -d @query.json \
-    localhost:50021/synthesis?speaker=1 \
+    "localhost:50021/synthesis?speaker=1" \
     > audio.wav
 ```
 
@@ -88,7 +88,7 @@ curl -s \
     -H "Content-Type: application/json" \
     -X POST \
     -d @newquery.json \
-    localhost:50021/synthesis?speaker=1 \
+    "localhost:50021/synthesis?speaker=1" \
     > audio.wav
 ```
 


### PR DESCRIPTION
## 内容

READMEに記載されているコマンド例がそのままだと正常に実行できない箇所があったため、修正しました。
`curl`コマンドを投げる際、クエリパラメータを含む場合はURL部分をダブルクォーテーションで囲まないとコマンドを正しく解釈できないようです。
(ダブルクォーテーションがついてないのは2箇所のみで、他の部分については問題ありませんでした。)

- エラー例
```
$ curl -s -H "Content-Type: application/json" -X POST -d @query.json localhost:50021/synthesis?speaker=1 > audio.wav
zsh: no matches found: localhost:50021/synthesis?speaker=1
```

## 関連 Issue

なし

## スクリーンショット・動画など

なし

## その他
