### PR TITLE
Word typesを日本語じゃなくす

### DIFF
--- a/run.py
+++ b/run.py
@@ -720,8 +720,8 @@ def generate_app(
             言葉の発音（カタカナ）
         accent_type: int
             アクセント型（音が下がる場所を指す）
-        word_type: str, optional
-            固有名詞、普通名詞、動詞、形容詞、語尾のいずれか
+        word_type: WordTypes, optional
+            PROPER_NOUN（固有名詞）、COMMON_NOUN（普通名詞）、VERB（動詞）、ADJECTIVE（形容詞）、SUFFIX（語尾）のいずれか
         priority: int, optional
             単語の優先度（0から10までの整数）
             数字が大きいほど優先度が高くなる
@@ -764,8 +764,8 @@ def generate_app(
             アクセント型（音が下がる場所を指す）
         word_uuid: str
             更新する言葉のUUID
-        word_type: str, optional
-            固有名詞、普通名詞、動詞、形容詞、語尾のいずれか
+        word_type: WordTypes, optional
+            PROPER_NOUN（固有名詞）、COMMON_NOUN（普通名詞）、VERB（動詞）、ADJECTIVE（形容詞）、SUFFIX（語尾）のいずれか
         priority: int, optional
             単語の優先度（0から10までの整数）
             数字が大きいほど優先度が高くなる

--- a/test/test_user_dict.py
+++ b/test/test_user_dict.py
@@ -8,7 +8,7 @@ from unittest import TestCase
 from fastapi import HTTPException
 from pyopenjtalk import unset_user_dict
 
-from voicevox_engine.model import UserDictWord
+from voicevox_engine.model import UserDictWord, WordTypes
 from voicevox_engine.part_of_speech_data import MAX_PRIORITY, part_of_speech_data
 from voicevox_engine.user_dict import (
     apply_word,
@@ -23,7 +23,7 @@ from voicevox_engine.user_dict import (
 valid_dict_dict_json = {
     "aab7dda2-0d97-43c8-8cb7-3f440dab9b4e": {
         "surface": "ｔｅｓｔ",
-        "cost": part_of_speech_data["固有名詞"].cost_candidates[5],
+        "cost": part_of_speech_data[WordTypes.PROPER_NOUN].cost_candidates[5],
         "part_of_speech": "名詞",
         "part_of_speech_detail_1": "固有名詞",
         "part_of_speech_detail_2": "一般",

--- a/voicevox_engine/model.py
+++ b/voicevox_engine/model.py
@@ -253,11 +253,11 @@ class WordTypes(str, Enum):
     fastapiでword_type引数を検証する時に使用するクラス
     """
 
-    PROPER_NOUN = "固有名詞"
-    COMMON_NOUN = "普通名詞"
-    VERB = "動詞"
-    ADJECTIVE = "形容詞"
-    SUFFIX = "語尾"
+    PROPER_NOUN = "PROPER_NOUN"
+    COMMON_NOUN = "COMMON_NOUN"
+    VERB = "VERB"
+    ADJECTIVE = "ADJECTIVE"
+    SUFFIX = "SUFFIX"
 
 
 class SupportedDevicesInfo(BaseModel):

--- a/voicevox_engine/part_of_speech_data.py
+++ b/voicevox_engine/part_of_speech_data.py
@@ -1,12 +1,17 @@
 from typing import Dict
 
-from .model import USER_DICT_MAX_PRIORITY, USER_DICT_MIN_PRIORITY, PartOfSpeechDetail
+from .model import (
+    USER_DICT_MAX_PRIORITY,
+    USER_DICT_MIN_PRIORITY,
+    PartOfSpeechDetail,
+    WordTypes,
+)
 
 MIN_PRIORITY = USER_DICT_MIN_PRIORITY
 MAX_PRIORITY = USER_DICT_MAX_PRIORITY
 
-part_of_speech_data: Dict[str, PartOfSpeechDetail] = {
-    "固有名詞": PartOfSpeechDetail(
+part_of_speech_data: Dict[WordTypes, PartOfSpeechDetail] = {
+    WordTypes.PROPER_NOUN: PartOfSpeechDetail(
         part_of_speech="名詞",
         part_of_speech_detail_1="固有名詞",
         part_of_speech_detail_2="一般",
@@ -34,7 +39,7 @@ part_of_speech_data: Dict[str, PartOfSpeechDetail] = {
             "C5",
         ],
     ),
-    "普通名詞": PartOfSpeechDetail(
+    WordTypes.COMMON_NOUN: PartOfSpeechDetail(
         part_of_speech="名詞",
         part_of_speech_detail_1="一般",
         part_of_speech_detail_2="*",
@@ -62,7 +67,7 @@ part_of_speech_data: Dict[str, PartOfSpeechDetail] = {
             "C5",
         ],
     ),
-    "動詞": PartOfSpeechDetail(
+    WordTypes.VERB: PartOfSpeechDetail(
         part_of_speech="動詞",
         part_of_speech_detail_1="自立",
         part_of_speech_detail_2="*",
@@ -85,7 +90,7 @@ part_of_speech_data: Dict[str, PartOfSpeechDetail] = {
             "*",
         ],
     ),
-    "形容詞": PartOfSpeechDetail(
+    WordTypes.ADJECTIVE: PartOfSpeechDetail(
         part_of_speech="形容詞",
         part_of_speech_detail_1="自立",
         part_of_speech_detail_2="*",
@@ -108,7 +113,7 @@ part_of_speech_data: Dict[str, PartOfSpeechDetail] = {
             "*",
         ],
     ),
-    "語尾": PartOfSpeechDetail(
+    WordTypes.SUFFIX: PartOfSpeechDetail(
         part_of_speech="名詞",
         part_of_speech_detail_1="接尾",
         part_of_speech_detail_2="一般",

--- a/voicevox_engine/user_dict.py
+++ b/voicevox_engine/user_dict.py
@@ -11,7 +11,7 @@ from appdirs import user_data_dir
 from fastapi import HTTPException
 from pydantic import conint
 
-from .model import UserDictWord
+from .model import UserDictWord, WordTypes
 from .part_of_speech_data import MAX_PRIORITY, MIN_PRIORITY, part_of_speech_data
 from .utility import engine_root
 
@@ -118,7 +118,9 @@ def read_dict(user_dict_path: Path = user_dict_path) -> Dict[str, UserDictWord]:
             # 0.12以前の辞書は、context_idがハードコーディングされていたためにユーザー辞書内に保管されていない
             # ハードコーディングされていたcontext_idは固有名詞を意味するものなので、固有名詞のcontext_idを補完する
             if word.get("context_id") is None:
-                word["context_id"] = part_of_speech_data["固有名詞"].context_id
+                word["context_id"] = part_of_speech_data[
+                    WordTypes.PROPER_NOUN
+                ].context_id
             word["priority"] = cost2priority(word["context_id"], word["cost"])
             del word["cost"]
             result[str(UUID(word_uuid))] = UserDictWord(**word)
@@ -130,11 +132,11 @@ def create_word(
     surface: str,
     pronunciation: str,
     accent_type: int,
-    word_type: Optional[str] = None,
+    word_type: Optional[WordTypes] = None,
     priority: Optional[int] = None,
 ) -> UserDictWord:
     if word_type is None:
-        word_type = "固有名詞"
+        word_type = WordTypes.PROPER_NOUN
     if word_type not in part_of_speech_data.keys():
         raise HTTPException(status_code=422, detail="不明な品詞です")
     if priority is None:
@@ -164,7 +166,7 @@ def apply_word(
     surface: str,
     pronunciation: str,
     accent_type: int,
-    word_type: Optional[str] = None,
+    word_type: Optional[WordTypes] = None,
     priority: Optional[int] = None,
     user_dict_path: Path = user_dict_path,
     compiled_dict_path: Path = compiled_dict_path,
@@ -189,7 +191,7 @@ def rewrite_word(
     surface: str,
     pronunciation: str,
     accent_type: int,
-    word_type: Optional[str] = None,
+    word_type: Optional[WordTypes] = None,
     priority: Optional[int] = None,
     user_dict_path: Path = user_dict_path,
     compiled_dict_path: Path = compiled_dict_path,


### PR DESCRIPTION
## 内容

WordTypesのEnumのobjectが日本語だったのですが、openapiが日本語変数にしようとし、デフォルト設定ではエディタ側でコードがちゃんと自動生成できませんでした。
（日本語変数になるべき部分が空欄になるので構文エラーになる）

コード自動生成時に`allowUnicodeIdentifiers`を指定すると日本語変数もできました。
https://github.com/OpenAPITools/openapi-generator/blob/master/docs/generators/typescript-fetch.md

でもこれを指定すると、なぜかAPI用のメソッドがtags名に従ったinterface名の下にできるようになってしまいました。
こんな感じです。
![image](https://user-images.githubusercontent.com/4987327/170877293-e33574bf-091a-4c37-890b-44271240c857.png)

別にこれでも日本語名interfaceを使えばいいのですが、エンジンのメソッドを呼ぶための型パズルも修正する必要があり、影響範囲が大きいと感じたので、Enumの方を日本語じゃなくするようにしました。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他

たぶん @takana-v さんの実装部分で、日本語Enumのほうが僕も好きなのですが、エディタ側の理由で変更しちゃってもいいでしょうか･･･。
