### PR TITLE
毎回デフォルト辞書をコンパイルするように変更

### DIFF
--- a/voicevox_engine/user_dict.py
+++ b/voicevox_engine/user_dict.py
@@ -45,11 +45,10 @@ def user_dict_startup_processing(
     default_dict_path: Path = default_dict_path,
     compiled_dict_path: Path = compiled_dict_path,
 ):
-    if not compiled_dict_path.is_file():
-        pyopenjtalk.create_user_dict(
-            str(default_dict_path.resolve(strict=True)),
-            str(compiled_dict_path.resolve()),
-        )
+    pyopenjtalk.create_user_dict(
+        str(default_dict_path.resolve(strict=True)),
+        str(compiled_dict_path.resolve()),
+    )
     pyopenjtalk.set_user_dict(str(compiled_dict_path.resolve(strict=True)))
 
 


### PR DESCRIPTION
## 内容

題の通り

## 関連 Issue

- #421 

close #421

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他

手元の環境では、辞書のコンパイルには0.003秒ほどしかかからなかったので影響は少ないかと思います。