### PR TITLE
コード署名する

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,17 @@ on:
     types:
       - created
   workflow_dispatch:
+    inputs:
+      version:
+        description: "バージョン情報（A.BB.C / A.BB.C-preview.D）"
+        required: true
+      prerelease:
+        description: "プレリリースかどうか"
+        type: boolean
+        default: true
+      code_signing:
+        description: "コード署名する"
+        type: boolean
 
 env:
   IMAGE_NAME: ${{ secrets.DOCKERHUB_USERNAME }}/voicevox_engine
@@ -14,8 +25,8 @@ env:
   VOICEVOX_RESOURCE_VERSION: "0.13.0-preview.2"
   VOICEVOX_CORE_VERSION: "0.12.2"
   VOICEVOX_ENGINE_VERSION:
-    |- # releaseのときはタグが、それ以外はlatestがバージョン名に
-    ${{ github.event.release.tag_name != '' && github.event.release.tag_name || 'latest' }}
+    |- # releaseタグ名か、workflow_dispatchでのバージョン名か、latestが入る
+    ${{ github.event.release.tag_name || github.event.inputs.version || 'latest' }}
 
 jobs:
   # Build Mac binary (x64 arch only)
@@ -798,6 +809,15 @@ jobs:
           # pysoundfile
           ln -sf "${{ env.PYTHON_SITE_PACKAGES_DIR }}/_soundfile_data" artifact/
 
+      - name: Code signing
+        if: github.event.inputs.code_signing
+        shell: bash
+        run: |
+          bash build_util/codesign.bash "artifact/run.exe"
+        env:
+          CERT_BASE64: ${{ secrets.CERT_BASE64 }}
+          CERT_PASSWORD: ${{ secrets.CERT_PASSWORD }}
+
       # FIXME: versioned name may be useful; but
       # actions/download-artifact and dawidd6/download-artifact do not support
       # wildcard / forward-matching yet.
@@ -855,6 +875,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ github.ref }} # == github.event.release.tag_name
+          prelease: ${{ github.event.inputs.prerelease }}
           file_glob: true
           file: ${{ matrix.artifact_name }}.7z.*
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -400,6 +400,7 @@ jobs:
           path: build/run.dist/
 
   build-windows:
+    environment: ${{ github.event.inputs.code_signing && 'code_signing' }} # コード署名用のenvironment
     strategy:
       matrix:
         include:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -842,7 +842,7 @@ jobs:
             artifact/
 
   upload-to-release:
-    if: env.VOICEVOX_ENGINE_VERSION != 'latest'
+    if: (github.event.release.tag_name || github.event.inputs.version) != ''
     needs: [build-mac, build-linux, build-windows]
     runs-on: ubuntu-latest
     strategy:
@@ -888,7 +888,7 @@ jobs:
           file: ${{ matrix.artifact_name }}.7z.*
 
   run-release-test-workflow:
-    if: env.VOICEVOX_ENGINE_VERSION != 'latest'
+    if: (github.event.release.tag_name || github.event.inputs.version) != ''
     needs: [upload-to-release]
     uses: ./.github/workflows/release-test.yml
     with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -876,7 +876,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ env.VOICEVOX_ENGINE_VERSION }}
-          prelease: ${{ github.event.inputs.prerelease }}
+          prerelease: ${{ github.event.inputs.prerelease }}
           file_glob: true
           file: ${{ matrix.artifact_name }}.7z.*
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -819,13 +819,6 @@ jobs:
           CERT_BASE64: ${{ secrets.CERT_BASE64 }}
           CERT_PASSWORD: ${{ secrets.CERT_PASSWORD }}
 
-        # ブランチのデフォルト戻した？？？
-        # ブランチのデフォルト戻した？？？
-        # ブランチのデフォルト戻した？？？
-        # ブランチのデフォルト戻した？？？
-        # ブランチのデフォルト戻した？？？
-        # ブランチのデフォルト戻した？？？
-
       # FIXME: versioned name may be useful; but
       # actions/download-artifact and dawidd6/download-artifact do not support
       # wildcard / forward-matching yet.
@@ -892,5 +885,5 @@ jobs:
     needs: [upload-to-release]
     uses: ./.github/workflows/release-test.yml
     with:
-      version: ${{ github.event.release.tag_name || github.event.inputs.version }}
+      version: ${{ github.event.release.tag_name || github.event.inputs.version }} # env.VOICEVOX_ENGINE_VERSIONが使えない
       repo_url: ${{ format('{0}/{1}', github.server_url, github.repository) }} # このリポジトリのURL

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -250,7 +250,7 @@ jobs:
       - uses: actions/upload-artifact@v2
         # env:
         #   VERSIONED_ARTIFACT_NAME: |
-        #     ${{ format('{0}-{1}', matrix.artifact_name, (github.event.release.tag_name != '' && github.event.release.tag_name) || github.sha) }}
+        #     ${{ format('{0}-{1}', matrix.artifact_name, (env.VOICEVOX_ENGINE_VERSION != 'latest' && env.VOICEVOX_ENGINE_VERSION) || github.sha) }}
         with:
           name: ${{ matrix.artifact_name }}
           path: build/run.dist/
@@ -394,7 +394,7 @@ jobs:
       - uses: actions/upload-artifact@v2
         # env:
         #   VERSIONED_ARTIFACT_NAME: |
-        #     ${{ format('{0}-{1}', matrix.artifact_name, (github.event.release.tag_name != '' && github.event.release.tag_name) || github.sha) }}
+        #     ${{ format('{0}-{1}', matrix.artifact_name, (env.VOICEVOX_ENGINE_VERSION != 'latest' && env.VOICEVOX_ENGINE_VERSION) || github.sha) }}
         with:
           name: ${{ matrix.artifact_name }}
           path: build/run.dist/
@@ -819,6 +819,13 @@ jobs:
           CERT_BASE64: ${{ secrets.CERT_BASE64 }}
           CERT_PASSWORD: ${{ secrets.CERT_PASSWORD }}
 
+        # ブランチのデフォルト戻した？？？
+        # ブランチのデフォルト戻した？？？
+        # ブランチのデフォルト戻した？？？
+        # ブランチのデフォルト戻した？？？
+        # ブランチのデフォルト戻した？？？
+        # ブランチのデフォルト戻した？？？
+
       # FIXME: versioned name may be useful; but
       # actions/download-artifact and dawidd6/download-artifact do not support
       # wildcard / forward-matching yet.
@@ -828,14 +835,14 @@ jobs:
       - uses: actions/upload-artifact@v2
         # env:
         #   VERSIONED_ARTIFACT_NAME: |
-        #     ${{ format('{0}-{1}', matrix.artifact_name, (github.event.release.tag_name != '' && github.event.release.tag_name) || github.sha) }}
+        #     ${{ format('{0}-{1}', matrix.artifact_name, (env.VOICEVOX_ENGINE_VERSION != 'latest' && env.VOICEVOX_ENGINE_VERSION) || github.sha) }}
         with:
           name: ${{ matrix.artifact_name }}
           path: |
             artifact/
 
   upload-to-release:
-    if: github.event.release.tag_name != ''
+    if: env.VOICEVOX_ENGINE_VERSION != 'latest'
     needs: [build-mac, build-linux, build-windows]
     runs-on: ubuntu-latest
     strategy:
@@ -875,15 +882,15 @@ jobs:
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ github.ref }} # == github.event.release.tag_name
+          tag: ${{ env.VOICEVOX_ENGINE_VERSION }}
           prelease: ${{ github.event.inputs.prerelease }}
           file_glob: true
           file: ${{ matrix.artifact_name }}.7z.*
 
   run-release-test-workflow:
-    if: github.event.release.tag_name != ''
+    if: env.VOICEVOX_ENGINE_VERSION != 'latest'
     needs: [upload-to-release]
     uses: ./.github/workflows/release-test.yml
     with:
-      version: ${{ github.event.release.tag_name }}
+      version: ${{ env.VOICEVOX_ENGINE_VERSION }}
       repo_url: ${{ format('{0}/{1}', github.server_url, github.repository) }} # このリポジトリのURL

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -892,5 +892,5 @@ jobs:
     needs: [upload-to-release]
     uses: ./.github/workflows/release-test.yml
     with:
-      version: ${{ env.VOICEVOX_ENGINE_VERSION }}
+      version: ${{ github.event.release.tag_name || github.event.inputs.version }}
       repo_url: ${{ format('{0}/{1}', github.server_url, github.repository) }} # このリポジトリのURL

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -400,7 +400,7 @@ jobs:
           path: build/run.dist/
 
   build-windows:
-    environment: ${{ github.event.inputs.code_signing == 'true' && 'code_signing' }} # コード署名用のenvironment（false時の挙動は2022年7月10日時点で未定義動作）
+    environment: ${{ github.event.inputs.code_signing == 'true' && 'code_signing' }} # コード署名用のenvironment
     strategy:
       matrix:
         include:
@@ -876,7 +876,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ env.VOICEVOX_ENGINE_VERSION }}
-          prerelease: ${{ github.event.inputs.prerelease }}
+          prelease: ${{ github.event.inputs.prerelease }}
           file_glob: true
           file: ${{ matrix.artifact_name }}.7z.*
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -811,7 +811,7 @@ jobs:
           ln -sf "${{ env.PYTHON_SITE_PACKAGES_DIR }}/_soundfile_data" artifact/
 
       - name: Code signing
-        if: github.event.inputs.code_signing
+        if: github.event.inputs.code_signing == 'true'
         shell: bash
         run: |
           bash build_util/codesign.bash "artifact/run.exe"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -400,7 +400,7 @@ jobs:
           path: build/run.dist/
 
   build-windows:
-    environment: ${{ github.event.inputs.code_signing == 'true' && 'code_signing' }} # コード署名用のenvironment
+    environment: ${{ github.event.inputs.code_signing == 'true' && 'code_signing' }} # コード署名用のenvironment（false時の挙動は2022年7月10日時点で未定義動作）
     strategy:
       matrix:
         include:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -400,7 +400,7 @@ jobs:
           path: build/run.dist/
 
   build-windows:
-    environment: ${{ github.event.inputs.code_signing && 'code_signing' }} # コード署名用のenvironment
+    environment: ${{ github.event.inputs.code_signing == 'true' && 'code_signing' }} # コード署名用のenvironment
     strategy:
       matrix:
         include:

--- a/build_util/codesign.bash
+++ b/build_util/codesign.bash
@@ -1,0 +1,49 @@
+# !!! コードサイニング証明書を取り扱うので取り扱い注意 !!!
+
+set -eu
+
+if [ -v "${CERT_BASE64}" ]; then
+    echo "CERT_BASE64が未定義です"
+    exit 1
+fi
+if [ -v "${CERT_PASSWORD}" ]; then
+    echo "CERT_PASSWORDが未定義です"
+    exit 1
+fi
+
+if [ $# -ne 1 ]; then
+    echo "引数の数が一致しません"
+    exit 1
+fi
+target_file_glob="$1"
+
+# 証明書
+CERT_PATH=cert.pfx
+echo -n "$CERT_BASE64" | base64 -d - > $CERT_PATH
+
+# 指定ファイルに署名する
+function codesign() {
+    TARGET="$1"
+    SIGNTOOL=$(find "C:/Program Files (x86)/Windows Kits/10/App Certification Kit" -name "signtool.exe" | sort -V | tail -n 1)
+    powershell "& '$SIGNTOOL' sign /fd SHA256 /td SHA256 /tr http://timestamp.digicert.com /f $CERT_PATH /p $CERT_PASSWORD '$TARGET'"
+}
+
+# 指定ファイルが署名されているか
+function is_signed() {
+    TARGET="$1"
+    SIGNTOOL=$(find "C:/Program Files (x86)/Windows Kits/10/App Certification Kit" -name "signtool.exe" | sort -V | tail -n 1)
+    powershell "& '$SIGNTOOL' verify /pa '$TARGET'" || return 1
+}
+
+# 署名されていなければ署名
+ls $target_file_glob | while read target_file; do
+    if is_signed "$target_file"; then
+        echo "署名済み: $target_file"
+    else
+        echo "署名: $target_file"
+        codesign "$target_file"
+    fi
+done
+
+# 証明書を消去
+rm $CERT_PATH


### PR DESCRIPTION
## 内容

run.exeをコード署名します。

証明書.pfxファイルをbase64エンコードしたものをsecret.CERT_BASE64に登録し、
証明書のパスワードをsecret.CERT_PASSWORDに登録して、
workflow_dispatchで「コード署名する」にチェックを入れてbuild.ymlを起動すれば、
core.dllが署名されます。

もしくはcode_signingenvironmentを作成し、同様にCERT_BASE64とCERT_PASSWORDを登録して実行しても署名できます。
（こちらのフローは、OSSリポジトリ上でビルドする場合を想定しています。）

「コード署名する」にチェックを入れずにビルドしたり、releaseを作ってビルドした場合は署名用のコードが実行されないので、メンテナー以外の方は今まで通りにテストビルドができます。

## 関連 Issue

- https://github.com/VOICEVOX/voicevox_core/pull/164

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他

実際にこちらでビルドを試しています。

- https://github.com/Hiroshiba/voicevox_engine/actions/runs/2616784139

実際のビルド結果がこちらです。

https://github.com/Hiroshiba/voicevox_engine/releases/tag/check-code-sign