### PR TITLE
コマンドライン引数にhelpを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,12 @@ python -m pip install -r requirements.txt
 
 ## 実行
 
+コマンドライン引数の詳細は以下のコマンドで確認してください。
+
+```bash
+python run.py --help
+```
+
 ```bash
 # 製品版 VOICEVOX でサーバーを起動
 VOICEVOX_DIR="C:/path/to/voicevox" # 製品版 VOICEVOX ディレクトリのパス

--- a/run.py
+++ b/run.py
@@ -832,7 +832,8 @@ if __name__ == "__main__":
         "--cpu_num_threads",
         type=int,
         default=os.getenv("VV_CPU_NUM_THREADS") or None,
-        help="音声合成を行うスレッド数です。指定しないと、代わりに環境変数VV_CPU_NUM_THREADSの値が使われます。VV_CPU_NUM_THREADSに値がなかった、または数値でなかった場合はエラー終了します。",
+        help="音声合成を行うスレッド数です。指定しないと、代わりに環境変数VV_CPU_NUM_THREADSの値が使われます。"
+        "VV_CPU_NUM_THREADSに値がなかった、または数値でなかった場合はエラー終了します。",
     )
 
     args = parser.parse_args()

--- a/run.py
+++ b/run.py
@@ -785,23 +785,54 @@ def generate_app(
 
 if __name__ == "__main__":
     multiprocessing.freeze_support()
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--host", type=str, default="127.0.0.1")
-    parser.add_argument("--port", type=int, default=50021)
-    parser.add_argument("--use_gpu", action="store_true")
-    parser.add_argument("--voicevox_dir", type=Path, default=None)
-    parser.add_argument("--voicelib_dir", type=Path, default=None, action="append")
-    parser.add_argument("--runtime_dir", type=Path, default=None, action="append")
-    parser.add_argument("--enable_mock", action="store_true")
-    parser.add_argument("--enable_cancellable_synthesis", action="store_true")
+    parser = argparse.ArgumentParser(description="VOICEVOX のエンジンです。")
+    parser.add_argument(
+        "--host", type=str, default="127.0.0.1", help="接続を受け付けるホストアドレスです。"
+    )
+    parser.add_argument("--port", type=int, default=50021, help="接続を受け付けるポート番号です。")
+    parser.add_argument(
+        "--use_gpu", action="store_true", help="指定するとGPUを使って音声合成するようになります。"
+    )
+    parser.add_argument(
+        "--voicevox_dir", type=Path, default=None, help="VOICEVOXのディレクトリパスです。"
+    )
+    parser.add_argument(
+        "--voicelib_dir",
+        type=Path,
+        default=None,
+        action="append",
+        help="VOICEVOX COREのディレクトリパスです。",
+    )
+    parser.add_argument(
+        "--runtime_dir",
+        type=Path,
+        default=None,
+        action="append",
+        help="VOICEVOX COREで使用するライブラリのディレクトリパスです。",
+    )
+    parser.add_argument(
+        "--enable_mock",
+        action="store_true",
+        help="指定するとVOICEVOX COREを使わずモックで音声合成を行います。",
+    )
+    parser.add_argument(
+        "--enable_cancellable_synthesis",
+        action="store_true",
+        help="指定すると音声合成を途中でキャンセルできるようになります。",
+    )
     parser.add_argument("--init_processes", type=int, default=2)
-    parser.add_argument("--load_all_models", action="store_true")
+    parser.add_argument(
+        "--load_all_models", action="store_true", help="指定すると起動時に全ての音声合成モデルを読み込みます。"
+    )
 
     # 引数へcpu_num_threadsの指定がなければ、環境変数をロールします。
     # 環境変数にもない場合は、Noneのままとします。
     # VV_CPU_NUM_THREADSが空文字列でなく数値でもない場合、エラー終了します。
     parser.add_argument(
-        "--cpu_num_threads", type=int, default=os.getenv("VV_CPU_NUM_THREADS") or None
+        "--cpu_num_threads",
+        type=int,
+        default=os.getenv("VV_CPU_NUM_THREADS") or None,
+        help="音声合成を行うスレッド数です。指定しないと、代わりに環境変数VV_CPU_NUM_THREADSの値が使われます。VV_CPU_NUM_THREADSに値がなかった、または数値でなかった場合はエラー終了します。",
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
## 内容

コマンドライン引数に説明を追加しました。
また、このことを`README.md`に追記しました。

## 関連 Issue

close #411 

## スクリーンショット・動画など

```
$ python run.py --help
usage: run.py [-h] [--host HOST] [--port PORT] [--use_gpu]
              [--voicevox_dir VOICEVOX_DIR] [--voicelib_dir VOICELIB_DIR]
              [--runtime_dir RUNTIME_DIR] [--enable_mock]
              [--enable_cancellable_synthesis]
              [--init_processes INIT_PROCESSES] [--load_all_models]
              [--cpu_num_threads CPU_NUM_THREADS]

VOICEVOX のエンジンです。

optional arguments:
  -h, --help            show this help message and exit
  --host HOST           接続を受け付けるホストアドレスです。
  --port PORT           接続を受け付けるポート番号です。
  --use_gpu             指定するとGPUを使って音声合成するようになります。
  --voicevox_dir VOICEVOX_DIR
                        VOICEVOXのディレクトリパスです。
  --voicelib_dir VOICELIB_DIR
                        VOICEVOX COREのディレクトリパスです。
  --runtime_dir RUNTIME_DIR
                        VOICEVOX COREで使用するライブラリのディレクトリパスです。
  --enable_mock         指定するとVOICEVOX COREを使わずモックで音声合成を行います。
  --enable_cancellable_synthesis
                        指定すると音声合成を途中でキャンセルできるようになります。
  --init_processes INIT_PROCESSES
  --load_all_models     指定すると起動時に全ての音声合成モデルを読み込みます。
  --cpu_num_threads CPU_NUM_THREADS
                        音声合成を行うスレッド数です。指定しないと、代わりに環境変数VV_CPU_NUM_THREADSの値が使われ
                        ます。VV_CPU_NUM_THREADSに値がなかった、または数値でなかった場合はエラー終了します。
```

## その他

引数`init_processes`が使われていなかったため、何のためのものかわからず説明を付与できませんでした。
文面などに変更の必要があればお知らせいただければと思います。

`host`、`voicelib_dir`、`runtime_dir`あたりが分かりづらいのではないかと感じています。