### PR TITLE
マニフェストに能力を追加

### DIFF
--- a/engine_manifest.json
+++ b/engine_manifest.json
@@ -12,5 +12,42 @@
     "update_infos": "engine_manifest_assets/update_infos.json",
     "dependency_licenses": "engine_manifest_assets/dependency_licenses.json",
     "downloadable_libraries_path": null,
-    "downloadable_libraries_url": null
+    "downloadable_libraries_url": null,
+    "supported_features": {
+        "adjust_mora_pitch": {
+            "type": "bool",
+            "value": true,
+            "name": "モーラごとの音高の調整"
+        },
+        "adjust_phoneme_length": {
+            "type": "bool",
+            "value": true,
+            "name": "音素ごとの長さの調整"
+        },
+        "adjust_speed_scale": {
+            "type": "bool",
+            "value": true,
+            "name": "全体の話速の調整"
+        },
+        "adjust_pitch_scale": {
+            "type": "bool",
+            "value": true,
+            "name": "全体の音高の調整"
+        },
+        "adjust_intonation_scale": {
+            "type": "bool",
+            "value": true,
+            "name": "全体の抑揚の調整"
+        },
+        "adjust_volume_scale": {
+            "type": "bool",
+            "value": true,
+            "name": "全体の音量の調整"
+        },
+        "interrogative_upspeak": {
+            "type": "bool",
+            "value": true,
+            "name": "疑問文の自動調整"
+        }
+    }
 }

--- a/voicevox_engine/engine_manifest/EngineManifest.py
+++ b/voicevox_engine/engine_manifest/EngineManifest.py
@@ -24,6 +24,20 @@ class LicenseInfo(BaseModel):
     text: str = Field(title="依存ライブラリのライセンス本文")
 
 
+class SupportedFeatures(BaseModel):
+    """
+    エンジンが持つ機能の一覧
+    """
+
+    adjust_mora_pitch: bool = Field(title="モーラごとの音高の調整")
+    adjust_phoneme_length: bool = Field(title="音素ごとの長さの調整")
+    adjust_speed_scale: bool = Field(title="全体の話速の調整")
+    adjust_pitch_scale: bool = Field(title="全体の音高の調整")
+    adjust_intonation_scale: bool = Field(title="全体の抑揚の調整")
+    adjust_volume_scale: bool = Field(title="全体の音量の調整")
+    interrogative_upspeak: bool = Field(title="疑問文の自動調整")
+
+
 class EngineManifest(BaseModel):
     """
     エンジン自体に関する情報
@@ -44,3 +58,4 @@ class EngineManifest(BaseModel):
     downloadable_libraries_url: Optional[str] = Field(
         title="ダウンロード可能な音声ライブラリ情報を取得するためのAPIのURL"
     )
+    supported_features: SupportedFeatures = Field(title="エンジンが持つ機能")

--- a/voicevox_engine/engine_manifest/EngineManifestLoader.py
+++ b/voicevox_engine/engine_manifest/EngineManifestLoader.py
@@ -39,5 +39,9 @@ class EngineManifestLoader:
             ],
             downloadable_libraries_path=manifest["downloadable_libraries_path"],
             downloadable_libraries_url=manifest["downloadable_libraries_url"],
+            supported_features={
+                key: item["value"]
+                for key, item in manifest["supported_features"].items()
+            },
         )
         return manifest


### PR DESCRIPTION
## 内容

エンジンマニフェストに、エンジンが備えている能力の一覧を付け足しました。
また、APIでその能力一覧を返すようにしました。

## 関連 Issue

close #362 
