### PR TITLE
synthesisと_synthesis_implメソッドの戻り値の型を修正

### DIFF
--- a/voicevox_engine/synthesis_engine/synthesis_engine_base.py
+++ b/voicevox_engine/synthesis_engine/synthesis_engine_base.py
@@ -2,6 +2,8 @@ import copy
 from abc import ABCMeta, abstractmethod
 from typing import List, Optional
 
+import numpy as np
+
 from .. import full_context_label
 from ..full_context_label import extract_full_context_label
 from ..model import AccentPhrase, AudioQuery, Mora
@@ -208,7 +210,7 @@ class SynthesisEngineBase(metaclass=ABCMeta):
         query: AudioQuery,
         speaker_id: int,
         enable_interrogative_upspeak: bool = True,
-    ) -> str:
+    ) -> np.ndarray:
         """
         音声合成クエリ内の疑問文指定されたMoraを変形した後、
         継承先における実装`_synthesis_impl`を使い音声合成を行う
@@ -234,7 +236,7 @@ class SynthesisEngineBase(metaclass=ABCMeta):
         return self._synthesis_impl(query, speaker_id)
 
     @abstractmethod
-    def _synthesis_impl(self, query: AudioQuery, speaker_id: int):
+    def _synthesis_impl(self, query: AudioQuery, speaker_id: int) -> np.ndarray:
         """
         音声合成クエリから音声合成に必要な情報を構成し、実際に音声合成を行う
         Parameters


### PR DESCRIPTION
## 内容

`SynthesisEngineBase` の `synthesis` メソッドの戻り値の型が `str` になっているのを発見したので修正しました。

