### PR TITLE
code_signingがtrueじゃないとき「false」environmentを使おうとしてしまう問題を解決

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -370,7 +370,7 @@ jobs:
           path: build/run.dist/
 
   build-windows:
-    environment: ${{ github.event.inputs.code_signing == 'true' && 'code_signing' }} # コード署名用のenvironment
+    environment: ${{ github.event.inputs.code_signing == 'true' && 'code_signing' || '' }} # コード署名用のenvironment
     strategy:
       matrix:
         include:


### PR DESCRIPTION
## 内容

code_signingがtrueじゃないとき「false」environmentを使おうとしてしまう問題を解決を解決します。


## その他
