### PR TITLE
[PyInstaller] Linuxビルドがうまく動かない問題を修正

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,6 +94,13 @@ jobs:
         shell: bash
         run: brew install gnu-sed
 
+      # ONNX Runtime providersとCUDA周りをリンクするために使う
+      - name: Install patchelf
+        if: startsWith(matrix.os, 'ubuntu-') && endsWith(matrix.artifact_name, 'nvidia')
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y patchelf
+
       # Download CUDA
       - name: Prepare CUDA DLL cache
         if: matrix.cuda_version != ''
@@ -451,6 +458,7 @@ jobs:
           set -eux
 
           # ONNX Runtime providers (PyInstaller does not copy dynamic loaded libraries)
+          patchelf --set-rpath '$ORIGIN' "$(pwd)/download/onnxruntime/lib"/libonnxruntime_providers_*.so
           ln -sf "$(pwd)/download/onnxruntime/lib"/libonnxruntime_*.so dist/run.dist/
 
           # CUDA


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->
`libonnxruntime_providers_cuda.so`が`libcublas.so.8`などの共有ライブラリの依存を解決できず、Linuxで動かない場合があるようで、それを解決するために`patchelf`を使ってリンクするようにしました(同じディレクトリにある共有ライブラリをリンク対象とするように`rpath`を設定した)。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->
- https://github.com/VOICEVOX/voicevox_engine/issues/121#issuecomment-927200777

