### PR TITLE
ENH: 音声合成時と辞書更新時に作成される一時ファイルを始末する

### DIFF
--- a/run.py
+++ b/run.py
@@ -59,6 +59,7 @@ from voicevox_engine.user_dict import (
 from voicevox_engine.utility import (
     ConnectBase64WavesException,
     connect_base64_waves,
+    delete_file,
     engine_root,
 )
 
@@ -119,12 +120,6 @@ def generate_app(
         if core_version in synthesis_engines:
             return synthesis_engines[core_version]
         raise HTTPException(status_code=422, detail="不明なバージョンです")
-
-    def delete_file(file_path: str) -> None:
-        try:
-            os.remove(file_path)
-        except OSError:
-            traceback.print_exc()
 
     @app.post(
         "/audio_query",

--- a/voicevox_engine/user_dict.py
+++ b/voicevox_engine/user_dict.py
@@ -1,6 +1,8 @@
 import json
+import os
 import shutil
 import sys
+import traceback
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import Dict, List, Optional
@@ -96,6 +98,10 @@ def update_dict(
         str(Path(f.name).resolve(strict=True)),
         str(tmp_dict_path),
     )
+    try:
+        os.remove(f.name)
+    except OSError:
+        traceback.print_exc()
     if not tmp_dict_path.is_file():
         raise RuntimeError("辞書のコンパイル時にエラーが発生しました。")
     pyopenjtalk.unset_user_dict()

--- a/voicevox_engine/user_dict.py
+++ b/voicevox_engine/user_dict.py
@@ -1,8 +1,6 @@
 import json
-import os
 import shutil
 import sys
-import traceback
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import Dict, List, Optional
@@ -15,7 +13,7 @@ from pydantic import conint
 
 from .model import UserDictWord, WordTypes
 from .part_of_speech_data import MAX_PRIORITY, MIN_PRIORITY, part_of_speech_data
-from .utility import engine_root, get_save_dir
+from .utility import delete_file, engine_root, get_save_dir
 
 root_dir = engine_root()
 save_dir = get_save_dir()
@@ -98,10 +96,7 @@ def update_dict(
         str(Path(f.name).resolve(strict=True)),
         str(tmp_dict_path),
     )
-    try:
-        os.remove(f.name)
-    except OSError:
-        traceback.print_exc()
+    delete_file(f.name)
     if not tmp_dict_path.is_file():
         raise RuntimeError("辞書のコンパイル時にエラーが発生しました。")
     pyopenjtalk.unset_user_dict()

--- a/voicevox_engine/utility/__init__.py
+++ b/voicevox_engine/utility/__init__.py
@@ -3,12 +3,13 @@ from .connect_base64_waves import (
     connect_base64_waves,
     decode_base64_waves,
 )
-from .path_utility import engine_root, get_save_dir
+from .path_utility import delete_file, engine_root, get_save_dir
 
 __all__ = [
     "ConnectBase64WavesException",
     "connect_base64_waves",
     "decode_base64_waves",
+    "delete_file",
     "engine_root",
     "get_save_dir",
 ]

--- a/voicevox_engine/utility/path_utility.py
+++ b/voicevox_engine/utility/path_utility.py
@@ -1,4 +1,6 @@
+import os
 import sys
+import traceback
 from pathlib import Path
 
 from appdirs import user_data_dir
@@ -24,3 +26,10 @@ def get_save_dir():
     # FIXME: Windowsは`voicevox-engine/voicevox-engine`ディレクトリに保存されているので
     # `VOICEVOX/voicevox-engine`に変更する
     return Path(user_data_dir("voicevox-engine"))
+
+
+def delete_file(file_path: str) -> None:
+    try:
+        os.remove(file_path)
+    except OSError:
+        traceback.print_exc()


### PR DESCRIPTION
## 内容

音声合成時と辞書更新時に作成される一時ファイルが削除されずに放置されているとTwitterで見かけましたので始末するようにしました。

## その他

run.pyの追加した関数や引数周りの位置がこれでいいのか不安です。

Bacground TaskについてFastAPIのドキュメント
https://fastapi.tiangolo.com/tutorial/background-tasks/