### PR TITLE
新しいコアライブラリのファイル名に対応

### DIFF
--- a/voicevox_engine/synthesis_engine/core_wrapper.py
+++ b/voicevox_engine/synthesis_engine/core_wrapper.py
@@ -197,7 +197,9 @@ CORE_INFOS = [
 ]
 
 
-# version 0.12 以降のコアの名前
+# version 0.12 以降のコアの名前の辞書
+# - version 0.12, 0.13 のコアの名前: core
+# - version 0.14 からのコアの名前: voicevox_core
 CORENAME_DICT = {
     "Windows": ("voicevox_core.dll", "core.dll"),
     "Linux": ("libvoicevox_core.so", "libcore.so"),

--- a/voicevox_engine/synthesis_engine/core_wrapper.py
+++ b/voicevox_engine/synthesis_engine/core_wrapper.py
@@ -199,15 +199,17 @@ CORE_INFOS = [
 
 # version 0.12 以降のコアの名前
 CORENAME_DICT = {
-    "Windows": "core.dll",
-    "Linux": "libcore.so",
-    "Darwin": "libcore.dylib",
+    "Windows": ("voicevox_core.dll", "core.dll"),
+    "Linux": ("libvoicevox_core.so", "libcore.so"),
+    "Darwin": ("libvoicevox_core.dylib", "libcore.dylib"),
 }
 
 
-def is_version_0_12_core_or_later(core_dir: Path) -> bool:
+def find_version_0_12_core_or_later(core_dir: Path) -> Optional[str]:
     """
-    core_dir で指定したディレクトリにあるコアライブラリが Version 0.12 以降であるかどうかを返す。
+    core_dir で指定したディレクトリにあるコアライブラリが Version 0.12 以降である場合、
+    見つかった共有ライブラリの名前を返す。
+
     Version 0.12 以降と判定する条件は、
 
     - core_dir に metas.json が存在しない
@@ -216,10 +218,14 @@ def is_version_0_12_core_or_later(core_dir: Path) -> bool:
     の両方が真のときである。
     cf. https://github.com/VOICEVOX/voicevox_engine/issues/385
     """
-    return (
-        not (core_dir / "metas.json").exists()
-        and (core_dir / CORENAME_DICT[platform.system()]).is_file()
-    )
+    if (core_dir / "metas.json").exists():
+        return None
+
+    for core_name in CORENAME_DICT[platform.system()]:
+        if (core_dir / core_name).is_file():
+            return core_name
+
+    return None
 
 
 def get_arch_name() -> Optional[str]:
@@ -294,13 +300,12 @@ def check_core_type(core_dir: Path) -> Optional[str]:
 
 
 def load_core(core_dir: Path, use_gpu: bool) -> CDLL:
-    if is_version_0_12_core_or_later(core_dir):
+    core_name = find_version_0_12_core_or_later(core_dir)
+    if core_name:
         try:
             # NOTE: CDLL クラスのコンストラクタの引数 name には文字列を渡す必要がある。
             #       Windows 環境では PathLike オブジェクトを引数として渡すと初期化に失敗する。
-            return CDLL(
-                str((core_dir / CORENAME_DICT[platform.system()]).resolve(strict=True))
-            )
+            return CDLL(str((core_dir / core_name).resolve(strict=True)))
         except OSError as err:
             raise RuntimeError(f"コアの読み込みに失敗しました：{err}")
 
@@ -361,7 +366,10 @@ class CoreWrapper:
         self.exist_load_model = False
         self.exist_is_model_loaded = False
 
-        if is_version_0_12_core_or_later(core_dir):
+        is_version_0_12_core_or_later = (
+            find_version_0_12_core_or_later(core_dir) is not None
+        )
+        if is_version_0_12_core_or_later:
             model_type = "onnxruntime"
             self.exist_load_model = True
             self.exist_is_model_loaded = True
@@ -409,7 +417,7 @@ class CoreWrapper:
         cwd = os.getcwd()
         os.chdir(core_dir)
         try:
-            if is_version_0_12_core_or_later(core_dir):
+            if is_version_0_12_core_or_later:
                 if not self.core.initialize(use_gpu, cpu_num_threads, load_all_models):
                     raise Exception(self.core.last_error_message().decode("utf-8"))
             elif exist_cpu_num_threads:


### PR DESCRIPTION
## 内容

コアの https://github.com/VOICEVOX/voicevox_core/pull/256 の変更により、コアライブラリの名前が

- Windows: `core.dll` -> `voicevox_core.dll`
- Linux: `libcore.so` -> `libvoicevox_core.so`
- macOS: `libcore.dylib` -> `libvoicevox_core.dylib`

に変わったため、これに対応します。これまでの名前のコアライブラリも今まで通りロードできるようになっています。

#454 では VERSION ファイルを用いたバージョン判定について触れましたが、コアの API に互換性がある場合はそこまでやる必要がなさそうと判断したので未実装です。

## 関連 Issue

ref #454 

## その他

https://github.com/VOICEVOX/voicevox_core/pull/279 （これまでのコアの API との互換性を保つための変更）のテストに使えます