### PR TITLE
fix: エンジン起動時にデフォルト辞書に加えてユーザー辞書もコンパイルする

### DIFF
--- a/voicevox_engine/user_dict.py
+++ b/voicevox_engine/user_dict.py
@@ -49,6 +49,10 @@ def user_dict_startup_processing(
         str(compiled_dict_path.resolve()),
     )
     pyopenjtalk.set_user_dict(str(compiled_dict_path.resolve(strict=True)))
+    if user_dict_path.is_file():
+        update_dict(
+            default_dict_path=default_dict_path, compiled_dict_path=compiled_dict_path
+        )
 
 
 def update_dict(


### PR DESCRIPTION
## 内容

#423 でデフォルト辞書の更新に対応できるような変更が行われていますが、その際に、エンジン起動時に default.csv のみをソースとして辞書をコンパイルし直すようになりました（以下のコード）。この結果、ユーザーが前回までに追加した単語についての情報はエンジン起動時に user.dic からなくなってしまいます。そして、なんらかの単語の編集操作を行ったときに、`update_dict` 関数経由で初めて user_dict.json の情報を含んだ user.dic が作成されるので、その操作以降はユーザーが追加した単語を扱えるようになります。

https://github.com/VOICEVOX/voicevox_engine/blob/440b463770ac5be1e8573575ad4c1d4367a1b70c/voicevox_engine/user_dict.py#L43-L51

一方、以前は以下のようにコンパイル済み辞書があった場合は user.dic の再コンパイルが行われないようになっていたので、前回までにユーザーが情報を追加した状態の user.dic が残り、エンジン起動直後からユーザーが追加した情報を使えるようになっていました。

https://github.com/VOICEVOX/voicevox_engine/blob/6bcdc766c3b4c9c5a500eda21d560ce1aab32250/voicevox_engine/user_dict.py#L24-L33

後者の方が本来エンジンに期待する挙動と思われます。これを踏まえて、エンジン起動時に user_dict.json の内容も追加されるような修正を行いました。

## 関連 Issue

ref https://github.com/VOICEVOX/voicevox/issues/936
