### PR TITLE
ENH:ユーザー辞書のディレクトリを製品版と開発版で切り替える

### DIFF
--- a/voicevox_engine/utility/path_utility.py
+++ b/voicevox_engine/utility/path_utility.py
@@ -7,16 +7,12 @@ from appdirs import user_data_dir
 
 
 def engine_root() -> Path:
-    # nuitkaビルドをした際はグローバルに__compiled__が含まれる
-    if "__compiled__" in globals():
-        root_dir = Path(sys.argv[0]).parent
-
-    # pyinstallerでビルドをした際はsys.frozenが設定される
-    elif getattr(sys, "frozen", False):
-        root_dir = Path(sys.argv[0]).parent
-
-    else:
+    if is_development():
         root_dir = Path(__file__).parents[2]
+
+    # Nuitka/Pyinstallerでビルドされている場合
+    else:
+        root_dir = Path(sys.argv[0]).parent
 
     return root_dir.resolve(strict=True)
 

--- a/voicevox_engine/utility/path_utility.py
+++ b/voicevox_engine/utility/path_utility.py
@@ -21,11 +21,31 @@ def engine_root() -> Path:
     return root_dir.resolve(strict=True)
 
 
+def is_development() -> bool:
+    """
+    開発版かどうか判定する関数
+    Nuitka/Pyinstallerでコンパイルされていない場合は開発環境とする。
+    """
+    # nuitkaビルドをした際はグローバルに__compiled__が含まれる
+    if "__compiled__" in globals():
+        return False
+
+    # pyinstallerでビルドをした際はsys.frozenが設定される
+    elif getattr(sys, "frozen", False):
+        return False
+
+    return True
+
+
 def get_save_dir():
     # FIXME: ファイル保存場所をエンジン固有のIDが入ったものにする
     # FIXME: Windowsは`voicevox-engine/voicevox-engine`ディレクトリに保存されているので
     # `VOICEVOX/voicevox-engine`に変更する
-    return Path(user_data_dir("voicevox-engine"))
+    if is_development():
+        app_name = "voicevox-engine-dev"
+    else:
+        app_name = "voicevox-engine"
+    return Path(user_data_dir(app_name))
 
 
 def delete_file(file_path: str) -> None:


### PR DESCRIPTION
## 内容

ユーザー辞書のディレクトリを製品版と開発版で切り替える`get_save_dir()`の戻り値を製品版と開発版で切り替えるようにします。

## 関連 Issue

ref #472 

## その他

- 追加した`is_development()`関数の内容が`engine_root()`とほぼ同じですがこれでいいのか
- FIXMEの部分をどうするか
  とりあえず`VOICEVOX/voicevox-engine[-dev]`を返すコードも書いてみましたが…