### PR TITLE
FIX: Windowsでエディタのログが文字化けする問題への対策

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,25 @@ VOICEVOX ENGINE が使う処理能力を調節したい場合は、CPU スレッ
   python run.py --voicevox_dir=$VOICEVOX_DIR
   ```
 
+### ログのエンコーディングをUTF-8に指定する
+
+未指定の場合は環境によって自動選択されます。  
+自動選択が原因で文字化けが発生する場合はUTF-8に固定することで対応がしやすくなります。
+
+- 実行時引数で指定する
+
+  ```bash
+  python run.py --voicevox_dir=$VOICEVOX_DIR --output_log_utf8
+  ```
+
+- 環境変数で指定する
+
+  ```bash
+  # 1の場合はUTF-8、0または空文字で自動選択になります。
+  export VV_OUTPUT_LOG_UTF8=1
+  python run.py --voicevox_dir=$VOICEVOX_DIR
+  ```
+
 ### 過去のバージョンのコアを使う
 VOICEVOX Core 0.5.4以降のコアを使用する事が可能です。  
 Macでのlibtorch版コアのサポートはしていません。

--- a/README.md
+++ b/README.md
@@ -331,6 +331,12 @@ python run.py --voicevox_dir=$VOICEVOX_DIR --voicelib_dir=$VOICELIB_DIR
 python run.py --enable_mock
 ```
 
+```bash
+# ログをUTF8に変更
+python run.py --output_log_utf8
+# もしくは VV_OUTPUT_LOG_UTF8=1 python run.py
+```
+
 ### CPU スレッド数を指定する
 
 CPU スレッド数が未指定の場合は、論理コア数の半分か物理コア数が使われます。（殆どの CPU で、これは全体の処理能力の半分です）  
@@ -346,25 +352,6 @@ VOICEVOX ENGINE が使う処理能力を調節したい場合は、CPU スレッ
 - 環境変数で指定する
   ```bash
   export VV_CPU_NUM_THREADS=4
-  python run.py --voicevox_dir=$VOICEVOX_DIR
-  ```
-
-### ログのエンコーディングをUTF-8に指定する
-
-未指定の場合は環境によって自動選択されます。  
-自動選択が原因で文字化けが発生する場合はUTF-8に固定することで対応がしやすくなります。
-
-- 実行時引数で指定する
-
-  ```bash
-  python run.py --voicevox_dir=$VOICEVOX_DIR --output_log_utf8
-  ```
-
-- 環境変数で指定する
-
-  ```bash
-  # 1の場合はUTF-8、0または空文字で自動選択になります。
-  export VV_OUTPUT_LOG_UTF8=1
   python run.py --voicevox_dir=$VOICEVOX_DIR
   ```
 

--- a/run.py
+++ b/run.py
@@ -73,13 +73,13 @@ def set_output_log_utf8() -> None:
     """
     stdout/stderrのエンコーディングをUTF-8に切り替える関数
     """
-    # 念のためNoneチェックする https://docs.python.org/ja/3/library/sys.html#sys.__stdin__
+    # コンソールがない環境だとNone https://docs.python.org/ja/3/library/sys.html#sys.__stdin__
     if sys.stdout is not None:
-        # stdoutはTextIOBaseのサブクラスで必ずしもreconfigure()が実装されているとは限らない?
+        # 必ずしもreconfigure()が実装されているとは限らない
         try:
             sys.stdout.reconfigure(encoding="utf-8")
         except AttributeError:
-            # flush()しないとバッファに出力内容が残っている可能性がある
+            # バッファを全て出力する
             sys.stdout.flush()
             sys.stdout = TextIOWrapper(sys.stdout.buffer, encoding="utf-8")
     if sys.stderr is not None:
@@ -829,13 +829,10 @@ def generate_app(
 if __name__ == "__main__":
     multiprocessing.freeze_support()
 
-    # stdout/stderrの文字コード指定
     output_log_utf8 = os.getenv("VV_OUTPUT_LOG_UTF8", default="")
     if output_log_utf8 == "1":
-        # VV_OUTPUT_LOG_UTF8 の値が1ならUTF-8に切り替える
         set_output_log_utf8()
     elif not (output_log_utf8 == "" or output_log_utf8 == "0"):
-        # 想定外の環境変数が設定されていた場合とりあえず警告だけしておく
         print(
             "WARNING:  invalid VV_OUTPUT_LOG_UTF8 environment variable value",
             file=sys.stderr,
@@ -889,7 +886,7 @@ if __name__ == "__main__":
         type=int,
         default=os.getenv("VV_CPU_NUM_THREADS") or None,
         help="音声合成を行うスレッド数です。指定しないと、代わりに環境変数VV_CPU_NUM_THREADSの値が使われます。"
-        "VV_CPU_NUM_THREADSに値がなかった、または数値でなかった場合はエラー終了します。",
+        "VV_CPU_NUM_THREADSが空文字列でなく数値でもない場合はエラー終了します。",
     )
 
     parser.add_argument(


### PR DESCRIPTION
## 内容

Windowsでエディタのログが文字化けする問題への対策をしました。
今の状態だと一部問題が発生するのでDraftです。

この問題の原因はPythonの仕様によるものだと思います。
https://docs.python.org/ja/3/library/sys.html#sys.stdout

この自動選択により日本語環境のWindowsでエンジンがエディタから起動した場合、stdout/stderrのエンコードは基本的にcp932が選択されます。
しかし、エディタではUTF-8であると決め打ちしているため文字化けが発生します。
https://github.com/VOICEVOX/voicevox/blob/b801acbeeb061d787f15c56b721e2c2e2b356337/src/background.ts#L572-L578

この変更はエンジンのstdout/stderrをUTF-8に変更します。

## その他

この変更によりWindowsPowerShellとPowerShellで出力をパイプやリダイレクトすると文字化けが発生します。
これはPowerShellが出力をシステムロケールと解釈して自動的に変換してしまうからだと思われます。

エンジン単独で対策するよりも引数か環境変数でエンコーディングを指定するようにエディタとエンジン両方で対策する方がいいかもしれません。
(その場合、他のエンジンのことも考える必要があるのでマニフェストの拡張が必要？)