### PR TITLE
MAINT: user_dict_stratup_processingを削除

### DIFF
--- a/run.py
+++ b/run.py
@@ -55,7 +55,7 @@ from voicevox_engine.user_dict import (
     import_user_dict,
     read_dict,
     rewrite_word,
-    user_dict_startup_processing,
+    update_dict,
 )
 from voicevox_engine.utility import (
     ConnectBase64WavesException,
@@ -134,7 +134,7 @@ def generate_app(
 
     @app.on_event("startup")
     def apply_user_dict():
-        user_dict_startup_processing()
+        update_dict()
 
     def get_engine(core_version: Optional[str]) -> SynthesisEngineBase:
         if core_version is None:

--- a/test/test_user_dict.py
+++ b/test/test_user_dict.py
@@ -317,9 +317,9 @@ class TestUserDict(TestCase):
             compiled_dict_path=compiled_dict_path,
         )
 
-    def test_startup_processing(self):
-        user_dict_path = self.tmp_dir_path / "test_startup_processing_dict.json"
-        compiled_dict_path = self.tmp_dir_path / "test_startup_processing_dict.dic"
+    def test_update_dict(self):
+        user_dict_path = self.tmp_dir_path / "test_update_dict.json"
+        compiled_dict_path = self.tmp_dir_path / "test_update_dict.dic"
         update_dict(
             user_dict_path=user_dict_path, compiled_dict_path=compiled_dict_path
         )

--- a/test/test_user_dict.py
+++ b/test/test_user_dict.py
@@ -17,7 +17,7 @@ from voicevox_engine.user_dict import (
     import_user_dict,
     read_dict,
     rewrite_word,
-    user_dict_startup_processing,
+    update_dict,
 )
 
 # jsonとして保存される正しい形式の辞書データ
@@ -320,7 +320,7 @@ class TestUserDict(TestCase):
     def test_startup_processing(self):
         user_dict_path = self.tmp_dir_path / "test_startup_processing_dict.json"
         compiled_dict_path = self.tmp_dir_path / "test_startup_processing_dict.dic"
-        user_dict_startup_processing(
+        update_dict(
             user_dict_path=user_dict_path, compiled_dict_path=compiled_dict_path
         )
         test_text = "テスト用の文字列"
@@ -341,7 +341,7 @@ class TestUserDict(TestCase):
 
         # 疑似的にエンジンを再起動する
         unset_user_dict()
-        user_dict_startup_processing(
+        update_dict(
             user_dict_path=user_dict_path, compiled_dict_path=compiled_dict_path
         )
 

--- a/voicevox_engine/user_dict.py
+++ b/voicevox_engine/user_dict.py
@@ -40,24 +40,6 @@ def write_to_json(user_dict: Dict[str, UserDictWord], user_dict_path: Path):
     user_dict_path.write_text(user_dict_json, encoding="utf-8")
 
 
-def user_dict_startup_processing(
-    default_dict_path: Path = default_dict_path,
-    user_dict_path: Path = user_dict_path,
-    compiled_dict_path: Path = compiled_dict_path,
-):
-    pyopenjtalk.create_user_dict(
-        str(default_dict_path.resolve(strict=True)),
-        str(compiled_dict_path.resolve()),
-    )
-    pyopenjtalk.set_user_dict(str(compiled_dict_path.resolve(strict=True)))
-    if user_dict_path.is_file():
-        update_dict(
-            default_dict_path=default_dict_path,
-            user_dict_path=user_dict_path,
-            compiled_dict_path=compiled_dict_path,
-        )
-
-
 def update_dict(
     default_dict_path: Path = default_dict_path,
     user_dict_path: Path = user_dict_path,


### PR DESCRIPTION
## 内容

- #483 の続きです。
`user_dict_startup_processing()`が`update_dict()`の処理が重複しているため削除します。
