### PR TITLE
自動作成されたリリースのタグの場所を正しくする

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -827,13 +827,13 @@ jobs:
           mv archives.txt "${{ matrix.artifact_name }}.7z.txt"
 
       - name: Upload splitted archives to Release assets
-        uses: svenstaro/upload-release-action@v2
+        uses: softprops/action-gh-release@v1
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ env.VOICEVOX_ENGINE_VERSION }}
           prerelease: ${{ github.event.inputs.prerelease }}
-          file_glob: true
-          file: ${{ matrix.artifact_name }}.7z.*
+          tag_name: ${{ env.VOICEVOX_ENGINE_VERSION }}
+          files: |-
+            ${{ matrix.artifact_name }}.7z.*
+          target_commitish: ${{ github.ref }}
 
   run-release-test-workflow:
     if: (github.event.release.tag_name || github.event.inputs.version) != ''


### PR DESCRIPTION
## 内容

`svenstaro/upload-release-action@v2`で自動作成されたリリースに紐づくtagが、メインブランチの最新コミットを指してしまう問題を修正し、CIが実行されたコミットを指すようにします。
tagのコミットIDを指定できる、`softprops/action-gh-release@v1`を使用するように変更しました。

<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue

- ref <https://github.com/VOICEVOX/voicevox/issues/904>
- ref <https://github.com/VOICEVOX/voicevox_core/pull/311>

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## その他
