### PR TITLE
FIX: エラー処理周りでUnicodeErrorが発生しないようにする

### DIFF
--- a/run.py
+++ b/run.py
@@ -81,13 +81,17 @@ def set_output_log_utf8() -> None:
         except AttributeError:
             # バッファを全て出力する
             sys.stdout.flush()
-            sys.stdout = TextIOWrapper(sys.stdout.buffer, encoding="utf-8")
+            sys.stdout = TextIOWrapper(
+                sys.stdout.buffer, encoding="utf-8", errors="backslashreplace"
+            )
     if sys.stderr is not None:
         try:
             sys.stderr.reconfigure(encoding="utf-8")
         except AttributeError:
             sys.stderr.flush()
-            sys.stderr = TextIOWrapper(sys.stderr.buffer, encoding="utf-8")
+            sys.stderr = TextIOWrapper(
+                sys.stderr.buffer, encoding="utf-8", errors="backslashreplace"
+            )
 
 
 def generate_app(

--- a/voicevox_engine/synthesis_engine/core_wrapper.py
+++ b/voicevox_engine/synthesis_engine/core_wrapper.py
@@ -421,13 +421,25 @@ class CoreWrapper:
         try:
             if is_version_0_12_core_or_later:
                 if not self.core.initialize(use_gpu, cpu_num_threads, load_all_models):
-                    raise Exception(self.core.last_error_message().decode("utf-8"))
+                    raise Exception(
+                        self.core.last_error_message().decode(
+                            "utf-8", "backslashreplace"
+                        )
+                    )
             elif exist_cpu_num_threads:
                 if not self.core.initialize(".", use_gpu, cpu_num_threads):
-                    raise Exception(self.core.last_error_message().decode("utf-8"))
+                    raise Exception(
+                        self.core.last_error_message().decode(
+                            "utf-8", "backslashreplace"
+                        )
+                    )
             else:
                 if not self.core.initialize(".", use_gpu):
-                    raise Exception(self.core.last_error_message().decode("utf-8"))
+                    raise Exception(
+                        self.core.last_error_message().decode(
+                            "utf-8", "backslashreplace"
+                        )
+                    )
         finally:
             os.chdir(cwd)
 
@@ -448,7 +460,9 @@ class CoreWrapper:
             output.ctypes.data_as(POINTER(c_float)),
         )
         if not success:
-            raise Exception(self.core.last_error_message().decode("utf-8"))
+            raise Exception(
+                self.core.last_error_message().decode("utf-8", "backslashreplace")
+            )
         return output
 
     def yukarin_sa_forward(
@@ -481,7 +495,9 @@ class CoreWrapper:
             output.ctypes.data_as(POINTER(c_float)),
         )
         if not success:
-            raise Exception(self.core.last_error_message().decode("utf-8"))
+            raise Exception(
+                self.core.last_error_message().decode("utf-8", "backslashreplace")
+            )
         return output
 
     def decode_forward(
@@ -502,7 +518,9 @@ class CoreWrapper:
             output.ctypes.data_as(POINTER(c_float)),
         )
         if not success:
-            raise Exception(self.core.last_error_message().decode("utf-8"))
+            raise Exception(
+                self.core.last_error_message().decode("utf-8", "backslashreplace")
+            )
         return output
 
     def supported_devices(self) -> str:


### PR DESCRIPTION
## 内容

主に`core_wapper.py`でエラーが発生した場合`last_error_message()`を読み取って`str`にデコードしますがこの際にエラーメッセージが`UTF-8`ではなかった場合`UnicodeError`が発生して本来のメッセージが完全に分からなくなってしまいます。
この修正はエラーメッセージが`UTF-8`でなかったとしても`\uxxxx`といった形式に置き換えて表示してエラーメッセージが消えてしまわないようにします。

## 関連 Issue

- ref #488

## その他

上記Issueの解決ではありません。
