### PR TITLE
CORS関連のオプションを追加

### DIFF
--- a/run.py
+++ b/run.py
@@ -121,7 +121,7 @@ def generate_app(
         CORSMiddleware,
         allow_origins=allowed_origins,
         allow_credentials=True,
-        allow_origin_regex="^https?://(localhost|127\.0\.0\.1)(:[0-9]+)?$",
+        allow_origin_regex="^https?://(localhost|127\\.0\\.0\\.1)(:[0-9]+)?$",
         allow_methods=["*"],
         allow_headers=["*"],
     )

--- a/run.py
+++ b/run.py
@@ -121,6 +121,7 @@ def generate_app(
         CORSMiddleware,
         allow_origins=allowed_origins,
         allow_credentials=True,
+        allow_origin_regex="^https?://(localhost|127\.0\.0\.1)(:[0-9]+)?$",
         allow_methods=["*"],
         allow_headers=["*"],
     )

--- a/run.py
+++ b/run.py
@@ -110,12 +110,12 @@ def generate_app(
         version=__version__,
     )
 
-    #CORS設定
-    allowed_origins=["*"]
-    if(args.cors_policy_mode=="localapps"):
-        allowed_origins=["app://."]
-        if (args.allow_origin):
-            allowed_origins+=args.allow_origin
+    # CORS設定
+    allowed_origins = ["*"]
+    if args.cors_policy_mode == "localapps":
+        allowed_origins = ["app://."]
+        if args.allow_origin:
+            allowed_origins += args.allow_origin
 
     app.add_middleware(
         CORSMiddleware,
@@ -912,13 +912,11 @@ if __name__ == "__main__":
         "--cors_policy_mode",
         choices=["all", "localapps"],
         default="localapps",
-        help="allまたはlocalappsを指定。allはすべてを許可します。localappsはオリジン間リソース共有ポリシーを、app://.とlocalhost関連に限定します。その他のオリジンはallow_originオプションで追加できます。デフォルトはlocalapps。"
+        help="allまたはlocalappsを指定。allはすべてを許可します。localappsはオリジン間リソース共有ポリシーを、app://.とlocalhost関連に限定します。その他のオリジンはallow_originオプションで追加できます。デフォルトはlocalapps。",
     )
 
     parser.add_argument(
-        "--allow_origin",
-        nargs="*",
-        help="許可するオリジンを指定します。複数指定する場合は、直後にスペースで区切って追加できます。"
+        "--allow_origin", nargs="*", help="許可するオリジンを指定します。複数指定する場合は、直後にスペースで区切って追加できます。"
     )
 
     args = parser.parse_args()

--- a/run.py
+++ b/run.py
@@ -112,7 +112,7 @@ def generate_app(
 
     #CORS設定
     allowed_origins=["*"]
-    if(args.force_cors_policy):
+    if(args.cors_policy_mode=="localapps"):
         allowed_origins=["app://."]
         if (args.allow_origin):
             allowed_origins+=args.allow_origin
@@ -909,9 +909,10 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
-        "--force_cors_policy",
-        action="store_true",
-        help="オリジン間リソース共有ポリシーを、app://.に限定します。その他のオリジンはallow_originオプションで追加できます。"
+        "--cors_policy_mode",
+        choices=["all", "localapps"],
+        default="localapps",
+        help="allまたはlocalappsを指定。allはすべてを許可します。localappsはオリジン間リソース共有ポリシーを、app://.とlocalhost関連に限定します。その他のオリジンはallow_originオプションで追加できます。デフォルトはlocalapps。"
     )
 
     parser.add_argument(

--- a/run.py
+++ b/run.py
@@ -910,13 +910,13 @@ if __name__ == "__main__":
     parser.add_argument(
         "--force_cors_policy",
         action="store_true",
-        help="オリジン間リソース共有ポリシーを、app://.に限定します。その他のオリジンは--allow_originオプションで追加できます。"
+        help="オリジン間リソース共有ポリシーを、app://.に限定します。その他のオリジンはallow_originオプションで追加できます。"
     )
 
     parser.add_argument(
         "--allow_origin",
         nargs="*",
-        help="許可するオリジンを指定します。複数指定する場合は、その数だけ--allow_originを記述します。"
+        help="許可するオリジンを指定します。複数指定する場合は、その数だけallow_originを記述します。"
     )
 
     args = parser.parse_args()

--- a/run.py
+++ b/run.py
@@ -905,6 +905,11 @@ if __name__ == "__main__":
         "VV_OUTPUT_LOG_UTF8 の値が1の場合はUTF-8で、0または空文字、値がない場合は環境によって自動的に決定されます。",
     )
 
+    parser.add_argument(
+        "--force_cors_policy",
+        action="store_true",
+        help="オリジン間リソース共有ポリシーを、app://.とhttp://localhost:portに限定します。"
+    )
     args = parser.parse_args()
 
     if args.output_log_utf8:

--- a/run.py
+++ b/run.py
@@ -116,6 +116,12 @@ def generate_app(
         allowed_origins = ["app://."]
         if args.allow_origin:
             allowed_origins += args.allow_origin
+            if "*" in args.allow_origin:
+                print(
+                    'WARNING: Deprecated use of argument "*" in allow_origin. '
+                    'Use option "--cors_policy_mod all" instead. See "--help" for more.',
+                    file=sys.stderr,
+                )
 
     app.add_middleware(
         CORSMiddleware,

--- a/run.py
+++ b/run.py
@@ -918,7 +918,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--allow_origin",
         nargs="*",
-        help="許可するオリジンを指定します。複数指定する場合は、直後にスペースで区切って指定できます。"
+        help="許可するオリジンを指定します。複数指定する場合は、直後にスペースで区切って追加できます。"
     )
 
     args = parser.parse_args()

--- a/run.py
+++ b/run.py
@@ -110,9 +110,14 @@ def generate_app(
         version=__version__,
     )
 
+    #CORS設定
+    allowed_origins=["*"]
+    if(args.force_cors_policy):
+        allowed_origins=["app://.", "http://localhost:"+args.port]
+
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=["*"],
+        allow_origins=allowed_origins,
         allow_credentials=True,
         allow_methods=["*"],
         allow_headers=["*"],

--- a/run.py
+++ b/run.py
@@ -918,7 +918,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--allow_origin",
         nargs="*",
-        help="許可するオリジンを指定します。複数指定する場合は、その数だけallow_originを記述します。"
+        help="許可するオリジンを指定します。複数指定する場合は、直後にスペースで区切って指定できます。"
     )
 
     args = parser.parse_args()

--- a/run.py
+++ b/run.py
@@ -113,7 +113,9 @@ def generate_app(
     #CORS設定
     allowed_origins=["*"]
     if(args.force_cors_policy):
-        allowed_origins=["app://."]+args.allow_origin
+        allowed_origins=["app://."]
+        if (args.allow_origin):
+            allowed_origins+=args.allow_origin
 
     app.add_middleware(
         CORSMiddleware,

--- a/run.py
+++ b/run.py
@@ -910,7 +910,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--force_cors_policy",
         action="store_true",
-        help="オリジン間リソース共有ポリシーを、app://.とhttp://localhost:portに限定します。"
+        help="オリジン間リソース共有ポリシーを、app://.に限定します。その他のオリジンは--allow_originオプションで追加できます。"
     )
 
     parser.add_argument(

--- a/run.py
+++ b/run.py
@@ -113,7 +113,7 @@ def generate_app(
     #CORS設定
     allowed_origins=["*"]
     if(args.force_cors_policy):
-        allowed_origins=["app://.", "http://localhost:"+str(args.port)]
+        allowed_origins=["app://."]+args.allow_origin
 
     app.add_middleware(
         CORSMiddleware,
@@ -910,6 +910,13 @@ if __name__ == "__main__":
         action="store_true",
         help="オリジン間リソース共有ポリシーを、app://.とhttp://localhost:portに限定します。"
     )
+
+    parser.add_argument(
+        "-allow_origin",
+        nargs="*",
+        help="許可するオリジンを指定します。複数指定する場合は、その数だけ--allow_originを記述します。"
+    )
+
     args = parser.parse_args()
 
     if args.output_log_utf8:

--- a/run.py
+++ b/run.py
@@ -912,7 +912,7 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
-        "-allow_origin",
+        "--allow_origin",
         nargs="*",
         help="許可するオリジンを指定します。複数指定する場合は、その数だけ--allow_originを記述します。"
     )

--- a/run.py
+++ b/run.py
@@ -912,7 +912,9 @@ if __name__ == "__main__":
         "--cors_policy_mode",
         choices=["all", "localapps"],
         default="localapps",
-        help="allまたはlocalappsを指定。allはすべてを許可します。localappsはオリジン間リソース共有ポリシーを、app://.とlocalhost関連に限定します。その他のオリジンはallow_originオプションで追加できます。デフォルトはlocalapps。",
+        help="allまたはlocalappsを指定。allはすべてを許可します。"
+        "localappsはオリジン間リソース共有ポリシーを、app://.とlocalhost関連に限定します。"
+        "その他のオリジンはallow_originオプションで追加できます。デフォルトはlocalapps。",
     )
 
     parser.add_argument(

--- a/run.py
+++ b/run.py
@@ -113,7 +113,7 @@ def generate_app(
     #CORS設定
     allowed_origins=["*"]
     if(args.force_cors_policy):
-        allowed_origins=["app://.", "http://localhost:"+args.port]
+        allowed_origins=["app://.", "http://localhost:"+str(args.port)]
 
     app.add_middleware(
         CORSMiddleware,


### PR DESCRIPTION
## 内容

force_cors_policyオプションでオリジン間リソース共有ポリシーを、app://.に限定します。
allow_originオプションで新たに許可するオリジンを指定します。

例
```python run.py --force_cors_policy --allow_origin 'http://localhost:8080'  'http://example.com'```

## 関連 Issue

ref #392

## その他
デフォルトは今までどおりすべてのオリジンを許可します。
無関係なリクエストを弾くor 実行をキャンセルする機能は未実装です