### PR TITLE
cors_policy_modeとallow_originをgenerate_appの引数にする

### DIFF
--- a/run.py
+++ b/run.py
@@ -107,7 +107,6 @@ def generate_app(
     cors_policy_mode: CorsPolicyMode = CorsPolicyMode.localapps,
     allow_origin: Optional[List[str]] = None,
 ) -> FastAPI:
-    breakpoint()
     if root_dir is None:
         root_dir = engine_root()
 


### PR DESCRIPTION
## 内容

- https://github.com/VOICEVOX/voicevox_engine/pull/494

で、ドキュメント生成が失敗するようになってしまったので、とりあえず修正です。

## 関連 Issue

close #499

## その他

generate_appが`run.py`内にあるとこの問題が偶発的に起こり得てしまうので、generate_appを別のファイルに分けるなりの工夫が必要に感じました。
このPRがマージされたときにそのissueを作りたいと思います。

- [x] issue作る