### PR TITLE
PyInstaller: エンジン使用時に一時ファイルが残ってしまう問題の修正

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -429,27 +429,27 @@ jobs:
 
           if [ -f "download/onnxruntime/lib/onnxruntime_providers_cuda.dll" ]; then
             # ONNX Runtime providers (PyInstaller does not copy dynamic loaded libraries)
-            ln -sf "$(pwd)/download/onnxruntime/lib"/onnxruntime_*.dll dist/run.dist/
+            ln -sf "$(pwd)/download/onnxruntime/lib"/onnxruntime_*.dll dist/run/
 
             # CUDA
-            ln -sf "$(pwd)/download/cuda/bin"/cublas64_*.dll dist/run.dist/
-            ln -sf "$(pwd)/download/cuda/bin"/cublasLt64_*.dll dist/run.dist/
-            ln -sf "$(pwd)/download/cuda/bin"/cudart64_*.dll dist/run.dist/
-            ln -sf "$(pwd)/download/cuda/bin"/cufft64_*.dll dist/run.dist/
-            ln -sf "$(pwd)/download/cuda/bin"/curand64_*.dll dist/run.dist/
+            ln -sf "$(pwd)/download/cuda/bin"/cublas64_*.dll dist/run/
+            ln -sf "$(pwd)/download/cuda/bin"/cublasLt64_*.dll dist/run/
+            ln -sf "$(pwd)/download/cuda/bin"/cudart64_*.dll dist/run/
+            ln -sf "$(pwd)/download/cuda/bin"/cufft64_*.dll dist/run/
+            ln -sf "$(pwd)/download/cuda/bin"/curand64_*.dll dist/run/
 
             # cuDNN
-            ln -sf "$(pwd)/download/cudnn/bin"/cudnn64_*.dll dist/run.dist/
-            ln -sf "$(pwd)/download/cudnn/bin"/cudnn_*_infer64*.dll dist/run.dist/
+            ln -sf "$(pwd)/download/cudnn/bin"/cudnn64_*.dll dist/run/
+            ln -sf "$(pwd)/download/cudnn/bin"/cudnn_*_infer64*.dll dist/run/
           fi
 
           if [[ ${{ matrix.artifact_name }} == *-directml ]]; then
             # DirectML
-            ln -sf "$(pwd)/download/directml"/DirectML.dll dist/run.dist/
+            ln -sf "$(pwd)/download/directml"/DirectML.dll dist/run/
           fi
 
           # pysoundfile
-          ln -sf "${{ env.PYTHON_SITE_PACKAGES_DIR }}/_soundfile_data" dist/run.dist/
+          ln -sf "${{ env.PYTHON_SITE_PACKAGES_DIR }}/_soundfile_data" dist/run/
 
       - name: Create symlink of CUDA dependencies
         if: startsWith(matrix.os, 'ubuntu-') && endsWith(matrix.artifact_name, 'nvidia')
@@ -459,29 +459,29 @@ jobs:
 
           # ONNX Runtime providers (PyInstaller does not copy dynamic loaded libraries)
           patchelf --set-rpath '$ORIGIN' "$(pwd)/download/onnxruntime/lib"/libonnxruntime_providers_*.so
-          ln -sf "$(pwd)/download/onnxruntime/lib"/libonnxruntime_*.so dist/run.dist/
+          ln -sf "$(pwd)/download/onnxruntime/lib"/libonnxruntime_*.so dist/run/
 
           # CUDA
-          ln -sf "$(pwd)/download/cuda/bin"/libcublas.so.* dist/run.dist/
-          ln -sf "$(pwd)/download/cuda/bin"/libcublasLt.so.* dist/run.dist/
-          ln -sf "$(pwd)/download/cuda/bin"/libcudart.so.* dist/run.dist/
-          ln -sf "$(pwd)/download/cuda/bin"/libcufft.so.* dist/run.dist/
-          ln -sf "$(pwd)/download/cuda/bin"/libcurand.so.* dist/run.dist/
+          ln -sf "$(pwd)/download/cuda/bin"/libcublas.so.* dist/run/
+          ln -sf "$(pwd)/download/cuda/bin"/libcublasLt.so.* dist/run/
+          ln -sf "$(pwd)/download/cuda/bin"/libcudart.so.* dist/run/
+          ln -sf "$(pwd)/download/cuda/bin"/libcufft.so.* dist/run/
+          ln -sf "$(pwd)/download/cuda/bin"/libcurand.so.* dist/run/
 
           # cuDNN
-          ln -sf "$(pwd)/download/cudnn/bin"/libcudnn.so.* dist/run.dist/
-          ln -sf "$(pwd)/download/cudnn/bin"/libcudnn_*_infer.so.* dist/run.dist/
+          ln -sf "$(pwd)/download/cudnn/bin"/libcudnn.so.* dist/run/
+          ln -sf "$(pwd)/download/cudnn/bin"/libcudnn_*_infer.so.* dist/run/
 
       - name: Set @rpath to @executable_path
         if: startsWith(matrix.os, 'macos-')
         run: |
-          install_name_tool -add_rpath @executable_path/. dist/run.dist/run
+          install_name_tool -add_rpath @executable_path/. dist/run/run
 
       - name: Code signing
         if: github.event.inputs.code_signing == 'true' && startsWith(matrix.os, 'windows-')
         shell: bash
         run: |
-          bash build_util/codesign.bash "dist/run.dist/run.exe"
+          bash build_util/codesign.bash "dist/run/run.exe"
         env:
           CERT_BASE64: ${{ secrets.CERT_BASE64 }}
           CERT_PASSWORD: ${{ secrets.CERT_PASSWORD }}
@@ -499,7 +499,7 @@ jobs:
         #     ${{ format('{0}-{1}', matrix.artifact_name, (env.VOICEVOX_ENGINE_VERSION != 'latest' && env.VOICEVOX_ENGINE_VERSION) || github.sha) }}
         with:
           name: ${{ matrix.artifact_name }}
-          path: dist/run.dist/
+          path: dist/run/
 
   upload-to-release:
     if: (github.event.release.tag_name || github.event.inputs.version) != ''

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -448,9 +448,6 @@ jobs:
             ln -sf "$(pwd)/download/directml"/DirectML.dll dist/run/
           fi
 
-          # pysoundfile
-          ln -sf "${{ env.PYTHON_SITE_PACKAGES_DIR }}/_soundfile_data" dist/run/
-
       - name: Create symlink of CUDA dependencies
         if: startsWith(matrix.os, 'ubuntu-') && endsWith(matrix.artifact_name, 'nvidia')
         shell: bash

--- a/run.spec
+++ b/run.spec
@@ -3,7 +3,31 @@
 from PyInstaller.utils.hooks import collect_data_files
 import os
 
-datas = collect_data_files('pyopenjtalk')
+datas = [
+    ('engine_manifest_assets', 'engine_manifest_assets'),
+    ('speaker_info', 'speaker_info'),
+    ('default.csv', '.'),
+    ('licenses.json', '.'),
+    ('presets.yaml', '.'),
+]
+datas += collect_data_files('pyopenjtalk')
+
+# コアとONNX Runtimeはバイナリであるが、`binaries`に加えると
+# 依存関係のパスがPyInstallerに書き換えらるので、`datas`に加える
+# 参考: https://github.com/VOICEVOX/voicevox_engine/pull/446#issuecomment-1210052318
+libcore_path = os.environ.get('LIBCORE_PATH')
+if libcore_path:
+    print('LIBCORE_PATH is found:', libcore_path)
+    if not os.path.isfile(libcore_path):
+        raise Exception("LIBCORE_PATH was found, but it is not file!")
+    datas += [(libcore_path, ".")]
+
+libonnxruntime_path = os.environ.get('LIBONNXRUNTIME_PATH')
+if libonnxruntime_path:
+    print('LIBONNXRUNTIME_PATH is found:', libonnxruntime_path)
+    if not os.path.isfile(libonnxruntime_path):
+        raise Exception("LIBCORE_PATH was found, but it is not file!")
+    datas += [(libonnxruntime_path, ".")]
 
 
 block_cipher = None
@@ -30,17 +54,13 @@ pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
 exe = EXE(
     pyz,
     a.scripts,
-    a.binaries,
-    a.zipfiles,
-    a.datas,
     [],
+    exclude_binaries=True,
     name='run',
     debug=False,
     bootloader_ignore_signals=False,
     strip=False,
     upx=True,
-    upx_exclude=[],
-    runtime_tmpdir=None,
     console=True,
     disable_windowed_traceback=False,
     argv_emulation=False,
@@ -49,40 +69,13 @@ exe = EXE(
     entitlements_file=None,
 )
 
-datas = [
-    ('engine_manifest_assets', 'engine_manifest_assets', 'DATA'),
-    ('speaker_info', 'speaker_info', 'DATA'),
-    ('default.csv', 'default.csv', 'DATA'),
-    ('licenses.json', 'licenses.json', 'DATA'),
-    ('presets.yaml', 'presets.yaml', 'DATA'),
-]
-
-# コアとONNX Runtimeはバイナリであるが、`binaries`に加えると
-# 依存関係のパスがPyInstallerに書き換えらるので、`datas`に加える
-# 参考: https://github.com/VOICEVOX/voicevox_engine/pull/446#issuecomment-1210052318
-libcore_path = os.environ.get('LIBCORE_PATH')
-if libcore_path:
-    print('LIBCORE_PATH is found:', libcore_path)
-    if not os.path.isfile(libcore_path):
-        raise Exception("LIBCORE_PATH was found, but it is not file!")
-    filename = os.path.basename(libcore_path)
-    datas += [(filename, libcore_path, 'DATA')]
-
-libonnxruntime_path = os.environ.get('LIBONNXRUNTIME_PATH')
-if libonnxruntime_path:
-    print('LIBONNXRUNTIME_PATH is found:', libonnxruntime_path)
-    if not os.path.isfile(libonnxruntime_path):
-        raise Exception("LIBCORE_PATH was found, but it is not file!")
-    filename = os.path.basename(libonnxruntime_path)
-    datas += [(filename, libonnxruntime_path, 'DATA')]
-
 coll = COLLECT(
     exe,
-    [],
-    [],
-    datas,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
     strip=False,
     upx=True,
     upx_exclude=[],
-    name='run.dist',
+    name='run',
 )


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->
onefileオプションを用いて生成したspecファイルを使っていたことによる[一時ファイルが残る影響](https://twitter.com/sabonerune/status/1569326970777006080?s=20&t=517afIrH3_wxm2_KD400iQ)を解消する

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->
ref #439 
