### PR TITLE
PyInstaller: `engine_manifest.json`を含み忘れていた問題の解消

### DIFF
--- a/run.spec
+++ b/run.spec
@@ -6,6 +6,7 @@ import os
 datas = [
     ('engine_manifest_assets', 'engine_manifest_assets'),
     ('speaker_info', 'speaker_info'),
+    ('engine_manifest.json', '.'),
     ('default.csv', '.'),
     ('licenses.json', '.'),
     ('presets.yaml', '.'),


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->
題の通り、追従し忘れか何かで含み忘れていたので追加します。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->
ref #439 

