### PR TITLE
ENH: マニフェストにモーフィングの可否を追加

### DIFF
--- a/engine_manifest.json
+++ b/engine_manifest.json
@@ -48,6 +48,11 @@
             "type": "bool",
             "value": true,
             "name": "疑問文の自動調整"
+        },
+        "synthesis_morphing" : {
+            "type": "bool",
+            "value": true,
+            "name": "2人の話者でモーフィングした音声を合成"
         }
     }
 }

--- a/voicevox_engine/engine_manifest/EngineManifest.py
+++ b/voicevox_engine/engine_manifest/EngineManifest.py
@@ -36,6 +36,7 @@ class SupportedFeatures(BaseModel):
     adjust_intonation_scale: bool = Field(title="全体の抑揚の調整")
     adjust_volume_scale: bool = Field(title="全体の音量の調整")
     interrogative_upspeak: bool = Field(title="疑問文の自動調整")
+    synthesis_morphing: bool = Field(title="2人の話者でモーフィングした音声を合成")
 
 
 class EngineManifest(BaseModel):


### PR DESCRIPTION
## 内容

マニフェストにモーフィングの可否について情報がなかったため追加しました。

## 関連 Issue

- ref https://github.com/VOICEVOX/voicevox/issues/552
