### PR TITLE
upload-branchがエラーになる問題の解決

### DIFF
--- a/.github/workflows/upload-gh-pages.yml
+++ b/.github/workflows/upload-gh-pages.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   upload-doc:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
## 内容

`ubuntu-latest`が残っていてpython 3.8.10を使っていたので修正します。

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
