### PR TITLE
Docker: Dockerfileのsyntaxバージョンを1.3-labsから1.4にする

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.3-labs
+# syntax=docker/dockerfile:1.4
 
 ARG BASE_IMAGE=ubuntu:focal
 ARG BASE_RUNTIME_IMAGE=$BASE_IMAGE


### PR DESCRIPTION
## 内容

実験的バージョンである`1.3-labs`を使うのをやめ、正式版の`1.4`を使うようにします。

このPRによって何か新しい構文が使えるようになるというわけではないと思います。


## 詳細

Docker BuildKitがビルドするDockerfileでは、構文のバージョンを以下のような記法で指定することができます。

```dockerfile
# syntax=docker/dockerfile:1.4
```

これまで、Dockerfile内でヒアドキュメント記法（`<<EOF`）を使うため、実験的バージョン(experimental)である`1.3-labs`というバージョンを使用していました。

- Dockerfileの構文バージョンに関するDocker公式ドキュメント: <https://docs.docker.com/build/buildkit/dockerfile-frontend/>

`1.3-labs`相当の機能は、`1.4`として2022年3月にリリースされているようです。

- <https://github.com/moby/buildkit/releases/tag/dockerfile%2F1.4.0>

このPRは、実験的バージョンを使うのをやめるためのものです。

- ヒアドキュメントが正式には`1.4`から使用できるようになったことを示すDocker公式ドキュメント
    - <https://docs.docker.com/engine/reference/builder/#here-documents>

![image](https://user-images.githubusercontent.com/27213639/205427141-8b7f30ee-0376-401b-8e22-e556f1a09678.png)

ちなみに、現在は`1.4-labs`という実験的バージョンが存在しているようです。

- <https://hub.docker.com/r/docker/dockerfile>

![image](https://user-images.githubusercontent.com/27213639/205427226-27759e60-9e99-4eee-bc49-470c8c7fdc4a.png)
