### PR TITLE
Docker: Pythonのビルドに使用するpyenvのバージョンをv2.3.7に固定する

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -120,9 +120,7 @@ RUN <<EOF
 EOF
 
 ARG PYTHON_VERSION=3.8.10
-# FIXME: Lock pyenv version with git tag
-# 90d0d20508a91e7ea1e609e8aa9f9d1a28bb563e (including 3.7.12) not released yet (2021-09-12)
-ARG PYENV_VERSION=master
+ARG PYENV_VERSION=v2.3.7
 ARG PYENV_ROOT=/tmp/.pyenv
 ARG PYBUILD_ROOT=/tmp/python-build
 RUN <<EOF


### PR DESCRIPTION
## 内容

DockerfileによってビルドされるDockerイメージの再現性を上げるためのPRです。

Dockerfile内で使用していたpyenvのバージョンが固定されていなかったため、2022-12-03時点の最新リリースのv2.3.7に固定します。

- pyenv v2.3.7: <https://github.com/pyenv/pyenv/releases/tag/v2.3.7>

## 詳細

2021-09-12時点では、当時使用していたPythonバージョンの3.7.12に対応するpyenvがリリースされていなかったため、masterブランチを使うようにしていました。

この状態では、`master`という文字列に基づいてDockerイメージのレイヤーがキャッシュされるため、Dockerイメージのビルド環境によって実際に使用されるpyenvバージョンが変わってしまうおそれがあります。本来は、3.7.12に対応したコミットハッシュで固定するべきでした（コミットハッシュを使用していなかった理由はおそらく、`git clone`コマンドの`-b`オプションにコミットハッシュが使用できないためと思われます）。
