### PR TITLE
CI: Node 14のactions/cache@v2からNode 16のactions/cache@v3に更新

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -342,7 +342,7 @@ jobs:
 
       # Download VOICEVOX Core
       - name: Prepare VOICEVOX Core cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: voicevox-core-cache
         with:
           key: ${{ matrix.os }}-voicevox-core-${{ matrix.voicevox_core_asset_prefix }}-${{ env.VOICEVOX_CORE_VERSION }}


### PR DESCRIPTION
## 内容

#496 に1か所漏れがあったので修正します（ <https://github.com/VOICEVOX/voicevox_engine/actions/runs/3604256457> を見ていて気付きました ）。

`save-state`, `set-output`系の非推奨警告も`actions/cache@v2`から出ていそうなので、消えそう...?

<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue

- ref <https://github.com/VOICEVOX/voicevox/issues/987>

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->
