### PR TITLE
リリースファイルとアーティファクトにプロダクト名とバージョンを追加

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,8 @@ jobs:
         run: |
           : # release タグ名, または workflow_dispatch でのバージョン名. リリースでない (push event) 場合は空文字列.
           echo "voicevox-engine-version=${{ github.event.release.tag_name || github.event.inputs.version }}" >> $GITHUB_OUTPUT
+          : # release タグ名, または workflow_dispatch でのバージョン名, または 'latest'
+          echo "voicevox-engine-version-or-latest=${{ github.event.release.tag_name || github.event.inputs.version || 'latest' }}" >> $GITHUB_OUTPUT
 
   build-all:
     needs: [config]
@@ -87,6 +89,11 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      - name: declare variables
+        id: vars
+        run: |
+          echo "artifact-name=voicevox_engine-${{ matrix.artifact_name }}-${{ needs.config.outputs.voicevox-engine-version-or-latest }}-${{ github.sha }}" >> $GITHUB_OUTPUT
+
       - uses: actions/checkout@v3
 
       - name: Show disk space (debug info)
@@ -399,11 +406,11 @@ jobs:
 
           # Replace version & specify dynamic libraries
           if [[ ${{ matrix.os }} == macos-* ]]; then
-            gsed -i "s/__version__ = \"latest\"/__version__ = \"${{ needs.config.outputs.voicevox-engine-version || 'latest' }}\"/" voicevox_engine/__init__.py
+            gsed -i "s/__version__ = \"latest\"/__version__ = \"${{ needs.config.outputs.voicevox-engine-version-or-latest }}\"/" voicevox_engine/__init__.py
             LIBCORE_PATH=download/core/libvoicevox_core.dylib
             LIBONNXRUNTIME_PATH=download/onnxruntime/lib/libonnxruntime.dylib
           else
-            sed -i "s/__version__ = \"latest\"/__version__ = \"${{ needs.config.outputs.voicevox-engine-version || 'latest' }}\"/" voicevox_engine/__init__.py
+            sed -i "s/__version__ = \"latest\"/__version__ = \"${{ needs.config.outputs.voicevox-engine-version-or-latest }}\"/" voicevox_engine/__init__.py
             if [[ ${{ matrix.os }} == windows-* ]]; then
               LIBCORE_PATH=download/core/voicevox_core.dll
               LIBONNXRUNTIME_PATH=download/onnxruntime/lib/onnxruntime.dll
@@ -503,7 +510,7 @@ jobs:
         #   VERSIONED_ARTIFACT_NAME: |
         #     ${{ format('{0}-{1}', matrix.artifact_name, (needs.config.outputs.voicevox-engine-version != 'latest' && needs.config.outputs.voicevox-engine-version) || github.sha) }}
         with:
-          name: ${{ matrix.artifact_name }}
+          name: ${{ steps.vars.outputs.artifact-name }}
           path: dist/run/
 
   upload-to-release:
@@ -524,6 +531,9 @@ jobs:
         id: vars
         run: |
           echo "package-name=voicevox_engine-${{ matrix.artifact_name }}-${{ needs.config.outputs.voicevox-engine-version }}" >> $GITHUB_OUTPUT
+          : # this is exactly same as `steps.vars.outputs.artifact-name` in `build-all` job,
+          : # but since we cannot get the job outputs of matrix builds correctly, we need to redefine here.
+          echo "artifact-name=voicevox_engine-${{ matrix.artifact_name }}-${{ needs.config.outputs.voicevox-engine-version-or-latest }}-${{ github.sha }}" >> $GITHUB_OUTPUT
 
       - uses: actions/checkout@v3
 
@@ -536,7 +546,7 @@ jobs:
       - name: Download and extract artifact
         uses: actions/download-artifact@v3
         with:
-          name: ${{ matrix.artifact_name }}
+          name: ${{ steps.vars.outputs.artifact-name }}
           path: ${{ matrix.artifact_name }}/
 
       - name: Rearchive and split artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,8 +25,8 @@ env:
   VOICEVOX_RESOURCE_VERSION: "0.13.3"
   VOICEVOX_CORE_VERSION: "0.14.0-preview.2"
   VOICEVOX_ENGINE_VERSION:
-    |- # releaseタグ名か、workflow_dispatchでのバージョン名か、latestが入る
-    ${{ github.event.release.tag_name || github.event.inputs.version || 'latest' }}
+    |- # release タグ名, または workflow_dispatch でのバージョン名. リリースでない (push event) 場合は空文字列.
+    ${{ github.event.release.tag_name || github.event.inputs.version }}
 
 jobs:
   build-all:
@@ -391,11 +391,11 @@ jobs:
 
           # Replace version & specify dynamic libraries
           if [[ ${{ matrix.os }} == macos-* ]]; then
-            gsed -i "s/__version__ = \"latest\"/__version__ = \"${{ env.VOICEVOX_ENGINE_VERSION }}\"/" voicevox_engine/__init__.py
+            gsed -i "s/__version__ = \"latest\"/__version__ = \"${{ env.VOICEVOX_ENGINE_VERSION || 'latest' }}\"/" voicevox_engine/__init__.py
             LIBCORE_PATH=download/core/libvoicevox_core.dylib
             LIBONNXRUNTIME_PATH=download/onnxruntime/lib/libonnxruntime.dylib
           else
-            sed -i "s/__version__ = \"latest\"/__version__ = \"${{ env.VOICEVOX_ENGINE_VERSION }}\"/" voicevox_engine/__init__.py
+            sed -i "s/__version__ = \"latest\"/__version__ = \"${{ env.VOICEVOX_ENGINE_VERSION || 'latest' }}\"/" voicevox_engine/__init__.py
             if [[ ${{ matrix.os }} == windows-* ]]; then
               LIBCORE_PATH=download/core/voicevox_core.dll
               LIBONNXRUNTIME_PATH=download/onnxruntime/lib/onnxruntime.dll
@@ -499,7 +499,7 @@ jobs:
           path: dist/run/
 
   upload-to-release:
-    if: (github.event.release.tag_name || github.event.inputs.version) != ''
+    if: env.VOICEVOX_ENGINE_VERSION != ''
     needs: [build-all]
     runs-on: ubuntu-latest
     strategy:
@@ -511,9 +511,12 @@ jobs:
           - windows-cpu
           - windows-directml
           - windows-nvidia
-    env:
-      package_name: voicevox_engine-${{ matrix.artifact_name }}-${{ env.VOICEVOX_ENGINE_VERSION }}
     steps:
+      - name: declare variables
+        id: vars
+        run: |
+          echo "package-name=voicevox_engine-${{ matrix.artifact_name }}-${{ env.VOICEVOX_ENGINE_VERSION }}" >> $GITHUB_OUTPUT
+
       - uses: actions/checkout@v3
 
       - name: Install dependencies
@@ -531,22 +534,22 @@ jobs:
       - name: Rearchive and split artifact
         run: |
           # Compress to artifact.7z.001, artifact.7z.002, ...
-          7z -r -v2g a "${{ env.package_name }}.7z" "${{ matrix.artifact_name }}/"
+          7z -r -v2g a "${{ steps.vars.package-name }}.7z" "${{ matrix.artifact_name }}/"
 
           # Compress to artifact.001.vvpp,artifact.002.vvpp, ...
           (cd "${{ matrix.artifact_name }}" && zip -r - . > ../compressed.zip)
-          split -b 2G --numeric-suffixes=1 -a 3 --additional-suffix .vvpp ./compressed.zip ./${{ env.package_name }}.
+          split -b 2G --numeric-suffixes=1 -a 3 --additional-suffix .vvpp ./compressed.zip ./${{ steps.vars.package-name }}.
 
           # Rename to artifact.vvpp if there are only artifact.001.vvpp
-          if [ "$(ls ${{ env.package_name }}.*.vvpp | wc -l)" == 1 ]; then
-            mv ${{ env.package_name }}.001.vvpp ${{ env.package_name }}.vvpp
+          if [ "$(ls ${{ steps.vars.package-name }}.*.vvpp | wc -l)" == 1 ]; then
+            mv ${{ steps.vars.package-name }}.001.vvpp ${{ steps.vars.package-name }}.vvpp
           fi
 
           # Output splitted archive list
-          ls ${{ env.package_name }}.7z.* > archives_7z.txt
-          mv archives_7z.txt "${{ env.package_name }}.7z.txt"
-          ls ${{ env.package_name }}*.vvpp > archives_vvpp.txt
-          mv archives_vvpp.txt "${{ env.package_name }}.vvpp.txt"
+          ls ${{ steps.vars.package-name }}.7z.* > archives_7z.txt
+          mv archives_7z.txt "${{ steps.vars.package-name }}.7z.txt"
+          ls ${{ steps.vars.package-name }}*.vvpp > archives_vvpp.txt
+          mv archives_vvpp.txt "${{ steps.vars.package-name }}.vvpp.txt"
 
       - name: Upload splitted archives to Release assets
         uses: softprops/action-gh-release@v1
@@ -554,15 +557,15 @@ jobs:
           prerelease: ${{ github.event.inputs.prerelease }}
           tag_name: ${{ env.VOICEVOX_ENGINE_VERSION }}
           files: |-
-            ${{ env.package_name }}.7z.*
-            ${{ env.package_name }}*.vvpp
-            ${{ env.package_name }}.vvpp.txt
+            ${{ steps.vars.package-name }}.7z.*
+            ${{ steps.vars.package-name }}*.vvpp
+            ${{ steps.vars.package-name }}.vvpp.txt
           target_commitish: ${{ github.sha }}
 
   run-release-test-workflow:
-    if: (github.event.release.tag_name || github.event.inputs.version) != ''
+    if: env.VOICEVOX_ENGINE_VERSION != ''
     needs: [upload-to-release]
     uses: ./.github/workflows/release-test.yml
     with:
-      version: ${{ github.event.release.tag_name || github.event.inputs.version }} # env.VOICEVOX_ENGINE_VERSIONが使えない
+      version: ${{ env.VOICEVOX_ENGINE_VERSION }}
       repo_url: ${{ format('{0}/{1}', github.server_url, github.repository) }} # このリポジトリのURL

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -512,7 +512,7 @@ jobs:
           - windows-directml
           - windows-nvidia
     env:
-      package_name: voicevox_engine-${{ env.VOICEVOX_ENGINE_VERSION }}-${{ matrix.artifact_name }}
+      package_name: voicevox_engine-${{ matrix.artifact_name }}-${{ env.VOICEVOX_ENGINE_VERSION }}
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,11 +29,13 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       voicevox-engine-version: ${{ steps.vars.outputs.voicevox-engine-version }}
+      voicevox-engine-version-or-latest: ${{ steps.vars.outputs.voicevox-engine-version-or-latest }}
     steps:
       - name: declare variables
         id: vars
+        shell: bash
         run: |
-          : # release タグ名, または workflow_dispatch でのバージョン名. リリースでない (push event) 場合は空文字列.
+          : # release タグ名, または workflow_dispatch でのバージョン名. リリースでない (push event) 場合は空文字列
           echo "voicevox-engine-version=${{ github.event.release.tag_name || github.event.inputs.version }}" >> $GITHUB_OUTPUT
           : # release タグ名, または workflow_dispatch でのバージョン名, または 'latest'
           echo "voicevox-engine-version-or-latest=${{ github.event.release.tag_name || github.event.inputs.version || 'latest' }}" >> $GITHUB_OUTPUT
@@ -91,6 +93,7 @@ jobs:
     steps:
       - name: declare variables
         id: vars
+        shell: bash
         run: |
           echo "artifact-name=voicevox_engine-${{ matrix.artifact_name }}-${{ needs.config.outputs.voicevox-engine-version-or-latest }}-${{ github.sha }}" >> $GITHUB_OUTPUT
 
@@ -498,17 +501,8 @@ jobs:
           CERT_BASE64: ${{ secrets.CERT_BASE64 }}
           CERT_PASSWORD: ${{ secrets.CERT_PASSWORD }}
 
-      # FIXME: versioned name may be useful; but
-      # actions/download-artifact and dawidd6/download-artifact do not support
-      # wildcard / forward-matching yet.
-      # Currently, It is good to use static artifact name for future binary test workflow.
-      # https://github.com/actions/toolkit/blob/ea81280a4d48fb0308d40f8f12ae00d117f8acb9/packages/artifact/src/internal/artifact-client.ts#L147
-      # https://github.com/dawidd6/action-download-artifact/blob/af92a8455a59214b7b932932f2662fdefbd78126/main.js#L113
       - name: Upload artifact
         uses: actions/upload-artifact@v3
-        # env:
-        #   VERSIONED_ARTIFACT_NAME: |
-        #     ${{ format('{0}-{1}', matrix.artifact_name, (needs.config.outputs.voicevox-engine-version != 'latest' && needs.config.outputs.voicevox-engine-version) || github.sha) }}
         with:
           name: ${{ steps.vars.outputs.artifact-name }}
           path: dist/run/
@@ -529,6 +523,7 @@ jobs:
     steps:
       - name: declare variables
         id: vars
+        shell: bash
         run: |
           echo "package-name=voicevox_engine-${{ matrix.artifact_name }}-${{ needs.config.outputs.voicevox-engine-version }}" >> $GITHUB_OUTPUT
           : # this is exactly same as `steps.vars.outputs.artifact-name` in `build-all` job,

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,17 +28,17 @@ jobs:
   config: # 全 jobs で利用する定数の定義. `env` が利用できないコンテキストでも利用できる.
     runs-on: ubuntu-latest
     outputs:
-      voicevox-engine-version: ${{ steps.vars.outputs.voicevox-engine-version }}
-      voicevox-engine-version-or-latest: ${{ steps.vars.outputs.voicevox-engine-version-or-latest }}
+      version: ${{ steps.vars.outputs.version }}
+      version-or-latest: ${{ steps.vars.outputs.version-or-latest }}
     steps:
       - name: declare variables
         id: vars
         shell: bash
         run: |
           : # release タグ名, または workflow_dispatch でのバージョン名. リリースでない (push event) 場合は空文字列
-          echo "voicevox-engine-version=${{ github.event.release.tag_name || github.event.inputs.version }}" >> $GITHUB_OUTPUT
+          echo "version=${{ github.event.release.tag_name || github.event.inputs.version }}" >> $GITHUB_OUTPUT
           : # release タグ名, または workflow_dispatch でのバージョン名, または 'latest'
-          echo "voicevox-engine-version-or-latest=${{ github.event.release.tag_name || github.event.inputs.version || 'latest' }}" >> $GITHUB_OUTPUT
+          echo "version-or-latest=${{ github.event.release.tag_name || github.event.inputs.version || 'latest' }}" >> $GITHUB_OUTPUT
 
   build-all:
     needs: [config]
@@ -95,7 +95,7 @@ jobs:
         id: vars
         shell: bash
         run: |
-          echo "artifact-name=voicevox_engine-${{ matrix.artifact_name }}-${{ needs.config.outputs.voicevox-engine-version-or-latest }}-${{ github.sha }}" >> $GITHUB_OUTPUT
+          echo "artifact-name=voicevox_engine-${{ matrix.artifact_name }}-${{ needs.config.outputs.version-or-latest }}-${{ github.sha }}" >> $GITHUB_OUTPUT
 
       - uses: actions/checkout@v3
 
@@ -409,11 +409,11 @@ jobs:
 
           # Replace version & specify dynamic libraries
           if [[ ${{ matrix.os }} == macos-* ]]; then
-            gsed -i "s/__version__ = \"latest\"/__version__ = \"${{ needs.config.outputs.voicevox-engine-version-or-latest }}\"/" voicevox_engine/__init__.py
+            gsed -i "s/__version__ = \"latest\"/__version__ = \"${{ needs.config.outputs.version-or-latest }}\"/" voicevox_engine/__init__.py
             LIBCORE_PATH=download/core/libvoicevox_core.dylib
             LIBONNXRUNTIME_PATH=download/onnxruntime/lib/libonnxruntime.dylib
           else
-            sed -i "s/__version__ = \"latest\"/__version__ = \"${{ needs.config.outputs.voicevox-engine-version-or-latest }}\"/" voicevox_engine/__init__.py
+            sed -i "s/__version__ = \"latest\"/__version__ = \"${{ needs.config.outputs.version-or-latest }}\"/" voicevox_engine/__init__.py
             if [[ ${{ matrix.os }} == windows-* ]]; then
               LIBCORE_PATH=download/core/voicevox_core.dll
               LIBONNXRUNTIME_PATH=download/onnxruntime/lib/onnxruntime.dll
@@ -508,7 +508,7 @@ jobs:
           path: dist/run/
 
   upload-to-release:
-    if: needs.config.outputs.voicevox-engine-version != ''
+    if: needs.config.outputs.version != ''
     needs: [config, build-all]
     runs-on: ubuntu-latest
     strategy:
@@ -525,10 +525,10 @@ jobs:
         id: vars
         shell: bash
         run: |
-          echo "package-name=voicevox_engine-${{ matrix.artifact_name }}-${{ needs.config.outputs.voicevox-engine-version }}" >> $GITHUB_OUTPUT
+          echo "package-name=voicevox_engine-${{ matrix.artifact_name }}-${{ needs.config.outputs.version }}" >> $GITHUB_OUTPUT
           : # this is exactly same as `steps.vars.outputs.artifact-name` in `build-all` job,
           : # but since we cannot get the job outputs of matrix builds correctly, we need to redefine here.
-          echo "artifact-name=voicevox_engine-${{ matrix.artifact_name }}-${{ needs.config.outputs.voicevox-engine-version-or-latest }}-${{ github.sha }}" >> $GITHUB_OUTPUT
+          echo "artifact-name=voicevox_engine-${{ matrix.artifact_name }}-${{ needs.config.outputs.version-or-latest }}-${{ github.sha }}" >> $GITHUB_OUTPUT
 
       - uses: actions/checkout@v3
 
@@ -568,7 +568,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           prerelease: ${{ github.event.inputs.prerelease }}
-          tag_name: ${{ needs.config.outputs.voicevox-engine-version }}
+          tag_name: ${{ needs.config.outputs.version }}
           files: |-
             ${{ steps.vars.outputs.package-name }}.7z.*
             ${{ steps.vars.outputs.package-name }}*.vvpp
@@ -576,9 +576,9 @@ jobs:
           target_commitish: ${{ github.sha }}
 
   run-release-test-workflow:
-    if: needs.config.outputs.voicevox-engine-version != ''
+    if: needs.config.outputs.version != ''
     needs: [config, upload-to-release]
     uses: ./.github/workflows/release-test.yml
     with:
-      version: ${{ needs.config.outputs.voicevox-engine-version }}
+      version: ${{ needs.config.outputs.version }}
       repo_url: ${{ format('{0}/{1}', github.server_url, github.repository) }} # このリポジトリのURL

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
   config: # 全 jobs で利用する定数の定義. `env` が利用できないコンテキストでも利用できる.
     runs-on: ubuntu-latest
     outputs:
-      voicevox-engine-version: ${{ steps.vars.outputs.voicevox-engine-version }}
+      voicevox-engine-version: ${{ steps.outputs.vars.outputs.voicevox-engine-version }}
     steps:
       - name: declare variables
         id: vars
@@ -542,22 +542,22 @@ jobs:
       - name: Rearchive and split artifact
         run: |
           # Compress to artifact.7z.001, artifact.7z.002, ...
-          7z -r -v2g a "${{ steps.vars.package-name }}.7z" "${{ matrix.artifact_name }}/"
+          7z -r -v2g a "${{ steps.outputs.vars.package-name }}.7z" "${{ matrix.artifact_name }}/"
 
           # Compress to artifact.001.vvpp,artifact.002.vvpp, ...
           (cd "${{ matrix.artifact_name }}" && zip -r - . > ../compressed.zip)
-          split -b 2G --numeric-suffixes=1 -a 3 --additional-suffix .vvpp ./compressed.zip ./${{ steps.vars.package-name }}.
+          split -b 2G --numeric-suffixes=1 -a 3 --additional-suffix .vvpp ./compressed.zip ./${{ steps.outputs.vars.package-name }}.
 
           # Rename to artifact.vvpp if there are only artifact.001.vvpp
-          if [ "$(ls ${{ steps.vars.package-name }}.*.vvpp | wc -l)" == 1 ]; then
-            mv ${{ steps.vars.package-name }}.001.vvpp ${{ steps.vars.package-name }}.vvpp
+          if [ "$(ls ${{ steps.outputs.vars.package-name }}.*.vvpp | wc -l)" == 1 ]; then
+            mv ${{ steps.outputs.vars.package-name }}.001.vvpp ${{ steps.outputs.vars.package-name }}.vvpp
           fi
 
           # Output splitted archive list
-          ls ${{ steps.vars.package-name }}.7z.* > archives_7z.txt
-          mv archives_7z.txt "${{ steps.vars.package-name }}.7z.txt"
-          ls ${{ steps.vars.package-name }}*.vvpp > archives_vvpp.txt
-          mv archives_vvpp.txt "${{ steps.vars.package-name }}.vvpp.txt"
+          ls ${{ steps.outputs.vars.package-name }}.7z.* > archives_7z.txt
+          mv archives_7z.txt "${{ steps.outputs.vars.package-name }}.7z.txt"
+          ls ${{ steps.outputs.vars.package-name }}*.vvpp > archives_vvpp.txt
+          mv archives_vvpp.txt "${{ steps.outputs.vars.package-name }}.vvpp.txt"
 
       - name: Upload splitted archives to Release assets
         uses: softprops/action-gh-release@v1
@@ -565,9 +565,9 @@ jobs:
           prerelease: ${{ github.event.inputs.prerelease }}
           tag_name: ${{ needs.config.outputs.voicevox-engine-version }}
           files: |-
-            ${{ steps.vars.package-name }}.7z.*
-            ${{ steps.vars.package-name }}*.vvpp
-            ${{ steps.vars.package-name }}.vvpp.txt
+            ${{ steps.outputs.vars.package-name }}.7z.*
+            ${{ steps.outputs.vars.package-name }}*.vvpp
+            ${{ steps.outputs.vars.package-name }}.vvpp.txt
           target_commitish: ${{ github.sha }}
 
   run-release-test-workflow:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
   config: # 全 jobs で利用する定数の定義. `env` が利用できないコンテキストでも利用できる.
     runs-on: ubuntu-latest
     outputs:
-      voicevox-engine-version: ${{ steps.outputs.vars.outputs.voicevox-engine-version }}
+      voicevox-engine-version: ${{ steps.vars.outputs.voicevox-engine-version }}
     steps:
       - name: declare variables
         id: vars
@@ -542,22 +542,22 @@ jobs:
       - name: Rearchive and split artifact
         run: |
           # Compress to artifact.7z.001, artifact.7z.002, ...
-          7z -r -v2g a "${{ steps.outputs.vars.package-name }}.7z" "${{ matrix.artifact_name }}/"
+          7z -r -v2g a "${{ steps.vars.outputs.package-name }}.7z" "${{ matrix.artifact_name }}/"
 
           # Compress to artifact.001.vvpp,artifact.002.vvpp, ...
           (cd "${{ matrix.artifact_name }}" && zip -r - . > ../compressed.zip)
-          split -b 2G --numeric-suffixes=1 -a 3 --additional-suffix .vvpp ./compressed.zip ./${{ steps.outputs.vars.package-name }}.
+          split -b 2G --numeric-suffixes=1 -a 3 --additional-suffix .vvpp ./compressed.zip ./${{ steps.vars.outputs.package-name }}.
 
           # Rename to artifact.vvpp if there are only artifact.001.vvpp
-          if [ "$(ls ${{ steps.outputs.vars.package-name }}.*.vvpp | wc -l)" == 1 ]; then
-            mv ${{ steps.outputs.vars.package-name }}.001.vvpp ${{ steps.outputs.vars.package-name }}.vvpp
+          if [ "$(ls ${{ steps.vars.outputs.package-name }}.*.vvpp | wc -l)" == 1 ]; then
+            mv ${{ steps.vars.outputs.package-name }}.001.vvpp ${{ steps.vars.outputs.package-name }}.vvpp
           fi
 
           # Output splitted archive list
-          ls ${{ steps.outputs.vars.package-name }}.7z.* > archives_7z.txt
-          mv archives_7z.txt "${{ steps.outputs.vars.package-name }}.7z.txt"
-          ls ${{ steps.outputs.vars.package-name }}*.vvpp > archives_vvpp.txt
-          mv archives_vvpp.txt "${{ steps.outputs.vars.package-name }}.vvpp.txt"
+          ls ${{ steps.vars.outputs.package-name }}.7z.* > archives_7z.txt
+          mv archives_7z.txt "${{ steps.vars.outputs.package-name }}.7z.txt"
+          ls ${{ steps.vars.outputs.package-name }}*.vvpp > archives_vvpp.txt
+          mv archives_vvpp.txt "${{ steps.vars.outputs.package-name }}.vvpp.txt"
 
       - name: Upload splitted archives to Release assets
         uses: softprops/action-gh-release@v1
@@ -565,9 +565,9 @@ jobs:
           prerelease: ${{ github.event.inputs.prerelease }}
           tag_name: ${{ needs.config.outputs.voicevox-engine-version }}
           files: |-
-            ${{ steps.outputs.vars.package-name }}.7z.*
-            ${{ steps.outputs.vars.package-name }}*.vvpp
-            ${{ steps.outputs.vars.package-name }}.vvpp.txt
+            ${{ steps.vars.outputs.package-name }}.7z.*
+            ${{ steps.vars.outputs.package-name }}*.vvpp
+            ${{ steps.vars.outputs.package-name }}.vvpp.txt
           target_commitish: ${{ github.sha }}
 
   run-release-test-workflow:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.vars.outputs.version }}
-      version-or-latest: ${{ steps.vars.outputs.version-or-latest }}
+      version_or_latest: ${{ steps.vars.outputs.version_or_latest }}
     steps:
       - name: declare variables
         id: vars
@@ -38,7 +38,7 @@ jobs:
           : # release タグ名, または workflow_dispatch でのバージョン名. リリースでない (push event) 場合は空文字列
           echo "version=${{ github.event.release.tag_name || github.event.inputs.version }}" >> $GITHUB_OUTPUT
           : # release タグ名, または workflow_dispatch でのバージョン名, または 'latest'
-          echo "version-or-latest=${{ github.event.release.tag_name || github.event.inputs.version || 'latest' }}" >> $GITHUB_OUTPUT
+          echo "version_or_latest=${{ github.event.release.tag_name || github.event.inputs.version || 'latest' }}" >> $GITHUB_OUTPUT
 
   build-all:
     needs: [config]
@@ -95,7 +95,7 @@ jobs:
         id: vars
         shell: bash
         run: |
-          echo "artifact-name=voicevox_engine-${{ matrix.artifact_name }}-${{ needs.config.outputs.version-or-latest }}-${{ github.sha }}" >> $GITHUB_OUTPUT
+          echo "artifact_name=voicevox_engine-${{ matrix.artifact_name }}-${{ needs.config.outputs.version_or_latest }}-${{ github.sha }}" >> $GITHUB_OUTPUT
 
       - uses: actions/checkout@v3
 
@@ -409,11 +409,11 @@ jobs:
 
           # Replace version & specify dynamic libraries
           if [[ ${{ matrix.os }} == macos-* ]]; then
-            gsed -i "s/__version__ = \"latest\"/__version__ = \"${{ needs.config.outputs.version-or-latest }}\"/" voicevox_engine/__init__.py
+            gsed -i "s/__version__ = \"latest\"/__version__ = \"${{ needs.config.outputs.version_or_latest }}\"/" voicevox_engine/__init__.py
             LIBCORE_PATH=download/core/libvoicevox_core.dylib
             LIBONNXRUNTIME_PATH=download/onnxruntime/lib/libonnxruntime.dylib
           else
-            sed -i "s/__version__ = \"latest\"/__version__ = \"${{ needs.config.outputs.version-or-latest }}\"/" voicevox_engine/__init__.py
+            sed -i "s/__version__ = \"latest\"/__version__ = \"${{ needs.config.outputs.version_or_latest }}\"/" voicevox_engine/__init__.py
             if [[ ${{ matrix.os }} == windows-* ]]; then
               LIBCORE_PATH=download/core/voicevox_core.dll
               LIBONNXRUNTIME_PATH=download/onnxruntime/lib/onnxruntime.dll
@@ -504,7 +504,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ steps.vars.outputs.artifact-name }}
+          name: ${{ steps.vars.outputs.artifact_name }}
           path: dist/run/
 
   upload-to-release:
@@ -525,10 +525,10 @@ jobs:
         id: vars
         shell: bash
         run: |
-          echo "package-name=voicevox_engine-${{ matrix.artifact_name }}-${{ needs.config.outputs.version }}" >> $GITHUB_OUTPUT
-          : # this is exactly same as `steps.vars.outputs.artifact-name` in `build-all` job,
+          echo "package_name=voicevox_engine-${{ matrix.artifact_name }}-${{ needs.config.outputs.version }}" >> $GITHUB_OUTPUT
+          : # this is exactly same as `steps.vars.outputs.artifact_name` in `build-all` job,
           : # but since we cannot get the job outputs of matrix builds correctly, we need to redefine here.
-          echo "artifact-name=voicevox_engine-${{ matrix.artifact_name }}-${{ needs.config.outputs.version-or-latest }}-${{ github.sha }}" >> $GITHUB_OUTPUT
+          echo "artifact_name=voicevox_engine-${{ matrix.artifact_name }}-${{ needs.config.outputs.version_or_latest }}-${{ github.sha }}" >> $GITHUB_OUTPUT
 
       - uses: actions/checkout@v3
 
@@ -541,28 +541,28 @@ jobs:
       - name: Download and extract artifact
         uses: actions/download-artifact@v3
         with:
-          name: ${{ steps.vars.outputs.artifact-name }}
+          name: ${{ steps.vars.outputs.artifact_name }}
           path: ${{ matrix.artifact_name }}/
 
       - name: Rearchive and split artifact
         run: |
           # Compress to artifact.7z.001, artifact.7z.002, ...
-          7z -r -v2g a "${{ steps.vars.outputs.package-name }}.7z" "${{ matrix.artifact_name }}/"
+          7z -r -v2g a "${{ steps.vars.outputs.package_name }}.7z" "${{ matrix.artifact_name }}/"
 
           # Compress to artifact.001.vvpp,artifact.002.vvpp, ...
           (cd "${{ matrix.artifact_name }}" && zip -r - . > ../compressed.zip)
-          split -b 2G --numeric-suffixes=1 -a 3 --additional-suffix .vvpp ./compressed.zip ./${{ steps.vars.outputs.package-name }}.
+          split -b 2G --numeric-suffixes=1 -a 3 --additional-suffix .vvpp ./compressed.zip ./${{ steps.vars.outputs.package_name }}.
 
           # Rename to artifact.vvpp if there are only artifact.001.vvpp
-          if [ "$(ls ${{ steps.vars.outputs.package-name }}.*.vvpp | wc -l)" == 1 ]; then
-            mv ${{ steps.vars.outputs.package-name }}.001.vvpp ${{ steps.vars.outputs.package-name }}.vvpp
+          if [ "$(ls ${{ steps.vars.outputs.package_name }}.*.vvpp | wc -l)" == 1 ]; then
+            mv ${{ steps.vars.outputs.package_name }}.001.vvpp ${{ steps.vars.outputs.package_name }}.vvpp
           fi
 
           # Output splitted archive list
-          ls ${{ steps.vars.outputs.package-name }}.7z.* > archives_7z.txt
-          mv archives_7z.txt "${{ steps.vars.outputs.package-name }}.7z.txt"
-          ls ${{ steps.vars.outputs.package-name }}*.vvpp > archives_vvpp.txt
-          mv archives_vvpp.txt "${{ steps.vars.outputs.package-name }}.vvpp.txt"
+          ls ${{ steps.vars.outputs.package_name }}.7z.* > archives_7z.txt
+          mv archives_7z.txt "${{ steps.vars.outputs.package_name }}.7z.txt"
+          ls ${{ steps.vars.outputs.package_name }}*.vvpp > archives_vvpp.txt
+          mv archives_vvpp.txt "${{ steps.vars.outputs.package_name }}.vvpp.txt"
 
       - name: Upload splitted archives to Release assets
         uses: softprops/action-gh-release@v1
@@ -570,9 +570,9 @@ jobs:
           prerelease: ${{ github.event.inputs.prerelease }}
           tag_name: ${{ needs.config.outputs.version }}
           files: |-
-            ${{ steps.vars.outputs.package-name }}.7z.*
-            ${{ steps.vars.outputs.package-name }}*.vvpp
-            ${{ steps.vars.outputs.package-name }}.vvpp.txt
+            ${{ steps.vars.outputs.package_name }}.7z.*
+            ${{ steps.vars.outputs.package_name }}*.vvpp
+            ${{ steps.vars.outputs.package_name }}.vvpp.txt
           target_commitish: ${{ github.sha }}
 
   run-release-test-workflow:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -511,6 +511,8 @@ jobs:
           - windows-cpu
           - windows-directml
           - windows-nvidia
+    env:
+      package_name: voicevox_engine-${{ env.VOICEVOX_ENGINE_VERSION }}-${{ matrix.artifact_name }}
     steps:
       - uses: actions/checkout@v3
 
@@ -529,22 +531,22 @@ jobs:
       - name: Rearchive and split artifact
         run: |
           # Compress to artifact.7z.001, artifact.7z.002, ...
-          7z -r -v2g a "${{ matrix.artifact_name }}.7z" "${{ matrix.artifact_name }}/"
+          7z -r -v2g a "${{ env.package_name }}.7z" "${{ matrix.artifact_name }}/"
 
           # Compress to artifact.001.vvpp,artifact.002.vvpp, ...
           (cd "${{ matrix.artifact_name }}" && zip -r - . > ../compressed.zip)
-          split -b 2G --numeric-suffixes=1 -a 3 --additional-suffix .vvpp ./compressed.zip ./${{ matrix.artifact_name }}.
+          split -b 2G --numeric-suffixes=1 -a 3 --additional-suffix .vvpp ./compressed.zip ./${{ env.package_name }}.
 
           # Rename to artifact.vvpp if there are only artifact.001.vvpp
-          if [ "$(ls ${{ matrix.artifact_name }}.*.vvpp | wc -l)" == 1 ]; then
-            mv ${{ matrix.artifact_name }}.001.vvpp ${{ matrix.artifact_name }}.vvpp
+          if [ "$(ls ${{ env.package_name }}.*.vvpp | wc -l)" == 1 ]; then
+            mv ${{ env.package_name }}.001.vvpp ${{ env.package_name }}.vvpp
           fi
 
           # Output splitted archive list
-          ls ${{ matrix.artifact_name }}.7z.* > archives_7z.txt
-          mv archives_7z.txt "${{ matrix.artifact_name }}.7z.txt"
-          ls ${{ matrix.artifact_name }}*.vvpp > archives_vvpp.txt
-          mv archives_vvpp.txt "${{ matrix.artifact_name }}.vvpp.txt"
+          ls ${{ env.package_name }}.7z.* > archives_7z.txt
+          mv archives_7z.txt "${{ env.package_name }}.7z.txt"
+          ls ${{ env.package_name }}*.vvpp > archives_vvpp.txt
+          mv archives_vvpp.txt "${{ env.package_name }}.vvpp.txt"
 
       - name: Upload splitted archives to Release assets
         uses: softprops/action-gh-release@v1
@@ -552,9 +554,9 @@ jobs:
           prerelease: ${{ github.event.inputs.prerelease }}
           tag_name: ${{ env.VOICEVOX_ENGINE_VERSION }}
           files: |-
-            ${{ matrix.artifact_name }}.7z.*
-            ${{ matrix.artifact_name }}*.vvpp
-            ${{ matrix.artifact_name }}.vvpp.txt
+            ${{ env.package_name }}.7z.*
+            ${{ env.package_name }}*.vvpp
+            ${{ env.package_name }}.vvpp.txt
           target_commitish: ${{ github.sha }}
 
   run-release-test-workflow:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -511,11 +511,14 @@ jobs:
           - windows-cpu
           - windows-directml
           - windows-nvidia
+    outputs:
+      voicevox-engine-version: ${{ steps.vars.voicevox-engine-version }}
     steps:
       - name: declare variables
         id: vars
         run: |
           echo "package-name=voicevox_engine-${{ matrix.artifact_name }}-${{ env.VOICEVOX_ENGINE_VERSION }}" >> $GITHUB_OUTPUT
+          echo "voicevox-engine-version={{ env.VOICEVOX_ENGINE_VERSION }}" >> $GITHUB_OUTPUT
 
       - uses: actions/checkout@v3
 
@@ -567,5 +570,5 @@ jobs:
     needs: [upload-to-release]
     uses: ./.github/workflows/release-test.yml
     with:
-      version: ${{ env.VOICEVOX_ENGINE_VERSION }}
+      version: ${{ needs.upload-to-release.outputs.voicevox-engine-version }}
       repo_url: ${{ format('{0}/{1}', github.server_url, github.repository) }} # このリポジトリのURL

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ env:
 
 jobs:
   config: # 全 jobs で利用する定数の定義. `env` が利用できないコンテキストでも利用できる.
-    uses: ubuntu-latest
+    runs-on: ubuntu-latest
     outputs:
       voicevox-engine-version: ${{ steps.vars.outputs.voicevox-engine-version }}
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,16 +20,24 @@ on:
         type: boolean
 
 env:
-  IMAGE_NAME: ${{ secrets.DOCKERHUB_USERNAME }}/voicevox_engine
   PYTHON_VERSION: "3.8.10"
   VOICEVOX_RESOURCE_VERSION: "0.13.3"
   VOICEVOX_CORE_VERSION: "0.14.0-preview.2"
-  VOICEVOX_ENGINE_VERSION:
-    |- # release タグ名, または workflow_dispatch でのバージョン名. リリースでない (push event) 場合は空文字列.
-    ${{ github.event.release.tag_name || github.event.inputs.version }}
 
 jobs:
+  config: # 全 jobs で利用する定数の定義. `env` が利用できないコンテキストでも利用できる.
+    uses: ubuntu-latest
+    outputs:
+      voicevox-engine-version: ${{ steps.vars.outputs.voicevox-engine-version }}
+    steps:
+      - name: declare variables
+        id: vars
+        run: |
+          : # release タグ名, または workflow_dispatch でのバージョン名. リリースでない (push event) 場合は空文字列.
+          echo "voicevox-engine-version=${{ github.event.release.tag_name || github.event.inputs.version }}" >> $GITHUB_OUTPUT
+
   build-all:
+    needs: [config]
     environment: ${{ github.event.inputs.code_signing == 'true' && 'code_signing' || '' }} # コード署名用のenvironment
     strategy:
       matrix:
@@ -391,11 +399,11 @@ jobs:
 
           # Replace version & specify dynamic libraries
           if [[ ${{ matrix.os }} == macos-* ]]; then
-            gsed -i "s/__version__ = \"latest\"/__version__ = \"${{ env.VOICEVOX_ENGINE_VERSION || 'latest' }}\"/" voicevox_engine/__init__.py
+            gsed -i "s/__version__ = \"latest\"/__version__ = \"${{ needs.config.outputs.voicevox-engine-version || 'latest' }}\"/" voicevox_engine/__init__.py
             LIBCORE_PATH=download/core/libvoicevox_core.dylib
             LIBONNXRUNTIME_PATH=download/onnxruntime/lib/libonnxruntime.dylib
           else
-            sed -i "s/__version__ = \"latest\"/__version__ = \"${{ env.VOICEVOX_ENGINE_VERSION || 'latest' }}\"/" voicevox_engine/__init__.py
+            sed -i "s/__version__ = \"latest\"/__version__ = \"${{ needs.config.outputs.voicevox-engine-version || 'latest' }}\"/" voicevox_engine/__init__.py
             if [[ ${{ matrix.os }} == windows-* ]]; then
               LIBCORE_PATH=download/core/voicevox_core.dll
               LIBONNXRUNTIME_PATH=download/onnxruntime/lib/onnxruntime.dll
@@ -493,14 +501,14 @@ jobs:
         uses: actions/upload-artifact@v3
         # env:
         #   VERSIONED_ARTIFACT_NAME: |
-        #     ${{ format('{0}-{1}', matrix.artifact_name, (env.VOICEVOX_ENGINE_VERSION != 'latest' && env.VOICEVOX_ENGINE_VERSION) || github.sha) }}
+        #     ${{ format('{0}-{1}', matrix.artifact_name, (needs.config.outputs.voicevox-engine-version != 'latest' && needs.config.outputs.voicevox-engine-version) || github.sha) }}
         with:
           name: ${{ matrix.artifact_name }}
           path: dist/run/
 
   upload-to-release:
-    if: env.VOICEVOX_ENGINE_VERSION != ''
-    needs: [build-all]
+    if: needs.config.outputs.voicevox-engine-version != ''
+    needs: [config, build-all]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -511,14 +519,11 @@ jobs:
           - windows-cpu
           - windows-directml
           - windows-nvidia
-    outputs:
-      voicevox-engine-version: ${{ steps.vars.voicevox-engine-version }}
     steps:
       - name: declare variables
         id: vars
         run: |
-          echo "package-name=voicevox_engine-${{ matrix.artifact_name }}-${{ env.VOICEVOX_ENGINE_VERSION }}" >> $GITHUB_OUTPUT
-          echo "voicevox-engine-version={{ env.VOICEVOX_ENGINE_VERSION }}" >> $GITHUB_OUTPUT
+          echo "package-name=voicevox_engine-${{ matrix.artifact_name }}-${{ needs.config.outputs.voicevox-engine-version }}" >> $GITHUB_OUTPUT
 
       - uses: actions/checkout@v3
 
@@ -558,7 +563,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           prerelease: ${{ github.event.inputs.prerelease }}
-          tag_name: ${{ env.VOICEVOX_ENGINE_VERSION }}
+          tag_name: ${{ needs.config.outputs.voicevox-engine-version }}
           files: |-
             ${{ steps.vars.package-name }}.7z.*
             ${{ steps.vars.package-name }}*.vvpp
@@ -566,9 +571,9 @@ jobs:
           target_commitish: ${{ github.sha }}
 
   run-release-test-workflow:
-    if: env.VOICEVOX_ENGINE_VERSION != ''
-    needs: [upload-to-release]
+    if: needs.config.outputs.voicevox-engine-version != ''
+    needs: [config, upload-to-release]
     uses: ./.github/workflows/release-test.yml
     with:
-      version: ${{ needs.upload-to-release.outputs.voicevox-engine-version }}
+      version: ${{ needs.config.outputs.voicevox-engine-version }}
       repo_url: ${{ format('{0}/{1}', github.server_url, github.repository) }} # このリポジトリのURL

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,14 +51,14 @@ jobs:
             architecture: "x64"
             voicevox_core_asset_prefix: voicevox_core-windows-x64-cpu
             onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.13.1/onnxruntime-win-x64-1.13.1.zip
-            artifact_name: windows-cpu
+            target: windows-cpu
           # Windows DirectML
           - os: windows-2019
             architecture: "x64"
             voicevox_core_asset_prefix: voicevox_core-windows-x64-directml
             onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.13.1/Microsoft.ML.OnnxRuntime.DirectML.1.13.1.zip
             directml_url: https://www.nuget.org/api/v2/package/Microsoft.AI.DirectML/1.10.0
-            artifact_name: windows-directml
+            target: windows-directml
           # Windows NVIDIA GPU
           - os: windows-2019
             architecture: "x64"
@@ -66,19 +66,19 @@ jobs:
             onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.13.1/onnxruntime-win-x64-gpu-1.13.1.zip
             cuda_version: "11.6.2"
             cudnn_url: https://developer.download.nvidia.com/compute/redist/cudnn/v8.4.1/local_installers/11.6/cudnn-windows-x86_64-8.4.1.50_cuda11.6-archive.zip
-            artifact_name: windows-nvidia
+            target: windows-nvidia
           # Mac CPU (x64 arch only)
           - os: macos-11
             architecture: "x64"
             voicevox_core_asset_prefix: voicevox_core-osx-x64-cpu
             onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.13.1/onnxruntime-osx-x86_64-1.13.1.tgz
-            artifact_name: macos-x64
+            target: macos-x64
           # Linux CPU
           - os: ubuntu-20.04
             architecture: "x64"
             voicevox_core_asset_prefix: voicevox_core-linux-x64-cpu
             onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.13.1/onnxruntime-linux-x64-1.13.1.tgz
-            artifact_name: linux-cpu
+            target: linux-cpu
           # Linux NVIDIA GPU
           - os: ubuntu-20.04
             architecture: "x64"
@@ -86,7 +86,7 @@ jobs:
             onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.13.1/onnxruntime-linux-x64-gpu-1.13.1.tgz
             cuda_version: "11.6.2"
             cudnn_url: https://developer.download.nvidia.com/compute/redist/cudnn/v8.4.1/local_installers/11.6/cudnn-linux-x86_64-8.4.1.50_cuda11.6-archive.tar.xz
-            artifact_name: linux-nvidia
+            target: linux-nvidia
 
     runs-on: ${{ matrix.os }}
 
@@ -95,7 +95,7 @@ jobs:
         id: vars
         shell: bash
         run: |
-          echo "artifact_name=voicevox_engine-${{ matrix.artifact_name }}-${{ needs.config.outputs.version_or_latest }}-${{ github.sha }}" >> $GITHUB_OUTPUT
+          echo "artifact_name=voicevox_engine-${{ matrix.target }}-${{ needs.config.outputs.version_or_latest }}-${{ github.sha }}" >> $GITHUB_OUTPUT
 
       - uses: actions/checkout@v3
 
@@ -114,7 +114,7 @@ jobs:
 
       # ONNX Runtime providersとCUDA周りをリンクするために使う
       - name: Install patchelf
-        if: startsWith(matrix.os, 'ubuntu-') && endsWith(matrix.artifact_name, 'nvidia')
+        if: startsWith(matrix.os, 'ubuntu-') && endsWith(matrix.target, 'nvidia')
         run: |
           sudo apt-get update
           sudo apt-get install -y patchelf
@@ -265,12 +265,12 @@ jobs:
 
       # Donwload DirectML
       - name: Export DirectML url to calc hash
-        if: endswith(matrix.artifact_name, '-directml')
+        if: endswith(matrix.target, '-directml')
         shell: bash
         run: echo "${{ matrix.directml_url }}" >> download/directml_url.txt
 
       - name: Cache DirectML
-        if: endswith(matrix.artifact_name, '-directml')
+        if: endswith(matrix.target, '-directml')
         uses: actions/cache@v3
         id: directml-cache
         with:
@@ -278,7 +278,7 @@ jobs:
           path: download/directml
 
       - name: Download DirectML
-        if: steps.directml-cache.outputs.cache-hit != 'true' && endswith(matrix.artifact_name, '-directml')
+        if: steps.directml-cache.outputs.cache-hit != 'true' && endswith(matrix.target, '-directml')
         shell: bash
         run: |
           curl -L "${{ matrix.directml_url }}" -o download/directml.zip
@@ -309,7 +309,7 @@ jobs:
           curl -L "${{ matrix.onnxruntime_url }}" > download/onnxruntime.zip
 
           # extract only dlls
-          if [[ ${{ matrix.artifact_name }} != *-directml ]]; then
+          if [[ ${{ matrix.target }} != *-directml ]]; then
             unzip download/onnxruntime.zip onnxruntime-*/lib/*.dll -d download/
             mv download/onnxruntime-* download/onnxruntime
           else
@@ -461,13 +461,13 @@ jobs:
             ln -sf "$(pwd)/download/cudnn/bin"/cudnn_*_infer64*.dll dist/run/
           fi
 
-          if [[ ${{ matrix.artifact_name }} == *-directml ]]; then
+          if [[ ${{ matrix.target }} == *-directml ]]; then
             # DirectML
             ln -sf "$(pwd)/download/directml"/DirectML.dll dist/run/
           fi
 
       - name: Create symlink of CUDA dependencies
-        if: startsWith(matrix.os, 'ubuntu-') && endsWith(matrix.artifact_name, 'nvidia')
+        if: startsWith(matrix.os, 'ubuntu-') && endsWith(matrix.target, 'nvidia')
         shell: bash
         run: |
           set -eux
@@ -513,7 +513,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        artifact_name:
+        target:
           - macos-x64
           - linux-cpu
           - linux-nvidia
@@ -525,10 +525,10 @@ jobs:
         id: vars
         shell: bash
         run: |
-          echo "package_name=voicevox_engine-${{ matrix.artifact_name }}-${{ needs.config.outputs.version }}" >> $GITHUB_OUTPUT
+          echo "package_name=voicevox_engine-${{ matrix.target }}-${{ needs.config.outputs.version }}" >> $GITHUB_OUTPUT
           : # this is exactly same as `steps.vars.outputs.artifact_name` in `build-all` job,
           : # but since we cannot get the job outputs of matrix builds correctly, we need to redefine here.
-          echo "artifact_name=voicevox_engine-${{ matrix.artifact_name }}-${{ needs.config.outputs.version_or_latest }}-${{ github.sha }}" >> $GITHUB_OUTPUT
+          echo "artifact_name=voicevox_engine-${{ matrix.target }}-${{ needs.config.outputs.version_or_latest }}-${{ github.sha }}" >> $GITHUB_OUTPUT
 
       - uses: actions/checkout@v3
 
@@ -542,15 +542,15 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: ${{ steps.vars.outputs.artifact_name }}
-          path: ${{ matrix.artifact_name }}/
+          path: ${{ matrix.target }}/
 
       - name: Rearchive and split artifact
         run: |
           # Compress to artifact.7z.001, artifact.7z.002, ...
-          7z -r -v2g a "${{ steps.vars.outputs.package_name }}.7z" "${{ matrix.artifact_name }}/"
+          7z -r -v2g a "${{ steps.vars.outputs.package_name }}.7z" "${{ matrix.target }}/"
 
           # Compress to artifact.001.vvpp,artifact.002.vvpp, ...
-          (cd "${{ matrix.artifact_name }}" && zip -r - . > ../compressed.zip)
+          (cd "${{ matrix.target }}" && zip -r - . > ../compressed.zip)
           split -b 2G --numeric-suffixes=1 -a 3 --additional-suffix .vvpp ./compressed.zip ./${{ steps.vars.outputs.package_name }}.
 
           # Rename to artifact.vvpp if there are only artifact.001.vvpp

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -66,8 +66,8 @@ jobs:
         shell: bash -euxv {0}
         run: |
           mkdir -p download
-          curl -L -o "download/list.txt" "${{ steps.vars.release-url }}/${{ steps.vars.package-name }}.7z.txt"
-          cat "download/list.txt" | xargs -I '%' curl -L -o "download/%" "${{ steps.vars.release-url }}/%"
+          curl -L -o "download/list.txt" "${{ steps.vars.outputs.release-url }}/${{ steps.vars.outputs.package-name }}.7z.txt"
+          cat "download/list.txt" | xargs -I '%' curl -L -o "download/%" "${{ steps.vars.outputs.release-url }}/%"
           7z x "download/$(head -n1 download/list.txt)"
           mv ${{ matrix.target }} dist/
 

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -53,8 +53,8 @@ jobs:
         id: vars
         shell: bash
         run: |
-          echo "release-url=${{ env.REPO_URL }}/releases/download/${{ env.VERSION }}" >> $GITHUB_OUTPUT
-          echo "package-name=voicevox_engine-${{ matrix.target }}-${{ env.VERSION }}" >> $GITHUB_OUTPUT
+          echo "release_url=${{ env.REPO_URL }}/releases/download/${{ env.VERSION }}" >> $GITHUB_OUTPUT
+          echo "package_name=voicevox_engine-${{ matrix.target }}-${{ env.VERSION }}" >> $GITHUB_OUTPUT
 
       - uses: actions/checkout@v2
 
@@ -67,8 +67,8 @@ jobs:
         shell: bash -euxv {0}
         run: |
           mkdir -p download
-          curl -L -o "download/list.txt" "${{ steps.vars.outputs.release-url }}/${{ steps.vars.outputs.package-name }}.7z.txt"
-          cat "download/list.txt" | xargs -I '%' curl -L -o "download/%" "${{ steps.vars.outputs.release-url }}/%"
+          curl -L -o "download/list.txt" "${{ steps.vars.outputs.release_url }}/${{ steps.vars.outputs.package_name }}.7z.txt"
+          cat "download/list.txt" | xargs -I '%' curl -L -o "download/%" "${{ steps.vars.outputs.release_url }}/%"
           7z x "download/$(head -n1 download/list.txt)"
           mv ${{ matrix.target }} dist/
 

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -51,6 +51,7 @@ jobs:
     steps:
       - name: declare variables
         id: vars
+        shell: bash
         run: |
           echo "release-url=${{ env.REPO_URL }}/releases/download/${{ env.VERSION }}" >> $GITHUB_OUTPUT
           echo "package-name=voicevox_engine-${{ matrix.target }}-${{ env.VERSION }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -43,10 +43,18 @@ jobs:
             target: windows-cpu
           - os: windows-2019
             target: windows-nvidia
+          - os: windows-2019
+            target: windows-directml
 
     runs-on: ${{ matrix.os }}
 
     steps:
+      - name: declare variables
+        id: vars
+        run: |
+          echo "release-url=${{ env.REPO_URL }}/releases/download/${{ env.VERSION }}" >> $GITHUB_OUTPUT
+          echo "package-name=voicevox_engine-${{ matrix.target }}-${{ env.VERSION }}" >> $GITHUB_OUTPUT
+
       - uses: actions/checkout@v2
 
       - uses: actions/setup-python@v2
@@ -56,12 +64,10 @@ jobs:
 
       - name: Download
         shell: bash -euxv {0}
-        env:
-          RELEASE_URL: ${{ env.REPO_URL }}/releases/download/${{ env.VERSION }}
         run: |
           mkdir -p download
-          curl -L -o "download/list.txt" "${{ env.RELEASE_URL }}/${{ matrix.target }}.7z.txt"
-          cat "download/list.txt" | xargs -I '%' curl -L -o "download/%" "${{ env.RELEASE_URL }}/%"
+          curl -L -o "download/list.txt" "${{ steps.vars.release-url }}/${{ steps.vars.package-name }}.7z.txt"
+          cat "download/list.txt" | xargs -I '%' curl -L -o "download/%" "${{ steps.vars.release-url }}/%"
           7z x "download/$(head -n1 download/list.txt)"
           mv ${{ matrix.target }} dist/
 


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->

`.github/workflows/build.yml` から自動でリリースされるファイルとアーティファクトにプロダクト名 (`voicevox_engine`) とバージョン (e.g. `0.14.0`) を追加します.

PR 後のファイル名:

```
voicevox_engine-linux-cpu-0.14.0.7z.001
voicevox_engine-linux-cpu-0.14.0.7z.txt
voicevox_engine-windows-directml-0.14.0-preview.5.vvpp
voicevox_engine-windows-directml-0.14.0-preview.5.vvpp.txt
```

PR 後のアーティファクト名 (リリースファイル名 + github.sha)

```
voicevox_engine-linux-cpu-latest-e540de8a30f969518d3f07acaf065b512890ec68
voicevox_engine-windows-nvidia-0.14.0-sarisia.1-e540de8a30f969518d3f07acaf065b512890ec68
```

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

fixes #533

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他

- naming convention は [VOICEVOX (Editor)](https://github.com/VOICEVOX/voicevox/releases) に合わせています
- ワークフロー内部では, アーティファクト名 (`matrix.artifact_name`) は参照されている箇所が多いので変更せず, リリースファイル, 及びアーティファクトのアップロード時にリネームする方針で実装しています
- ~~アーティファクト名を変更していないので, GitHub Actions のログ画面からアーティファクトをダウンロードする場合のファイル名は変更していません. `FIXME` が付いているので, よく利用されるのであれば別 Issue で検討する必要があるかと思います:~~ この PR で対応しました.

    https://github.com/VOICEVOX/voicevox_engine/blob/fa30e5940586af810042322cb201bd2883a876b8/.github/workflows/build.yml#L486-L499

- `release-test.yml` にて, `windows-directml` のテストが漏れていましたので, 追加しています.
- フォークでテストした際のリリースファイル名, アーティファクト名はこちらで確認いただけます:

  https://github.com/sarisia/voicevox_engine/releases/tag/0.14.0-sarisia.1

  https://github.com/sarisia/voicevox_engine/actions/runs/3783184456
