### PR TITLE
flake8-bugbear 指摘事項の修正 (b027)

### DIFF
--- a/voicevox_engine/synthesis_engine/synthesis_engine_base.py
+++ b/voicevox_engine/synthesis_engine/synthesis_engine_base.py
@@ -90,7 +90,7 @@ class SynthesisEngineBase(metaclass=ABCMeta):
     def supported_devices(self) -> Optional[str]:
         raise NotImplementedError
 
-    def initialize_speaker_synthesis(self, speaker_id: int):
+    def initialize_speaker_synthesis(self, speaker_id: int):  # noqa: B027
         """
         指定した話者での音声合成を初期化する。何度も実行可能。
         未実装の場合は何もしない


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->

flake8-bugbear 22.10.25 以降で追加されたチェックルール (B027: Empty method in abstract base class with no abstract decorator) に違反するコードを修正します.

この PR では, B027 を **無視** します. 指摘のあった `initialize_speaker_synthesis()` は, docstring にもある通り,

> 未実装の場合は何もしない

のが仕様です. よって, これは抽象メソッドではなく, `@abstractmethod` デコレータを付与する必要はありません (実際, 付与するとテストが落ちます).

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

この指摘事項は #535 で依存関係 (flake8-bugbear) がアップグレードされた際に検出されました. #535 のマージにはこの PR のマージが必要です.

当該の Run: https://github.com/VOICEVOX/voicevox_engine/actions/runs/3776794325/jobs/6420846964

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
