### PR TITLE
ライセンス生成時のエラーをコンソールに出力する

### DIFF
--- a/generate_licenses.py
+++ b/generate_licenses.py
@@ -136,8 +136,8 @@ def generate_licenses() -> List[License]:
         )
 
     # pip
-    licenses_json = json.loads(
-        subprocess.run(
+    try:
+        pip_licenses_output = subprocess.run(
             "pip-licenses "
             "--from=mixed "
             "--format=json "
@@ -149,7 +149,12 @@ def generate_licenses() -> List[License]:
             check=True,
             env=os.environ,
         ).stdout.decode()
-    )
+    except subprocess.CalledProcessError as err:
+        raise Exception(
+            f"command output:\n{err.stderr and err.stderr.decode()}"
+        ) from err
+
+    licenses_json = json.loads(pip_licenses_output)
     for license_json in licenses_json:
         license = License(
             name=license_json["Name"],


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->

`generate_licenses.py` 実行時, `pip-licenses` の実行でエラーが発生した際に,
エラーメッセージをコンソールに出力します.

現在の実装では, `pip-licenses` のエラーの原因がコンソールに出力されず,
`test.yml` ワークフローのライセンスチェックが失敗した際の原因特定が困難でしたので,
この PR ではそれを改善します.

Before:

```
Traceback (most recent call last):
  File "generate_licenses.py", line 325, in <module>
    licenses = generate_licenses()
  File "generate_licenses.py", line 140, in generate_licenses
    subprocess.run(
  File "C:\hostedtoolcache\windows\Python\3.8.10\x64\lib\subprocess.py", line 516, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command 'pip-licenses --from=mixed --format=json --with-urls --with-license-file --no-license-path ' returned non-zero exit status 1.
Error: Process completed with exit code 1.
```

After:

<details>

<summary>折りたたみ</summary>

```
Traceback (most recent call last):
  File "generate_licenses.py", line 140, in generate_licenses
    pip_licenses_output = subprocess.run(
  File "C:\hostedtoolcache\windows\Python\3.8.10\x64\lib\subprocess.py", line 516, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command 'pip-licenses --from=mixed --format=json --with-urls --with-license-file --no-license-path ' returned non-zero exit status 1.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "generate_licenses.py", line 330, in <module>
    licenses = generate_licenses()
  File "generate_licenses.py", line 153, in generate_licenses
    raise Exception(
Exception: command output:
Traceback (most recent call last):

  File "C:\hostedtoolcache\windows\Python\3.8.10\x64\lib\runpy.py", line 194, in _run_module_as_main

    return _run_code(code, main_globals, None,

  File "C:\hostedtoolcache\windows\Python\3.8.10\x64\lib\runpy.py", line 87, in _run_code

    exec(code, run_globals)

  File "D:\a\voicevox_engine\voicevox_engine\venv\Scripts\pip-licenses.exe\__main__.py", line 7, in <module>

  File "d:\a\voicevox_engine\voicevox_engine\venv\lib\site-packages\piplicenses.py", line 893, in main

    output_string = create_output_string(args)

  File "d:\a\voicevox_engine\voicevox_engine\venv\lib\site-packages\piplicenses.py", line 551, in create_output_string

    table = create_licenses_table(args, output_fields)

  File "d:\a\voicevox_engine\voicevox_engine\venv\lib\site-packages\piplicenses.py", line 296, in create_licenses_table

    for pkg in get_packages(args):

  File "d:\a\voicevox_engine\voicevox_engine\venv\lib\site-packages\piplicenses.py", line [258](https://github.com/sarisia/voicevox_engine/actions/runs/3848723111/jobs/6556861771#step:11:259), in get_packages

    pkg_info = get_pkg_info(pkg)

  File "d:\a\voicevox_engine\voicevox_engine\venv\lib\site-packages\piplicenses.py", line 178, in get_pkg_info

    (license_file, license_text) = get_pkg_included_file(

  File "d:\a\voicevox_engine\voicevox_engine\venv\lib\site-packages\piplicenses.py", line 171, in get_pkg_included_file

    with open(test_file, encoding='utf-8',

PermissionError: [Errno 13] Permission denied: 'd:\\a\\voicevox_engine\\voicevox_engine\\venv\\lib\\site-packages\\platformdirs-2.6.2.dist-info\\licenses'


Error: Process completed with exit code 1.
```

</details>

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
