### PR TITLE
default_setting.yml を Dockerfile に追加する

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -197,7 +197,7 @@ COPY --from=download-onnxruntime-env /opt/onnxruntime /opt/onnxruntime
 # Add local files
 ADD ./voicevox_engine /opt/voicevox_engine/voicevox_engine
 ADD ./docs /opt/voicevox_engine/docs
-ADD ./run.py ./generate_licenses.py ./presets.yaml ./default.csv ./engine_manifest.json /opt/voicevox_engine/
+ADD ./run.py ./generate_licenses.py ./presets.yaml ./default.csv ./default_setting.yml ./engine_manifest.json /opt/voicevox_engine/
 ADD ./speaker_info /opt/voicevox_engine/speaker_info
 ADD ./engine_manifest_assets /opt/voicevox_engine/engine_manifest_assets
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -199,6 +199,7 @@ ADD ./voicevox_engine /opt/voicevox_engine/voicevox_engine
 ADD ./docs /opt/voicevox_engine/docs
 ADD ./run.py ./generate_licenses.py ./presets.yaml ./default.csv ./default_setting.yml ./engine_manifest.json /opt/voicevox_engine/
 ADD ./speaker_info /opt/voicevox_engine/speaker_info
+ADD ./ui_template /opt/voicevox_engine/ui_template
 ADD ./engine_manifest_assets /opt/voicevox_engine/engine_manifest_assets
 
 # Replace version


### PR DESCRIPTION
## 内容

この PR は default_setting.yml を Docker コンテナに含めるように変更することで、Docker コンテナが実行できない問題を解消する。

先週マージされた差分 https://github.com/VOICEVOX/voicevox_engine/commit/cfc5ff1fb23d8fc25b8d81fb1c732da69f2ebc26 にて default_setting.yml が追加されています。この差分にある SettingLoader.py はデフォルトの設定ファイルのパスにアクセスしようとします。Docker コンテナ内では `/opt/voicevox_engine/default_setting.yml` となりますが、これは Dockerfile で追加されていません。また Dockerfile で記述されている run.py の引数でも設定ファイルは指定されていません。そのため README に記載されている手順で Docker 版を pull & run して実行しようとするとエラーになります。

エラーメッセージは以下の通りです：

```
$ docker pull voicevox/voicevox_engine:cpu-ubuntu20.04-latest
$ docker run --rm -it -p '127.0.0.1:50021:50021' voicevox/voicevox_engine:cpu-ubuntu20.04-latest
+ cat /opt/voicevox_engine/README.md
## 許諾内容
(snip)
## 免責事項

本ソフトウェアにより生じた損害・不利益について、製作者は一切の責任を負いません。

## その他

ご利用の際は VOICEVOX を利用したことがわかるクレジット表記が必要です。
+ exec gosu user /opt/python/bin/python3 ./run.py --voicelib_dir /opt/voicevox_core/ --runtime_dir /opt/onnxruntime/lib --host 0.0.0.0
Warning: cpu_num_threads is set to 0. ( The library leaves the decision to the synthesis runtime )
Traceback (most recent call last):
  File "./run.py", line 1060, in <module>
    settings = setting_loader.load_setting_file()
  File "/opt/voicevox_engine/voicevox_engine/setting/SettingLoader.py", line 18, in load_setting_file
    setting = yaml.safe_load(DEFAULT_SETTING_PATH.read_text(encoding="utf-8"))
  File "/opt/python/lib/python3.8/pathlib.py", line 1236, in read_text
    with self.open(mode='r', encoding=encoding, errors=errors) as f:
  File "/opt/python/lib/python3.8/pathlib.py", line 1222, in open
    return io.open(self, mode, buffering, encoding, errors, newline,
  File "/opt/python/lib/python3.8/pathlib.py", line 1078, in _opener
    return self._accessor.open(self, flags, mode)
FileNotFoundError: [Errno 2] No such file or directory: '/opt/voicevox_engine/default_setting.yml'
```

## 関連 Issue

なし

## スクリーンショット・動画など

なし

## その他
