### PR TITLE
モーフィングの許可に関する設定およびAPIを追加

### DIFF
--- a/run.py
+++ b/run.py
@@ -502,7 +502,7 @@ def generate_app(
         engine = get_engine(core_version)
 
         is_permitted = is_synthesis_morphing_permitted(
-            engine, base_speaker, target_speaker
+            engine, root_dir / "speaker_info", base_speaker, target_speaker
         )
 
         if is_permitted is None:
@@ -537,7 +537,7 @@ def generate_app(
         engine = get_engine(core_version)
 
         is_permitted = is_synthesis_morphing_permitted(
-            engine, base_speaker, target_speaker
+            engine, root_dir / "speaker_info", base_speaker, target_speaker
         )
         if is_permitted is None:
             raise HTTPException(status_code=404, detail="該当する話者が見つかりません")

--- a/run.py
+++ b/run.py
@@ -483,6 +483,33 @@ def generate_app(
             background=BackgroundTask(delete_file, f.name),
         )
 
+    @app.get(
+        "/is_morphable",
+        response_model=bool,
+        tags=["音声合成"],
+        summary="2人の話者でモーフィングが可能かどうか返す",
+    )
+    def is_morphable(
+        base_speaker: int,
+        target_speaker: int,
+        core_version: Optional[str] = None,
+    ):
+        """
+        指定された2人の話者でモーフィング機能を利用可能か返します。
+        モーフィングの許可/禁止は`/speakers`の`speaker.supportedFeatures.synthesisMorphing`に記載されています。
+        プロパティが存在しない場合は、モーフィングが許可されているとみなします。
+        """
+        engine = get_engine(core_version)
+
+        is_permitted = is_synthesis_morphing_permitted(
+            engine, base_speaker, target_speaker
+        )
+
+        if is_permitted is None:
+            raise HTTPException(status_code=404, detail="該当する話者が見つかりません")
+
+        return is_permitted
+
     @app.post(
         "/synthesis_morphing",
         response_class=FileResponse,

--- a/run.py
+++ b/run.py
@@ -44,7 +44,7 @@ from voicevox_engine.model import (
     UserDictWord,
     WordTypes,
 )
-from voicevox_engine.morphing import synthesis_morphing
+from voicevox_engine.morphing import is_synthesis_morphing_permitted, synthesis_morphing
 from voicevox_engine.morphing import (
     synthesis_morphing_parameter as _synthesis_morphing_parameter,
 )
@@ -508,6 +508,17 @@ def generate_app(
         モーフィングの割合は`morph_rate`で指定でき、0.0でベースの話者、1.0でターゲットの話者に近づきます。
         """
         engine = get_engine(core_version)
+
+        is_permitted = is_synthesis_morphing_permitted(
+            engine, base_speaker, target_speaker
+        )
+        if is_permitted is None:
+            raise HTTPException(status_code=404, detail="該当する話者が見つかりません")
+        if not is_permitted:
+            raise HTTPException(
+                status_code=400,
+                detail="指定された話者ペアでのモーフィング機能は禁止されています",
+            )
 
         # 生成したパラメータはキャッシュされる
         morph_param = synthesis_morphing_parameter(

--- a/speaker_info/35b2c544-660e-401e-b503-0e14c635303a/metas.json
+++ b/speaker_info/35b2c544-660e-401e-b503-0e14c635303a/metas.json
@@ -1,7 +1,7 @@
 {
     "speakerName": "dummy3",
     "speakerUuid": "dummy3uuid",
-    "supportedFeatures": {"synthesisMorphing": "PROHIBIT"},
+    "supportedFeatures": {"permitedSynthesisMorphing": "NOTHING"},
     "styles": [
         {
             "styleId": 8

--- a/speaker_info/35b2c544-660e-401e-b503-0e14c635303a/metas.json
+++ b/speaker_info/35b2c544-660e-401e-b503-0e14c635303a/metas.json
@@ -1,6 +1,7 @@
 {
     "speakerName": "dummy3",
     "speakerUuid": "dummy3uuid",
+    "supportedFeatures": {"synthesisMorphing": "PROHIBIT"},
     "styles": [
         {
             "styleId": 8

--- a/speaker_info/388f246b-8c41-4ac1-8e2d-5d79f3ff56d9/metas.json
+++ b/speaker_info/388f246b-8c41-4ac1-8e2d-5d79f3ff56d9/metas.json
@@ -1,6 +1,7 @@
 {
     "speakerName": "dummy2",
     "speakerUuid": "dummy2uuid",
+    "supportedFeatures": {"synthesisMorphing": "SELF_MORPHING_ONLY"},
     "styles": [
         {
             "styleId": 3

--- a/speaker_info/388f246b-8c41-4ac1-8e2d-5d79f3ff56d9/metas.json
+++ b/speaker_info/388f246b-8c41-4ac1-8e2d-5d79f3ff56d9/metas.json
@@ -1,7 +1,7 @@
 {
     "speakerName": "dummy2",
     "speakerUuid": "dummy2uuid",
-    "supportedFeatures": {"synthesisMorphing": "SELF_MORPHING_ONLY"},
+    "supportedFeatures": {"permitedSynthesisMorphing": "SELF_ONLY"},
     "styles": [
         {
             "styleId": 3

--- a/speaker_info/b1a81618-b27b-40d2-b0ea-27a9ad408c4b/metas.json
+++ b/speaker_info/b1a81618-b27b-40d2-b0ea-27a9ad408c4b/metas.json
@@ -1,6 +1,7 @@
 {
     "speakerName": "dummy4",
     "speakerUuid": "dummy4uuid",
+    "supportedFeatures": {"synthesisMorphing": "PERMIT"},
     "styles": [
         {
             "styleId": 9

--- a/speaker_info/b1a81618-b27b-40d2-b0ea-27a9ad408c4b/metas.json
+++ b/speaker_info/b1a81618-b27b-40d2-b0ea-27a9ad408c4b/metas.json
@@ -1,7 +1,7 @@
 {
     "speakerName": "dummy4",
     "speakerUuid": "dummy4uuid",
-    "supportedFeatures": {"synthesisMorphing": "PERMIT"},
+    "supportedFeatures": {"permitedSynthesisMorphing": "ALL"},
     "styles": [
         {
             "styleId": 9

--- a/voicevox_engine/dev/core/mock.py
+++ b/voicevox_engine/dev/core/mock.py
@@ -89,6 +89,7 @@ def metas() -> str:
                     {"name": "style2", "id": 5},
                     {"name": "style3", "id": 7},
                 ],
+                "supported_features": {"synthesis_morphing": "SELF_MORPHING_ONLY"},
                 "speaker_uuid": "388f246b-8c41-4ac1-8e2d-5d79f3ff56d9",
                 "version": "mock",
             },
@@ -97,6 +98,7 @@ def metas() -> str:
                 "styles": [
                     {"name": "style0", "id": 8},
                 ],
+                "supported_features": {"synthesis_morphing": "PERMIT"},
                 "speaker_uuid": "35b2c544-660e-401e-b503-0e14c635303a",
                 "version": "mock",
             },
@@ -105,6 +107,7 @@ def metas() -> str:
                 "styles": [
                     {"name": "style0", "id": 9},
                 ],
+                "supported_features": {"synthesis_morphing": "PROHIBIT"},
                 "speaker_uuid": "b1a81618-b27b-40d2-b0ea-27a9ad408c4b",
                 "version": "mock",
             },

--- a/voicevox_engine/dev/core/mock.py
+++ b/voicevox_engine/dev/core/mock.py
@@ -89,7 +89,6 @@ def metas() -> str:
                     {"name": "style2", "id": 5},
                     {"name": "style3", "id": 7},
                 ],
-                "supported_features": {"synthesis_morphing": "SELF_MORPHING_ONLY"},
                 "speaker_uuid": "388f246b-8c41-4ac1-8e2d-5d79f3ff56d9",
                 "version": "mock",
             },
@@ -98,7 +97,6 @@ def metas() -> str:
                 "styles": [
                     {"name": "style0", "id": 8},
                 ],
-                "supported_features": {"synthesis_morphing": "PERMIT"},
                 "speaker_uuid": "35b2c544-660e-401e-b503-0e14c635303a",
                 "version": "mock",
             },
@@ -107,7 +105,6 @@ def metas() -> str:
                 "styles": [
                     {"name": "style0", "id": 9},
                 ],
-                "supported_features": {"synthesis_morphing": "PROHIBIT"},
                 "speaker_uuid": "b1a81618-b27b-40d2-b0ea-27a9ad408c4b",
                 "version": "mock",
             },

--- a/voicevox_engine/model.py
+++ b/voicevox_engine/model.py
@@ -114,9 +114,9 @@ class SpeakerStyle(BaseModel):
 
 
 class SpeakerSupportSynthesisMorphing(str, Enum):
-    PERMIT = "PERMIT" # 全て許可
-    SELF_MORPHING_ONLY = "SELF_MORPHING_ONLY" # 同じ話者内でのみ許可
-    PROHIBIT = "PROHIBIT" # 全て禁止
+    PERMIT = "PERMIT"  # 全て許可
+    SELF_MORPHING_ONLY = "SELF_MORPHING_ONLY"  # 同じ話者内でのみ許可
+    PROHIBIT = "PROHIBIT"  # 全て禁止
 
     @classmethod
     def _missing_(cls, value: object) -> "SpeakerSupportSynthesisMorphing":

--- a/voicevox_engine/model.py
+++ b/voicevox_engine/model.py
@@ -125,7 +125,7 @@ class SpeakerSupportSynthesisMorphing(str, Enum):
 
 class SpeakerSupportedFeatures(BaseModel):
     """
-    スピーカーの対応機能
+    話者の対応機能の情報
     """
 
     synthesis_morphing: Optional[SpeakerSupportSynthesisMorphing] = Field(

--- a/voicevox_engine/model.py
+++ b/voicevox_engine/model.py
@@ -113,6 +113,26 @@ class SpeakerStyle(BaseModel):
     id: int = Field(title="スタイルID")
 
 
+class SpeakerSupportSynthesisMorphing(str, Enum):
+    PREMIT = "PREMIT"
+    SELF_MORPHING_ONLY = "SELF_MORPHING_ONLY"
+    PROHIBIT = "PROHIBIT"
+
+    @classmethod
+    def _missing_(cls, value: object) -> "SpeakerSupportSynthesisMorphing":
+        return SpeakerSupportSynthesisMorphing.PREMIT
+
+
+class SpeakerSupportedFeatures(BaseModel):
+    """
+    スピーカーの対応機能
+    """
+
+    synthesis_morphing: Optional[SpeakerSupportSynthesisMorphing] = Field(
+        title="モーフィング機能への対応", default=SpeakerSupportSynthesisMorphing(None)
+    )
+
+
 class Speaker(BaseModel):
     """
     スピーカー情報
@@ -120,6 +140,7 @@ class Speaker(BaseModel):
 
     name: str = Field(title="名前")
     speaker_uuid: str = Field(title="スピーカーのUUID")
+    supported_features: Optional[SpeakerSupportedFeatures] = Field(title="スピーカーの対応機能")
     styles: List[SpeakerStyle] = Field(title="スピーカースタイルの一覧")
     version: str = Field("スピーカーのバージョン")
 

--- a/voicevox_engine/model.py
+++ b/voicevox_engine/model.py
@@ -166,6 +166,12 @@ class SpeakerInfo(BaseModel):
     style_infos: List[StyleInfo] = Field(title="スタイルの追加情報")
 
 
+class SpeakerNotFoundError(LookupError):
+    def __init__(self, speaker: int, *args: object, **kywrds: object) -> None:
+        self.speaker = speaker
+        super().__init__(f"speaker {speaker} is not found.", *args, **kywrds)
+
+
 class DownloadableLibrary(BaseModel):
     """
     ダウンロード可能な音声ライブラリの情報（最新情報をwebで取得することを考慮して、ローカルの情報はない）

--- a/voicevox_engine/model.py
+++ b/voicevox_engine/model.py
@@ -113,14 +113,14 @@ class SpeakerStyle(BaseModel):
     id: int = Field(title="スタイルID")
 
 
-class SpeakerSupportSynthesisMorphing(str, Enum):
-    PERMIT = "PERMIT"  # 全て許可
-    SELF_MORPHING_ONLY = "SELF_MORPHING_ONLY"  # 同じ話者内でのみ許可
-    PROHIBIT = "PROHIBIT"  # 全て禁止
+class SpeakerSupporPermitedSynthesisMorphing(str, Enum):
+    ALL = "ALL"  # 全て許可
+    SELF_ONLY = "SELF_ONLY"  # 同じ話者内でのみ許可
+    NOTHING = "NOTHING"  # 全て禁止
 
     @classmethod
-    def _missing_(cls, value: object) -> "SpeakerSupportSynthesisMorphing":
-        return SpeakerSupportSynthesisMorphing.PERMIT
+    def _missing_(cls, value: object) -> "SpeakerSupporPermitedSynthesisMorphing":
+        return SpeakerSupporPermitedSynthesisMorphing.ALL
 
 
 class SpeakerSupportedFeatures(BaseModel):
@@ -128,8 +128,10 @@ class SpeakerSupportedFeatures(BaseModel):
     話者の対応機能の情報
     """
 
-    synthesis_morphing: Optional[SpeakerSupportSynthesisMorphing] = Field(
-        title="モーフィング機能への対応", default=SpeakerSupportSynthesisMorphing(None)
+    permited_synthesis_morphing: Optional[
+        SpeakerSupporPermitedSynthesisMorphing
+    ] = Field(
+        title="モーフィング機能への対応", default=SpeakerSupporPermitedSynthesisMorphing(None)
     )
 
 

--- a/voicevox_engine/model.py
+++ b/voicevox_engine/model.py
@@ -114,13 +114,13 @@ class SpeakerStyle(BaseModel):
 
 
 class SpeakerSupportSynthesisMorphing(str, Enum):
-    PREMIT = "PREMIT"
+    PERMIT = "PERMIT"
     SELF_MORPHING_ONLY = "SELF_MORPHING_ONLY"
     PROHIBIT = "PROHIBIT"
 
     @classmethod
     def _missing_(cls, value: object) -> "SpeakerSupportSynthesisMorphing":
-        return SpeakerSupportSynthesisMorphing.PREMIT
+        return SpeakerSupportSynthesisMorphing.PERMIT
 
 
 class SpeakerSupportedFeatures(BaseModel):

--- a/voicevox_engine/model.py
+++ b/voicevox_engine/model.py
@@ -114,9 +114,9 @@ class SpeakerStyle(BaseModel):
 
 
 class SpeakerSupportSynthesisMorphing(str, Enum):
-    PERMIT = "PERMIT"
-    SELF_MORPHING_ONLY = "SELF_MORPHING_ONLY"
-    PROHIBIT = "PROHIBIT"
+    PERMIT = "PERMIT" # 全て許可
+    SELF_MORPHING_ONLY = "SELF_MORPHING_ONLY" # 同じ話者内でのみ許可
+    PROHIBIT = "PROHIBIT" # 全て禁止
 
     @classmethod
     def _missing_(cls, value: object) -> "SpeakerSupportSynthesisMorphing":

--- a/voicevox_engine/morphing.py
+++ b/voicevox_engine/morphing.py
@@ -104,8 +104,6 @@ def is_synthesis_morphing_permitted(
         )
     )
 
-    print(base_speaker_morphing_info, target_speaker_morphing_info)
-    print(base_speaker_uuid, target_speaker_uuid)
     # 禁止されている場合はFalse
     if (
         base_speaker_morphing_info == SpeakerSupporPermitedSynthesisMorphing.NOTHING

--- a/voicevox_engine/morphing.py
+++ b/voicevox_engine/morphing.py
@@ -89,8 +89,8 @@ def is_synthesis_morphing_permitted(
     ):
         return base_speaker_info["speaker_uuid"] == target_speaker_info["speaker_uuid"]
     return (
-        base_speaker_morphing_info == SpeakerSupportSynthesisMorphing.PREMIT
-        and target_speaker_morphing_info == SpeakerSupportSynthesisMorphing.PREMIT
+        base_speaker_morphing_info == SpeakerSupportSynthesisMorphing.PERMIT
+        and target_speaker_morphing_info == SpeakerSupportSynthesisMorphing.PERMIT
     )
 
 

--- a/voicevox_engine/morphing.py
+++ b/voicevox_engine/morphing.py
@@ -8,7 +8,11 @@ import pyworld as pw
 
 from voicevox_engine.synthesis_engine.synthesis_engine_base import SynthesisEngineBase
 
-from .model import AudioQuery, SpeakerNotFoundError, SpeakerSupportSynthesisMorphing
+from .model import (
+    AudioQuery,
+    SpeakerNotFoundError,
+    SpeakerSupporPermitedSynthesisMorphing,
+)
 from .synthesis_engine import SynthesisEngine
 
 
@@ -88,35 +92,38 @@ def is_synthesis_morphing_permitted(
     )
 
     # FIXME: 他にsupported_featuresができたら共通化する
-    base_speaker_morphing_info: SpeakerSupportSynthesisMorphing = (
+    base_speaker_morphing_info: SpeakerSupporPermitedSynthesisMorphing = (
         base_speaker_engine_info.get("supportedFeatures", dict()).get(
-            "synthesisMorphing", SpeakerSupportSynthesisMorphing(None)
+            "permitedSynthesisMorphing", SpeakerSupporPermitedSynthesisMorphing(None)
         )
     )
 
-    target_speaker_morphing_info: SpeakerSupportSynthesisMorphing = (
+    target_speaker_morphing_info: SpeakerSupporPermitedSynthesisMorphing = (
         target_speaker_engine_info.get("supportedFeatures", dict()).get(
-            "synthesisMorphing", SpeakerSupportSynthesisMorphing(None)
+            "permitedSynthesisMorphing", SpeakerSupporPermitedSynthesisMorphing(None)
         )
     )
 
+    print(base_speaker_morphing_info, target_speaker_morphing_info)
+    print(base_speaker_uuid, target_speaker_uuid)
     # 禁止されている場合はFalse
     if (
-        base_speaker_morphing_info == SpeakerSupportSynthesisMorphing.PROHIBIT
-        or target_speaker_morphing_info == SpeakerSupportSynthesisMorphing.PROHIBIT
+        base_speaker_morphing_info == SpeakerSupporPermitedSynthesisMorphing.NOTHING
+        or target_speaker_morphing_info
+        == SpeakerSupporPermitedSynthesisMorphing.NOTHING
     ):
         return False
     # 同一話者のみの場合は同一話者判定
     if (
-        base_speaker_morphing_info == SpeakerSupportSynthesisMorphing.SELF_MORPHING_ONLY
+        base_speaker_morphing_info == SpeakerSupporPermitedSynthesisMorphing.SELF_ONLY
         or target_speaker_morphing_info
-        == SpeakerSupportSynthesisMorphing.SELF_MORPHING_ONLY
+        == SpeakerSupporPermitedSynthesisMorphing.SELF_ONLY
     ):
         return base_speaker_uuid == target_speaker_uuid
     # 念のため許可されているかチェック
     return (
-        base_speaker_morphing_info == SpeakerSupportSynthesisMorphing.PERMIT
-        and target_speaker_morphing_info == SpeakerSupportSynthesisMorphing.PERMIT
+        base_speaker_morphing_info == SpeakerSupporPermitedSynthesisMorphing.ALL
+        and target_speaker_morphing_info == SpeakerSupporPermitedSynthesisMorphing.ALL
     )
 
 

--- a/voicevox_engine/morphing.py
+++ b/voicevox_engine/morphing.py
@@ -2,14 +2,13 @@ import json
 from copy import deepcopy
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
 
 import numpy as np
 import pyworld as pw
 
 from voicevox_engine.synthesis_engine.synthesis_engine_base import SynthesisEngineBase
 
-from .model import AudioQuery, SpeakerSupportSynthesisMorphing
+from .model import AudioQuery, SpeakerNotFoundError, SpeakerSupportSynthesisMorphing
 from .synthesis_engine import SynthesisEngine
 
 
@@ -53,10 +52,10 @@ def is_synthesis_morphing_permitted(
     speaker_info_folder: Path,
     base_speaker: int,
     target_speaker: int,
-) -> Optional[bool]:
+) -> bool:
     """
     指定されたspeakerがモーフィング可能かどうか返す
-    speakerが見つからない場合はNoneを返す
+    speakerが見つからない場合はSpeakerNotFoundErrorを送出する
     """
 
     core_speakers = json.loads(engine.speakers)
@@ -69,7 +68,9 @@ def is_synthesis_morphing_permitted(
             target_speaker_core_info = speaker
 
     if base_speaker_core_info is None or target_speaker_core_info is None:
-        return None
+        raise SpeakerNotFoundError(
+            base_speaker if base_speaker_core_info is None else target_speaker
+        )
 
     base_speaker_uuid = base_speaker_core_info["speaker_uuid"]
     target_speaker_uuid = target_speaker_core_info["speaker_uuid"]


### PR DESCRIPTION
## 内容

+ https://github.com/VOICEVOX/voicevox_engine/issues/577
の実装です。

metasの`speaker`に`supportedFeatures`プロパティをオプショナルで追加しています。

`SpeakerSupportedFeatures`の`synthesisMorphing`プロパティの値として`PREMIT | SELF_MORPHING_ONLY | PROHIBIT`を設定することで、それぞれの`Speaker`に対してモーフィングの可否を設定できます。
プロパティが存在しない場合は`PREMIT`と等価です。

## 関連 Issue

close #577

## スクリーンショット・動画など

## その他
