### PR TITLE
WindowsではPyInstallerのbootloaderをカスタマイズする

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -270,8 +270,10 @@ jobs:
         run: |
           python -m pip install -r requirements-dev.txt
 
-          # Modify PyInstaller to enable NvOptimusEnablement and AmdPowerXpressRequestHighPerformance
-          ./build_util/modify_pyinstaller.bash
+          if [ "$RUNNER_OS" = Windows ]; then
+            # Modify PyInstaller to enable NvOptimusEnablement and AmdPowerXpressRequestHighPerformance
+            ./build_util/modify_pyinstaller.bash
+          fi
 
           # Download pyopenjtalk dictionary
           # try 5 times, sleep 5 seconds before retry

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -270,6 +270,9 @@ jobs:
         run: |
           python -m pip install -r requirements-dev.txt
 
+          # Modify PyInstaller to enable NvOptimusEnablement and AmdPowerXpressRequestHighPerformance
+          ./build_util/modify_pyinstaller.bash
+
           # Download pyopenjtalk dictionary
           # try 5 times, sleep 5 seconds before retry
           for i in $(seq 5); do

--- a/build_util/modify_pyinstaller.bash
+++ b/build_util/modify_pyinstaller.bash
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# PyInstallerをカスタマイズしてから再インストールする
+# 良いGPUが自動的に選択されるようにしている
+# https://github.com/VOICEVOX/voicevox_engine/issues/502
+
 set -eux
 
 pyinstaller_version=$(pyinstaller -v)


### PR DESCRIPTION
## 内容

PyInstallerのbootloaderをカスタマイズすることで、[`NvOptimusEnablement`](https://docs.nvidia.com/gameworks/content/technologies/desktop/optimus.htm)と[`AmdPowerXpressRequestHighPerformance`](https://gpuopen.com/learn/amdpowerxpressrequesthighperformance/)を有効化します。

これによりNVIDIA Control Panel等での設定が無くても、内蔵GPUより外付けのものが優先されるようになるはずです。

## 関連 Issue

Resolves #502.

## スクリーンショット・動画など

![image](https://user-images.githubusercontent.com/14125495/215301367-785f1548-1f48-4f3e-b6c0-edc111a591f6.png)

## その他

@y-chan さんの[コメント](https://github.com/VOICEVOX/voicevox_engine/issues/502#issuecomment-1407417825)が非常に参考になりました。コミットメッセージにも書きましたが、重ねてお礼申し上げます。
