### PR TITLE
/settingのAllow Originを設定しても正しく認識しない

### DIFF
--- a/run.py
+++ b/run.py
@@ -1195,7 +1195,13 @@ if __name__ == "__main__":
     )
 
     allow_origin = (
-        args.allow_origin if args.allow_origin is not None else settings.allow_origin
+        args.allow_origin
+        if args.allow_origin is not None
+        else (
+            settings.allow_origin.split(" ")
+            if settings.allow_origin is not None
+            else None
+        )
     )
 
     uvicorn.run(

--- a/run.py
+++ b/run.py
@@ -1194,15 +1194,11 @@ if __name__ == "__main__":
         else settings.cors_policy_mode
     )
 
-    allow_origin = (
-        args.allow_origin
-        if args.allow_origin is not None
-        else (
-            settings.allow_origin.split(" ")
-            if settings.allow_origin is not None
-            else None
-        )
-    )
+    allow_origin = None
+    if args.allow_origin is not None:
+        allow_origin = args.allow_origin
+    elif settings.allow_origin is not None:
+        allow_origin = settings.allow_origin.split(" ")
 
     uvicorn.run(
         generate_app(


### PR DESCRIPTION
## 内容

Allow Originの設定としてSettingsに書いたものを使う場合に、正しくホスト名を認識していませんでした。
コードを確認したところ、`settings.allow_origin`が文字列なのに`generate_app`の`List[str]`な引数にそのまま渡しているため、1文字ずつに分解されているようでした。
そのため、引数のAllow Originと、Settingsのものをどちらか使うかを判定する部分で、`settings.allow_origin`をリストに変換するようにしました。
この変換は/settingページの説明で、半角スペースで複数のオリジンを複数指定できるとありましたので、`settings.allow_origin.split(" ")`で分割・リスト化しています。

## 関連 Issue

## スクリーンショット・動画など

## その他
