### PR TITLE
FIX: update_dictのエラーハンドリングを改善

### DIFF
--- a/voicevox_engine/user_dict.py
+++ b/voicevox_engine/user_dict.py
@@ -1,6 +1,7 @@
 import json
 import shutil
 import sys
+import traceback
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import Dict, List, Optional
@@ -92,6 +93,10 @@ def update_dict(
     pyopenjtalk.unset_user_dict()
     try:
         shutil.move(tmp_dict_path, compiled_dict_path)  # ドライブを跨ぐためPath.replaceが使えない
+    except OSError:
+        traceback.print_exc()
+        if tmp_dict_path.exists():
+            delete_file(tmp_dict_path.name)
     finally:
         if compiled_dict_path.is_file():
             pyopenjtalk.set_user_dict(str(compiled_dict_path.resolve(strict=True)))


### PR DESCRIPTION
## 内容

update_dictで一時ディレクトリから移動するエラーハンドリングが間違っていたので修正しました

## その他

主にWindows環境でエンジンを多重起動したときに発生します。
この修正により辞書の更新に失敗してもそのまま起動することができます。
ただし、2つのエンジンが1つの辞書をロックすることになるので起動しているエンジンが1つになるまで辞書の更新ができない問題は解決しませんが…