### PR TITLE
FIX: デフォルト以外のサンプリングレートで正常にモーフィングができない問題への対策

### DIFF
--- a/run.py
+++ b/run.py
@@ -579,6 +579,7 @@ def generate_app(
         morph_wave = synthesis_morphing(
             morph_param=morph_param,
             morph_rate=morph_rate,
+            output_fs=query.outputSamplingRate,
             output_stereo=query.outputStereo,
         )
 
@@ -586,7 +587,7 @@ def generate_app(
             soundfile.write(
                 file=f,
                 data=morph_wave,
-                samplerate=morph_param.fs,
+                samplerate=query.outputSamplingRate,
                 format="WAV",
             )
 

--- a/voicevox_engine/morphing.py
+++ b/voicevox_engine/morphing.py
@@ -198,6 +198,7 @@ def synthesis_morphing(
         morph_param.frame_period,
     )
 
+    # TODO: synthesis_engine.py でのリサンプル処理と共通化する
     if output_fs != morph_param.fs:
         y_h = resample(y_h, output_fs * len(y_h) // morph_param.fs)
 

--- a/voicevox_engine/morphing.py
+++ b/voicevox_engine/morphing.py
@@ -16,7 +16,7 @@ from .synthesis_engine import SynthesisEngine
 # FIXME: ndarray type hint, https://github.com/JeremyCCHsu/Python-Wrapper-for-World-Vocoder/blob/2b64f86197573497c685c785c6e0e743f407b63e/pyworld/pyworld.pyx#L398  # noqa
 @dataclass(frozen=True)
 class MorphingParameter:
-    fs: float
+    fs: int
     frame_period: float
     base_f0: np.ndarray
     base_aperiodicity: np.ndarray
@@ -27,7 +27,7 @@ class MorphingParameter:
 def create_morphing_parameter(
     base_wave: np.ndarray,
     target_wave: np.ndarray,
-    fs: float,
+    fs: int,
 ) -> MorphingParameter:
     frame_period = 1.0
     base_f0, base_time_axis = pw.harvest(base_wave, fs, frame_period=frame_period)


### PR DESCRIPTION
## 内容

デフォルトのサンプリングレート以外だとなぜかうまくWORLDで合成ができないようなのでとりあえずデフォルトのサンプリングレートで合成を行った後にサンプリングレートの変更を行います。

## 関連 Issue

- ref VOICEVOX/voicevox#1169

## その他

WORLDや合成音声関係の知識がほぼないのでこの変更で起こる悪影響が正直分かりません。
