### PR TITLE
辞書が壊れてエンジンが起動しなくなる #623 の解決

### DIFF
--- a/voicevox_engine/user_dict.py
+++ b/voicevox_engine/user_dict.py
@@ -2,7 +2,6 @@ import json
 import shutil
 import sys
 import threading
-import traceback
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import Dict, List, Optional
@@ -99,10 +98,6 @@ def update_dict(
     try:
         with mutex_openjtalk_dict:
             shutil.move(tmp_dict_path, compiled_dict_path)  # ドライブを跨ぐためPath.replaceが使えない
-    except OSError:
-        traceback.print_exc()
-        if tmp_dict_path.exists():
-            delete_file(tmp_dict_path.name)
     finally:
         with mutex_openjtalk_dict:
             if compiled_dict_path.is_file():

--- a/voicevox_engine/utility/__init__.py
+++ b/voicevox_engine/utility/__init__.py
@@ -3,6 +3,7 @@ from .connect_base64_waves import (
     connect_base64_waves,
     decode_base64_waves,
 )
+from .mutex_utility import mutex_wrapper
 from .path_utility import delete_file, engine_root, get_save_dir
 
 __all__ = [
@@ -12,4 +13,5 @@ __all__ = [
     "delete_file",
     "engine_root",
     "get_save_dir",
+    "mutex_wrapper",
 ]

--- a/voicevox_engine/utility/mutex_utility.py
+++ b/voicevox_engine/utility/mutex_utility.py
@@ -1,0 +1,15 @@
+import threading
+
+
+def mutex_wrapper(lock: threading.Lock):
+    def wrap(f):
+        def func(*args, **kw):
+            lock.acquire()
+            try:
+                return f(*args, **kw)
+            finally:
+                lock.release()
+
+        return func
+
+    return wrap


### PR DESCRIPTION
## 内容

辞書周りにLockを２つ導入します。
user_dict.jsonの排他制御と、pyopenjtalkによる読み込みの排他制御です。

## 関連 Issue

close #623
<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## その他

テスト用コマンド
```bash

for i in {1..10}; do
    curl -s -X POST "localhost:50021/user_dict_word" \
        --get \
        --data-urlencode "surface=test$i" \
        --data-urlencode "pronunciation=テスト" \
        --data-urlencode "accent_type=1" &
done
wait
```
