### PR TITLE
分割を1900Mに変更

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -589,11 +589,11 @@ jobs:
       - name: Rearchive and split artifact
         run: |
           # Compress to artifact.7z.001, artifact.7z.002, ...
-          7z -r -v2g a "${{ steps.vars.outputs.package_name }}.7z" "${{ matrix.target }}/"
+          7z -r -v1900m a "${{ steps.vars.outputs.package_name }}.7z" "${{ matrix.target }}/"
 
           # Compress to artifact.001.vvppp,artifact.002.vvppp, ...
           (cd "${{ matrix.target }}" && zip -r - . > ../compressed.zip)
-          split -b 2G --numeric-suffixes=1 -a 3 --additional-suffix .vvppp ./compressed.zip ./${{ steps.vars.outputs.package_name }}.
+          split -b 1900M --numeric-suffixes=1 -a 3 --additional-suffix .vvppp ./compressed.zip ./${{ steps.vars.outputs.package_name }}.
 
           # Rename to artifact.vvpp if there are only artifact.001.vvppp
           if [ "$(ls ${{ steps.vars.outputs.package_name }}.*.vvppp | wc -l)" == 1 ]; then


### PR DESCRIPTION
## 内容

github releaseの容量は2GBだけど、`File size (2147483648) is greater than 2 GB`というエラーが出ていました。
2GiBと2GBの差ですね。。。。

1900Mにすれば1900MiB=1.992294GBなので大丈夫なはず。

## その他

エディタは1GB分割なので合わせても良かったかもですが、エンジンダウンロード機構があるアプリに影響があるためとりあえず1900MiB分割で
