### PR TITLE
EngineManifestの変更にEngineManifestLoaderを追従させる

### DIFF
--- a/voicevox_engine/engine_manifest/EngineManifestLoader.py
+++ b/voicevox_engine/engine_manifest/EngineManifestLoader.py
@@ -38,8 +38,6 @@ class EngineManifestLoader:
                     (self.root_dir / manifest["dependency_licenses"]).read_text("utf-8")
                 )
             ],
-            downloadable_libraries_path=manifest["downloadable_libraries_path"],
-            downloadable_libraries_url=manifest["downloadable_libraries_url"],
             supported_features={
                 key: item["value"]
                 for key, item in manifest["supported_features"].items()


### PR DESCRIPTION
## 内容

EngineManifestの変更に対してLoaderが古いままであることが原因でエラーが発生してしまっていたので、これを修正します。

## 関連 Issue

- #616 

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
