### PR TITLE
add: DockerHub で提供されているイメージに arm 版を追加

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -36,50 +36,106 @@ jobs:
           - nvidia-ubuntu20.04
           - cpu-ubuntu18.04
           - nvidia-ubuntu18.04
+        tag_platform_prefix:
+          - amd64
+          - arm64
+        exclude:
+          - tag: nvidia
+            tag_platform_prefix: arm64
+          - tag: nvidia-ubuntu20.04
+            tag_platform_prefix: arm64
+          - tag: nvidia-ubuntu18.04
+            tag_platform_prefix: arm64
         include:
           # Ubuntu 20.04
           - tag: ""
+            tag_platform_prefix: amd64
             target: runtime-env
             base_image: ubuntu:20.04
             base_runtime_image: ubuntu:20.04
-            onnxruntime_version: 1.13.1
-            platforms: linux/amd64,linux/arm64/v8
+            voicevox_core_asset_prefix: voicevox_core-linux-x64-cpu
+            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.13.1/onnxruntime-linux-x64-1.13.1.tgz
+            platforms: linux/amd64
+          - tag: ""
+            tag_platform_prefix: arm64
+            target: runtime-env
+            base_image: ubuntu:20.04
+            base_runtime_image: ubuntu:20.04
+            voicevox_core_asset_prefix: voicevox_core-linux-arm64-cpu
+            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.14.1/onnxruntime-linux-aarch64-1.14.1.tgz
+            platforms: linux/arm64/v8
           - tag: cpu
+            tag_platform_prefix: amd64
             target: runtime-env
             base_image: ubuntu:20.04
             base_runtime_image: ubuntu:20.04
-            onnxruntime_version: 1.13.1
-            platforms: linux/amd64,linux/arm64/v8
+            voicevox_core_asset_prefix: voicevox_core-linux-x64-cpu
+            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.13.1/onnxruntime-linux-x64-1.13.1.tgz
+            platforms: linux/amd64
+          - tag: cpu
+            tag_platform_prefix: arm64
+            target: runtime-env
+            base_image: ubuntu:20.04
+            base_runtime_image: ubuntu:20.04
+            voicevox_core_asset_prefix: voicevox_core-linux-arm64-cpu
+            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.14.1/onnxruntime-linux-aarch64-1.14.1.tgz
+            platforms: linux/arm64/v8
           - tag: cpu-ubuntu20.04
+            tag_platform_prefix: amd64
             target: runtime-env
             base_image: ubuntu:20.04
             base_runtime_image: ubuntu:20.04
-            onnxruntime_version: 1.13.1
-            platforms: linux/amd64,linux/arm64/v8
+            voicevox_core_asset_prefix: voicevox_core-linux-x64-cpu
+            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.13.1/onnxruntime-linux-x64-1.13.1.tgz
+            platforms: linux/amd64
+          - tag: cpu-ubuntu20.04
+            tag_platform_prefix: arm64
+            target: runtime-env
+            base_image: ubuntu:20.04
+            base_runtime_image: ubuntu:20.04
+            voicevox_core_asset_prefix: voicevox_core-linux-arm64-cpu
+            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.14.1/onnxruntime-linux-aarch64-1.14.1.tgz
+            platforms: linux/arm64/v8
           - tag: nvidia
+            tag_platform_prefix: amd64
             target: runtime-nvidia-env
             base_image: ubuntu:20.04
             base_runtime_image: nvidia/cuda:11.6.2-cudnn8-runtime-ubuntu20.04
-            onnxruntime_version: 1.13.1
+            voicevox_core_asset_prefix: voicevox_core-linux-x64-gpu
+            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.13.1/onnxruntime-linux-x64-gpu-1.13.1.tgz
             platforms: linux/amd64
           - tag: nvidia-ubuntu20.04
+            tag_platform_prefix: amd64
             target: runtime-nvidia-env
             base_image: ubuntu:20.04
             base_runtime_image: nvidia/cuda:11.6.2-cudnn8-runtime-ubuntu20.04
-            onnxruntime_version: 1.13.1
+            voicevox_core_asset_prefix: voicevox_core-linux-x64-gpu
+            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.13.1/onnxruntime-linux-x64-gpu-1.13.1.tgz
             platforms: linux/amd64
           # Ubuntu 18.04
           - tag: cpu-ubuntu18.04
+            tag_platform_prefix: amd64
             target: runtime-env
             base_image: ubuntu:18.04
             base_runtime_image: ubuntu:18.04
-            onnxruntime_version: 1.13.1
-            platforms: linux/amd64,linux/arm64/v8
+            voicevox_core_asset_prefix: voicevox_core-linux-x64-cpu
+            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.13.1/onnxruntime-linux-x64-1.13.1.tgz
+            platforms: linux/amd64
+          - tag: cpu-ubuntu18.04
+            tag_platform_prefix: arm64
+            target: runtime-env
+            base_image: ubuntu:18.04
+            base_runtime_image: ubuntu:18.04
+            voicevox_core_asset_prefix: voicevox_core-linux-x64-cpu
+            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.14.1/onnxruntime-linux-aarch64-1.14.1.tgz
+            platforms: linux/arm64/v8
           - tag: nvidia-ubuntu18.04
+            tag_platform_prefix: amd64
             target: runtime-nvidia-env
             base_image: ubuntu:18.04
             base_runtime_image: nvidia/cuda:11.6.2-cudnn8-runtime-ubuntu18.04
-            onnxruntime_version: 1.13.1
+            voicevox_core_asset_prefix: voicevox_core-linux-x64-gpu
+            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.13.1/onnxruntime-linux-x64-gpu-1.13.1.tgz
             platforms: linux/amd64
 
     steps:
@@ -131,6 +187,7 @@ jobs:
                 format('{0}:{1}-{2}', env.IMAGE_NAME, matrix.tag, env.VOICEVOX_ENGINE_VERSION)
               ) || format('{0}:{1}', env.IMAGE_NAME, env.VOICEVOX_ENGINE_VERSION)
             ) }}
+          VOICEVOX_CORE_ASSET_NAME: ${{ matrix.voicevox_core_asset_prefix }}-${{ env.VOICEVOX_CORE_VERSION }}
         with:
           context: .
           builder: ${{ steps.buildx.outputs.name }}
@@ -140,13 +197,104 @@ jobs:
             BASE_RUNTIME_IMAGE=${{ matrix.base_runtime_image }}
             PYTHON_VERSION=${{ env.PYTHON_VERSION }}
             VOICEVOX_ENGINE_VERSION=${{ env.VOICEVOX_ENGINE_VERSION }}
+            VOICEVOX_CORE_ASSET_NAME=${{ env.VOICEVOX_CORE_ASSET_NAME }}
             VOICEVOX_CORE_VERSION=${{ env.VOICEVOX_CORE_VERSION }}
             VOICEVOX_RESOURCE_VERSION=${{ env.VOICEVOX_RESOURCE_VERSION }}
-            USE_GPU=${{ matrix.target == 'runtime-nvidia-env' }}
-            ONNXRUNTIME_VERSION=${{ matrix.onnxruntime_version }}
+            ONNXRUNTIME_URL=${{ matrix.onnxruntime_url }}
           target: ${{ matrix.target }}
           push: true
-          tags: ${{ env.IMAGE_TAG }}
-          cache-from: type=registry,ref=${{ env.IMAGE_TAG }}-buildcache
-          cache-to: type=registry,ref=${{ env.IMAGE_TAG }}-buildcache,mode=max
+          tags: ${{ env.IMAGE_TAG }}-${{ matrix.tag_platform_prefix }}
+          cache-from: type=registry,ref=${{ env.IMAGE_TAG }}-${{ matrix.tag_platform_prefix }}-buildcache
+          cache-to: type=registry,ref=${{ env.IMAGE_TAG }}-${{ matrix.tag_platform_prefix }}-buildcache,mode=max
           platforms: ${{ matrix.platforms }}
+
+  create-manifests:
+    runs-on: [ ubuntu-latest ]
+    needs: build-docker
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # Tag ""
+      - name: Create and push manifest for ""
+        env:
+          TAG: ${{ env.IMAGE_NAME }}:${{ env.VOICEVOX_ENGINE_VERSION }}
+        run: |
+          docker manifest create \
+            ${{ env.TAG }} \
+            --amend ${{ env.TAG }}-amd64 \
+            --amend ${{ env.TAG }}-arm64
+          docker manifest push ${{ env.TAG }}
+
+      # Tag "cpu"
+      - name: Create and push manifest for "cpu"
+        env:
+          TAG: ${{ env.IMAGE_NAME }}:cpu-${{ env.VOICEVOX_ENGINE_VERSION }}
+        run: |
+          docker manifest create \
+            ${{ env.TAG }} \
+            --amend ${{ env.TAG }}-amd64 \
+            --amend ${{ env.TAG }}-arm64
+          docker manifest push ${{ env.TAG }}
+
+      # Tag "cpu-ubuntu20.04"
+      - name: Create and push manifest for "cpu-ubuntu20.04"
+        env:
+          TAG: ${{ env.IMAGE_NAME }}:cpu-ubuntu20.04-${{ env.VOICEVOX_ENGINE_VERSION }}
+        run: |
+          docker manifest create \
+            ${{ env.TAG }} \
+            --amend ${{ env.TAG }}-amd64 \
+            --amend ${{ env.TAG }}-arm64
+          docker manifest push ${{ env.TAG }}
+
+      # Tag "nvidia"
+      - name: Create and push manifest for "nvidia"
+        env:
+          TAG: ${{ env.IMAGE_NAME }}:nvidia-${{ env.VOICEVOX_ENGINE_VERSION }}
+        run: |
+          docker manifest create \
+            ${{ env.TAG }} \
+            --amend ${{ env.TAG }}-amd64
+          docker manifest push ${{ env.TAG }}
+
+      # Tag "nvidia-ubuntu20.04"
+      - name: Create and push manifest for "nvidia-ubuntu20.04"
+        env:
+          TAG: ${{ env.IMAGE_NAME }}:nvidia-ubuntu20.04-${{ env.VOICEVOX_ENGINE_VERSION }}
+        run: |
+          docker manifest create \
+            ${{ env.TAG }} \
+            --amend ${{ env.TAG }}-amd64
+          docker manifest push ${{ env.TAG }}
+
+      # Tag "cpu-ubuntu18.04"
+      - name: Create and push manifest for "cpu-ubuntu18.04"
+        env:
+          TAG: ${{ env.IMAGE_NAME }}:cpu-ubuntu18.04-${{ env.VOICEVOX_ENGINE_VERSION }}
+        run: |
+          docker manifest create \
+            ${{ env.TAG }} \
+            --amend ${{ env.TAG }}-amd64 \
+            --amend ${{ env.TAG }}-arm64
+          docker manifest push ${{ env.TAG }}
+
+      # Tag "nvidia-ubuntu18.04"
+      - name: Create and push manifest for "nvidia-ubuntu18.04"
+        env:
+          TAG: ${{ env.IMAGE_NAME }}:nvidia-ubuntu18.04-${{ env.VOICEVOX_ENGINE_VERSION }}
+        run: |
+          docker manifest create \
+            ${{ env.TAG }} \
+            --amend ${{ env.TAG }}-amd64
+          docker manifest push ${{ env.TAG }}

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -27,7 +27,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ ubuntu-latest ]
         tag:
           - ""
           - cpu
@@ -42,48 +42,51 @@ jobs:
             target: runtime-env
             base_image: ubuntu:20.04
             base_runtime_image: ubuntu:20.04
-            voicevox_core_asset_prefix: voicevox_core-linux-x64-cpu
-            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.13.1/onnxruntime-linux-x64-1.13.1.tgz
+            onnxruntime_version: 1.13.1
+            platforms: linux/amd64,linux/arm64/v8
           - tag: cpu
             target: runtime-env
             base_image: ubuntu:20.04
             base_runtime_image: ubuntu:20.04
-            voicevox_core_asset_prefix: voicevox_core-linux-x64-cpu
-            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.13.1/onnxruntime-linux-x64-1.13.1.tgz
+            onnxruntime_version: 1.13.1
+            platforms: linux/amd64,linux/arm64/v8
           - tag: cpu-ubuntu20.04
             target: runtime-env
             base_image: ubuntu:20.04
             base_runtime_image: ubuntu:20.04
-            voicevox_core_asset_prefix: voicevox_core-linux-x64-cpu
-            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.13.1/onnxruntime-linux-x64-1.13.1.tgz
+            onnxruntime_version: 1.13.1
+            platforms: linux/amd64,linux/arm64/v8
           - tag: nvidia
             target: runtime-nvidia-env
             base_image: ubuntu:20.04
             base_runtime_image: nvidia/cuda:11.6.2-cudnn8-runtime-ubuntu20.04
-            voicevox_core_asset_prefix: voicevox_core-linux-x64-gpu
-            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.13.1/onnxruntime-linux-x64-gpu-1.13.1.tgz
+            onnxruntime_version: 1.13.1
+            platforms: linux/amd64
           - tag: nvidia-ubuntu20.04
             target: runtime-nvidia-env
             base_image: ubuntu:20.04
             base_runtime_image: nvidia/cuda:11.6.2-cudnn8-runtime-ubuntu20.04
-            voicevox_core_asset_prefix: voicevox_core-linux-x64-gpu
-            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.13.1/onnxruntime-linux-x64-gpu-1.13.1.tgz
+            onnxruntime_version: 1.13.1
+            platforms: linux/amd64
           # Ubuntu 18.04
           - tag: cpu-ubuntu18.04
             target: runtime-env
             base_image: ubuntu:18.04
             base_runtime_image: ubuntu:18.04
-            voicevox_core_asset_prefix: voicevox_core-linux-x64-cpu
-            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.13.1/onnxruntime-linux-x64-1.13.1.tgz
+            onnxruntime_version: 1.13.1
+            platforms: linux/amd64,linux/arm64/v8
           - tag: nvidia-ubuntu18.04
             target: runtime-nvidia-env
             base_image: ubuntu:18.04
             base_runtime_image: nvidia/cuda:11.6.2-cudnn8-runtime-ubuntu18.04
-            voicevox_core_asset_prefix: voicevox_core-linux-x64-gpu
-            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.13.1/onnxruntime-linux-x64-gpu-1.13.1.tgz
+            onnxruntime_version: 1.13.1
+            platforms: linux/amd64
 
     steps:
       - uses: actions/checkout@v3
+
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v2
 
       - name: Setup Docker Buildx
         id: buildx
@@ -128,7 +131,6 @@ jobs:
                 format('{0}:{1}-{2}', env.IMAGE_NAME, matrix.tag, env.VOICEVOX_ENGINE_VERSION)
               ) || format('{0}:{1}', env.IMAGE_NAME, env.VOICEVOX_ENGINE_VERSION)
             ) }}
-          VOICEVOX_CORE_ASSET_NAME: ${{ matrix.voicevox_core_asset_prefix }}-${{ env.VOICEVOX_CORE_VERSION }}
         with:
           context: .
           builder: ${{ steps.buildx.outputs.name }}
@@ -138,12 +140,13 @@ jobs:
             BASE_RUNTIME_IMAGE=${{ matrix.base_runtime_image }}
             PYTHON_VERSION=${{ env.PYTHON_VERSION }}
             VOICEVOX_ENGINE_VERSION=${{ env.VOICEVOX_ENGINE_VERSION }}
-            VOICEVOX_CORE_ASSET_NAME=${{ env.VOICEVOX_CORE_ASSET_NAME }}
             VOICEVOX_CORE_VERSION=${{ env.VOICEVOX_CORE_VERSION }}
             VOICEVOX_RESOURCE_VERSION=${{ env.VOICEVOX_RESOURCE_VERSION }}
-            ONNXRUNTIME_URL=${{ matrix.onnxruntime_url }}
+            USE_GPU=${{ matrix.target == 'runtime-nvidia-env' }}
+            ONNXRUNTIME_VERSION=${{ matrix.onnxruntime_version }}
           target: ${{ matrix.target }}
           push: true
           tags: ${{ env.IMAGE_TAG }}
           cache-from: type=registry,ref=${{ env.IMAGE_TAG }}-buildcache
           cache-to: type=registry,ref=${{ env.IMAGE_TAG }}-buildcache,mode=max
+          platforms: ${{ matrix.platforms }}

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -27,7 +27,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ ubuntu-latest ]
+        os: [ubuntu-latest]
         tag:
           - ""
           - cpu

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -36,106 +36,50 @@ jobs:
           - nvidia-ubuntu20.04
           - cpu-ubuntu18.04
           - nvidia-ubuntu18.04
-        tag_platform_prefix:
-          - amd64
-          - arm64
-        exclude:
-          - tag: nvidia
-            tag_platform_prefix: arm64
-          - tag: nvidia-ubuntu20.04
-            tag_platform_prefix: arm64
-          - tag: nvidia-ubuntu18.04
-            tag_platform_prefix: arm64
         include:
           # Ubuntu 20.04
           - tag: ""
-            tag_platform_prefix: amd64
             target: runtime-env
             base_image: ubuntu:20.04
             base_runtime_image: ubuntu:20.04
-            voicevox_core_asset_prefix: voicevox_core-linux-x64-cpu
-            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.13.1/onnxruntime-linux-x64-1.13.1.tgz
-            platforms: linux/amd64
-          - tag: ""
-            tag_platform_prefix: arm64
-            target: runtime-env
-            base_image: ubuntu:20.04
-            base_runtime_image: ubuntu:20.04
-            voicevox_core_asset_prefix: voicevox_core-linux-arm64-cpu
-            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.14.1/onnxruntime-linux-aarch64-1.14.1.tgz
-            platforms: linux/arm64/v8
+            onnxruntime_version: 1.13.1
+            platforms: linux/amd64,linux/arm64/v8
           - tag: cpu
-            tag_platform_prefix: amd64
             target: runtime-env
             base_image: ubuntu:20.04
             base_runtime_image: ubuntu:20.04
-            voicevox_core_asset_prefix: voicevox_core-linux-x64-cpu
-            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.13.1/onnxruntime-linux-x64-1.13.1.tgz
-            platforms: linux/amd64
-          - tag: cpu
-            tag_platform_prefix: arm64
-            target: runtime-env
-            base_image: ubuntu:20.04
-            base_runtime_image: ubuntu:20.04
-            voicevox_core_asset_prefix: voicevox_core-linux-arm64-cpu
-            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.14.1/onnxruntime-linux-aarch64-1.14.1.tgz
-            platforms: linux/arm64/v8
+            onnxruntime_version: 1.13.1
+            platforms: linux/amd64,linux/arm64/v8
           - tag: cpu-ubuntu20.04
-            tag_platform_prefix: amd64
             target: runtime-env
             base_image: ubuntu:20.04
             base_runtime_image: ubuntu:20.04
-            voicevox_core_asset_prefix: voicevox_core-linux-x64-cpu
-            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.13.1/onnxruntime-linux-x64-1.13.1.tgz
-            platforms: linux/amd64
-          - tag: cpu-ubuntu20.04
-            tag_platform_prefix: arm64
-            target: runtime-env
-            base_image: ubuntu:20.04
-            base_runtime_image: ubuntu:20.04
-            voicevox_core_asset_prefix: voicevox_core-linux-arm64-cpu
-            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.14.1/onnxruntime-linux-aarch64-1.14.1.tgz
-            platforms: linux/arm64/v8
+            onnxruntime_version: 1.13.1
+            platforms: linux/amd64,linux/arm64/v8
           - tag: nvidia
-            tag_platform_prefix: amd64
             target: runtime-nvidia-env
             base_image: ubuntu:20.04
             base_runtime_image: nvidia/cuda:11.6.2-cudnn8-runtime-ubuntu20.04
-            voicevox_core_asset_prefix: voicevox_core-linux-x64-gpu
-            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.13.1/onnxruntime-linux-x64-gpu-1.13.1.tgz
+            onnxruntime_version: 1.13.1
             platforms: linux/amd64
           - tag: nvidia-ubuntu20.04
-            tag_platform_prefix: amd64
             target: runtime-nvidia-env
             base_image: ubuntu:20.04
             base_runtime_image: nvidia/cuda:11.6.2-cudnn8-runtime-ubuntu20.04
-            voicevox_core_asset_prefix: voicevox_core-linux-x64-gpu
-            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.13.1/onnxruntime-linux-x64-gpu-1.13.1.tgz
+            onnxruntime_version: 1.13.1
             platforms: linux/amd64
           # Ubuntu 18.04
           - tag: cpu-ubuntu18.04
-            tag_platform_prefix: amd64
             target: runtime-env
             base_image: ubuntu:18.04
             base_runtime_image: ubuntu:18.04
-            voicevox_core_asset_prefix: voicevox_core-linux-x64-cpu
-            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.13.1/onnxruntime-linux-x64-1.13.1.tgz
-            platforms: linux/amd64
-          - tag: cpu-ubuntu18.04
-            tag_platform_prefix: arm64
-            target: runtime-env
-            base_image: ubuntu:18.04
-            base_runtime_image: ubuntu:18.04
-            voicevox_core_asset_prefix: voicevox_core-linux-x64-cpu
-            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.14.1/onnxruntime-linux-aarch64-1.14.1.tgz
-            platforms: linux/arm64/v8
+            onnxruntime_version: 1.13.1
+            platforms: linux/amd64,linux/arm64/v8
           - tag: nvidia-ubuntu18.04
-            tag_platform_prefix: amd64
             target: runtime-nvidia-env
             base_image: ubuntu:18.04
             base_runtime_image: nvidia/cuda:11.6.2-cudnn8-runtime-ubuntu18.04
-            voicevox_core_asset_prefix: voicevox_core-linux-x64-gpu
-            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.13.1/onnxruntime-linux-x64-gpu-1.13.1.tgz
+            onnxruntime_version: 1.13.1
             platforms: linux/amd64
 
     steps:
@@ -187,7 +131,6 @@ jobs:
                 format('{0}:{1}-{2}', env.IMAGE_NAME, matrix.tag, env.VOICEVOX_ENGINE_VERSION)
               ) || format('{0}:{1}', env.IMAGE_NAME, env.VOICEVOX_ENGINE_VERSION)
             ) }}
-          VOICEVOX_CORE_ASSET_NAME: ${{ matrix.voicevox_core_asset_prefix }}-${{ env.VOICEVOX_CORE_VERSION }}
         with:
           context: .
           builder: ${{ steps.buildx.outputs.name }}
@@ -197,104 +140,13 @@ jobs:
             BASE_RUNTIME_IMAGE=${{ matrix.base_runtime_image }}
             PYTHON_VERSION=${{ env.PYTHON_VERSION }}
             VOICEVOX_ENGINE_VERSION=${{ env.VOICEVOX_ENGINE_VERSION }}
-            VOICEVOX_CORE_ASSET_NAME=${{ env.VOICEVOX_CORE_ASSET_NAME }}
             VOICEVOX_CORE_VERSION=${{ env.VOICEVOX_CORE_VERSION }}
             VOICEVOX_RESOURCE_VERSION=${{ env.VOICEVOX_RESOURCE_VERSION }}
-            ONNXRUNTIME_URL=${{ matrix.onnxruntime_url }}
+            USE_GPU=${{ matrix.target == 'runtime-nvidia-env' }}
+            ONNXRUNTIME_VERSION=${{ matrix.onnxruntime_version }}
           target: ${{ matrix.target }}
           push: true
-          tags: ${{ env.IMAGE_TAG }}-${{ matrix.tag_platform_prefix }}
-          cache-from: type=registry,ref=${{ env.IMAGE_TAG }}-${{ matrix.tag_platform_prefix }}-buildcache
-          cache-to: type=registry,ref=${{ env.IMAGE_TAG }}-${{ matrix.tag_platform_prefix }}-buildcache,mode=max
+          tags: ${{ env.IMAGE_TAG }}
+          cache-from: type=registry,ref=${{ env.IMAGE_TAG }}-buildcache
+          cache-to: type=registry,ref=${{ env.IMAGE_TAG }}-buildcache,mode=max
           platforms: ${{ matrix.platforms }}
-
-  create-manifests:
-    runs-on: [ ubuntu-latest ]
-    needs: build-docker
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Setup Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Login to DockerHub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      # Tag ""
-      - name: Create and push manifest for ""
-        env:
-          TAG: ${{ env.IMAGE_NAME }}:${{ env.VOICEVOX_ENGINE_VERSION }}
-        run: |
-          docker manifest create \
-            ${{ env.TAG }} \
-            --amend ${{ env.TAG }}-amd64 \
-            --amend ${{ env.TAG }}-arm64
-          docker manifest push ${{ env.TAG }}
-
-      # Tag "cpu"
-      - name: Create and push manifest for "cpu"
-        env:
-          TAG: ${{ env.IMAGE_NAME }}:cpu-${{ env.VOICEVOX_ENGINE_VERSION }}
-        run: |
-          docker manifest create \
-            ${{ env.TAG }} \
-            --amend ${{ env.TAG }}-amd64 \
-            --amend ${{ env.TAG }}-arm64
-          docker manifest push ${{ env.TAG }}
-
-      # Tag "cpu-ubuntu20.04"
-      - name: Create and push manifest for "cpu-ubuntu20.04"
-        env:
-          TAG: ${{ env.IMAGE_NAME }}:cpu-ubuntu20.04-${{ env.VOICEVOX_ENGINE_VERSION }}
-        run: |
-          docker manifest create \
-            ${{ env.TAG }} \
-            --amend ${{ env.TAG }}-amd64 \
-            --amend ${{ env.TAG }}-arm64
-          docker manifest push ${{ env.TAG }}
-
-      # Tag "nvidia"
-      - name: Create and push manifest for "nvidia"
-        env:
-          TAG: ${{ env.IMAGE_NAME }}:nvidia-${{ env.VOICEVOX_ENGINE_VERSION }}
-        run: |
-          docker manifest create \
-            ${{ env.TAG }} \
-            --amend ${{ env.TAG }}-amd64
-          docker manifest push ${{ env.TAG }}
-
-      # Tag "nvidia-ubuntu20.04"
-      - name: Create and push manifest for "nvidia-ubuntu20.04"
-        env:
-          TAG: ${{ env.IMAGE_NAME }}:nvidia-ubuntu20.04-${{ env.VOICEVOX_ENGINE_VERSION }}
-        run: |
-          docker manifest create \
-            ${{ env.TAG }} \
-            --amend ${{ env.TAG }}-amd64
-          docker manifest push ${{ env.TAG }}
-
-      # Tag "cpu-ubuntu18.04"
-      - name: Create and push manifest for "cpu-ubuntu18.04"
-        env:
-          TAG: ${{ env.IMAGE_NAME }}:cpu-ubuntu18.04-${{ env.VOICEVOX_ENGINE_VERSION }}
-        run: |
-          docker manifest create \
-            ${{ env.TAG }} \
-            --amend ${{ env.TAG }}-amd64 \
-            --amend ${{ env.TAG }}-arm64
-          docker manifest push ${{ env.TAG }}
-
-      # Tag "nvidia-ubuntu18.04"
-      - name: Create and push manifest for "nvidia-ubuntu18.04"
-        env:
-          TAG: ${{ env.IMAGE_NAME }}:nvidia-ubuntu18.04-${{ env.VOICEVOX_ENGINE_VERSION }}
-        run: |
-          docker manifest create \
-            ${{ env.TAG }} \
-            --amend ${{ env.TAG }}-amd64
-          docker manifest push ${{ env.TAG }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,10 +21,28 @@ RUN <<EOF
 EOF
 
 # assert VOICEVOX_CORE_VERSION >= 0.11.0 (ONNX)
-ARG VOICEVOX_CORE_ASSET_PREFIX=voicevox_core-linux-x64-cpu
+ARG TARGETPLATFORM
+ARG USE_GPU=false
 ARG VOICEVOX_CORE_VERSION=0.14.2
+
 RUN <<EOF
     set -eux
+
+    # Processing Switch
+    if [ "${USE_GPU}" = "true" ]; then
+        VOICEVOX_CORE_ASSET_ASSET_PROCESSING="gpu"
+    else
+        VOICEVOX_CORE_ASSET_ASSET_PROCESSING="cpu"
+    fi
+
+    # TARGETARCH Switch
+    if [ "${TARGETPLATFORM}" = "linux/amd64" ]; then
+        VOICEVOX_CORE_ASSET_TARGETARCH="x64"
+    else
+        VOICEVOX_CORE_ASSET_TARGETARCH="arm64"
+    fi
+
+    VOICEVOX_CORE_ASSET_PREFIX="voicevox_core-linux-${VOICEVOX_CORE_ASSET_TARGETARCH}-${VOICEVOX_CORE_ASSET_ASSET_PROCESSING}"
 
     # Download Core
     VOICEVOX_CORE_ASSET_NAME=${VOICEVOX_CORE_ASSET_PREFIX}-${VOICEVOX_CORE_VERSION}
@@ -64,9 +82,27 @@ RUN <<EOF
     rm -rf /var/lib/apt/lists/*
 EOF
 
-ARG ONNXRUNTIME_URL=https://github.com/microsoft/onnxruntime/releases/download/v1.13.1/onnxruntime-linux-x64-1.13.1.tgz
+ARG TARGETPLATFORM
+ARG USE_GPU=false
+ARG ONNXRUNTIME_VERSION=1.13.1
 RUN <<EOF
     set -eux
+
+    # Processing Switch
+    if [ "${USE_GPU}" = "true" ]; then
+        ONNXRUNTIME_PROCESSING="gpu-"
+    else
+        ONNXRUNTIME_PROCESSING=""
+    fi
+
+    # TARGETARCH Switch
+    if [ "${TARGETPLATFORM}" = "linux/amd64" ]; then
+        ONNXRUNTIME_TARGETARCH=x64
+    else
+        ONNXRUNTIME_TARGETARCH=aarch64
+    fi
+    
+    ONNXRUNTIME_URL="https://github.com/microsoft/onnxruntime/releases/download/v${ONNXRUNTIME_VERSION}/onnxruntime-linux-${ONNXRUNTIME_TARGETARCH}-${ONNXRUNTIME_PROCESSING}${ONNXRUNTIME_VERSION}.tgz"
 
     # Download ONNX Runtime
     wget -nv --show-progress -c -O "./onnxruntime.tgz" "${ONNXRUNTIME_URL}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,28 +21,10 @@ RUN <<EOF
 EOF
 
 # assert VOICEVOX_CORE_VERSION >= 0.11.0 (ONNX)
-ARG TARGETPLATFORM
-ARG USE_GPU=false
+ARG VOICEVOX_CORE_ASSET_PREFIX=voicevox_core-linux-x64-cpu
 ARG VOICEVOX_CORE_VERSION=0.14.2
-
 RUN <<EOF
     set -eux
-
-    # Processing Switch
-    if [ "${USE_GPU}" = "true" ]; then
-        VOICEVOX_CORE_ASSET_ASSET_PROCESSING="gpu"
-    else
-        VOICEVOX_CORE_ASSET_ASSET_PROCESSING="cpu"
-    fi
-
-    # TARGETARCH Switch
-    if [ "${TARGETPLATFORM}" = "linux/amd64" ]; then
-        VOICEVOX_CORE_ASSET_TARGETARCH="x64"
-    else
-        VOICEVOX_CORE_ASSET_TARGETARCH="arm64"
-    fi
-
-    VOICEVOX_CORE_ASSET_PREFIX="voicevox_core-linux-${VOICEVOX_CORE_ASSET_TARGETARCH}-${VOICEVOX_CORE_ASSET_ASSET_PROCESSING}"
 
     # Download Core
     VOICEVOX_CORE_ASSET_NAME=${VOICEVOX_CORE_ASSET_PREFIX}-${VOICEVOX_CORE_VERSION}
@@ -82,27 +64,9 @@ RUN <<EOF
     rm -rf /var/lib/apt/lists/*
 EOF
 
-ARG TARGETPLATFORM
-ARG USE_GPU=false
-ARG ONNXRUNTIME_VERSION=1.13.1
+ARG ONNXRUNTIME_URL=https://github.com/microsoft/onnxruntime/releases/download/v1.13.1/onnxruntime-linux-x64-1.13.1.tgz
 RUN <<EOF
     set -eux
-
-    # Processing Switch
-    if [ "${USE_GPU}" = "true" ]; then
-        ONNXRUNTIME_PROCESSING="gpu-"
-    else
-        ONNXRUNTIME_PROCESSING=""
-    fi
-
-    # TARGETARCH Switch
-    if [ "${TARGETPLATFORM}" = "linux/amd64" ]; then
-        ONNXRUNTIME_TARGETARCH=x64
-    else
-        ONNXRUNTIME_TARGETARCH=aarch64
-    fi
-    
-    ONNXRUNTIME_URL="https://github.com/microsoft/onnxruntime/releases/download/v${ONNXRUNTIME_VERSION}/onnxruntime-linux-${ONNXRUNTIME_TARGETARCH}-${ONNXRUNTIME_PROCESSING}${ONNXRUNTIME_VERSION}.tgz"
 
     # Download ONNX Runtime
     wget -nv --show-progress -c -O "./onnxruntime.tgz" "${ONNXRUNTIME_URL}"


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->

* GitHub Actions と Dockerfile を arm64 版に対応させました。
  * 確認に利用した DockerHub Repo 
    * https://hub.docker.com/r/likemikan/voicevox_engine
  * 検証で利用した PR
    * https://github.com/K-shir0/voicevox_engine/pull/1
    * https://github.com/K-shir0/voicevox_engine/pull/2
  

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

close #633

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

<img width="1185" alt="image" src="https://user-images.githubusercontent.com/50326556/228090348-33e3293d-8e7f-472a-804e-2d3c7e5638f3.png">

## その他

* onnxruntime の arm64-gpu が見当たらなかった cpu のみ対応 
* GPU 環境がないので gpu 版のイメージが正しく動作するかの検証は出来ていない
