### PR TITLE
feat: Bind to localhost instead of 127.0.0.1 by default

### DIFF
--- a/run.py
+++ b/run.py
@@ -1429,10 +1429,13 @@ def main() -> None:
         set_output_log_utf8()
 
     parser = argparse.ArgumentParser(description="VOICEVOX のエンジンです。")
+    # Uvicorn でバインドするアドレスを "localhost" にすることで IPv4 (127.0.0.1) と IPv6 ([::1]) の両方でリッスンできます.
+    # これは Uvicorn のドキュメントに記載されていない挙動です; 将来のアップデートにより動作しなくなる可能性があります.
+    # ref: https://github.com/VOICEVOX/voicevox_engine/pull/647#issuecomment-1540204653
     parser.add_argument(
         "--host",
         type=str,
-        default="127.0.0.1",
+        default="localhost",
         help="接続を受け付けるホストアドレスです。",
     )
     parser.add_argument(


### PR DESCRIPTION
## 内容

VOICEVOX Engine への `localhost` を用いたアクセスが遅いというツイート [^1] が散見されています．
実際には IPv6 からのフォールバック時に一定のタイムアウトを待つ実装によるものと考えられますが， `localhost` の名前解決が遅いことによるものだという虚偽情報が出回っています．

この回避策として `127.0.0.1` を使うことは確かに有効ですが， VOICEVOX Engine が IPv6 をリッスンした状態で起動するようにするほうがより建設的な解決策です．

ドキュメントに記載されていない挙動ではありますが， Uvicorn はバインドするアドレスとして `localhost` を指定すると IPv4/IPv6 の両者でリッスンするようです [^3]．この挙動をもとにして， `--host` オプションのデフォルトを `localhost` としました．

~この PR によってデフォルトで `[::1]` に対してサーバをバインドするようにし，一般ユーザがこうしたフォールバックによる遅い問題に直面することを防ぎます．今日，一般的な環境では IPv6 は当然有効になっているはずであり， `localhost` で解決される上で問題が起こることは考えづらいです．また OCI イメージについてはすでに `0.0.0.0` に対しバインドされるように Dockerfile で記述されるため影響しません．~

~残念ながら， VOICEVOX Engine で用いられているサーバ実装の Uvicorn では現在デュアルスタックのバインドがサポートされていません [^2] ．つまり `127.0.0.1` と `[::1]` の両方に対し同時にバインドすることができません．~

~これが破壊的変更と考えられることに代わりはないため，メジャーバージョンのアップグレード時等にリリースされるべきと考えます．~

[^1]: https://twitter.com/izumisatoshi05/status/1641406680545234944?s=20
[^2]: https://github.com/encode/uvicorn/discussions/1529
[^3]: https://github.com/VOICEVOX/voicevox_engine/pull/647#issuecomment-1540204653

## 関連 Issue

N/A

## スクリーンショット・動画など

サーバを起動して localhost, 127.0.0.1, [::1] のそれぞれからアクセスしたようす

<img width="1593" alt="image" src="https://github.com/VOICEVOX/voicevox_engine/assets/12772118/fca36b23-ced9-43ce-8d13-f16f9761de62">


<!-- <img width="1169" alt="image" src="https://user-images.githubusercontent.com/12772118/229023684-1dc3b09e-5212-4381-89f7-f2fb5c9380ef.png"> -->


## その他
