### PR TITLE
ヘルプの抜けを修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,12 +288,12 @@ VOICEVOXではセキュリティ保護のため`localhost`・`127.0.0.1`・`app:
 ```bash
 $ python run.py -h
 
-usage: run.py [-h] [--host HOST] [--port PORT] [--use_gpu] [--voicevox_dir VOICEVOX_DIR] [--voicelib_dir VOICELIB_DIR] [--runtime_dir RUNTIME_DIR] [--enable_mock] [--enable_cancellable_synthesis] [--init_processes INIT_PROCESSES] [--load_all_models] [--cpu_num_threads CPU_NUM_THREADS] [--output_log_utf8]
-              [--cors_policy_mode {CorsPolicyMode.all,CorsPolicyMode.localapps}] [--allow_origin [ALLOW_ORIGIN [ALLOW_ORIGIN ...]]] [--setting_file SETTING_FILE]
+usage: run.py [-h] [--host HOST] [--port PORT] [--use_gpu] [--voicevox_dir VOICEVOX_DIR] [--voicelib_dir VOICELIB_DIR] [--runtime_dir RUNTIME_DIR] [--enable_mock] [--enable_cancellable_synthesis] [--init_processes INIT_PROCESSES] [--load_all_models]
+              [--cpu_num_threads CPU_NUM_THREADS] [--output_log_utf8] [--cors_policy_mode {CorsPolicyMode.all,CorsPolicyMode.localapps}] [--allow_origin [ALLOW_ORIGIN ...]] [--setting_file SETTING_FILE]
 
 VOICEVOX のエンジンです。
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   --host HOST           接続を受け付けるホストアドレスです。
   --port PORT           接続を受け付けるポート番号です。
@@ -308,13 +308,14 @@ optional arguments:
   --enable_cancellable_synthesis
                         指定すると音声合成を途中でキャンセルできるようになります。
   --init_processes INIT_PROCESSES
+                        cancellable_synthesis機能の初期化時に生成するプロセス数です。
   --load_all_models     指定すると起動時に全ての音声合成モデルを読み込みます。
   --cpu_num_threads CPU_NUM_THREADS
                         音声合成を行うスレッド数です。指定しないと、代わりに環境変数VV_CPU_NUM_THREADSの値が使われます。VV_CPU_NUM_THREADSが空文字列でなく数値でもない場合はエラー終了します。
   --output_log_utf8     指定するとログ出力をUTF-8でおこないます。指定しないと、代わりに環境変数 VV_OUTPUT_LOG_UTF8 の値が使われます。VV_OUTPUT_LOG_UTF8 の値が1の場合はUTF-8で、0または空文字、値がない場合は環境によって自動的に決定されます。
   --cors_policy_mode {CorsPolicyMode.all,CorsPolicyMode.localapps}
                         CORSの許可モード。allまたはlocalappsが指定できます。allはすべてを許可します。localappsはオリジン間リソース共有ポリシーを、app://.とlocalhost関連に限定します。その他のオリジンはallow_originオプションで追加できます。デフォルトはlocalapps。
-  --allow_origin [ALLOW_ORIGIN [ALLOW_ORIGIN ...]]
+  --allow_origin [ALLOW_ORIGIN ...]
                         許可するオリジンを指定します。スペースで区切ることで複数指定できます。
   --setting_file SETTING_FILE
                         設定ファイルを指定できます。

--- a/run.py
+++ b/run.py
@@ -1141,7 +1141,12 @@ if __name__ == "__main__":
         action="store_true",
         help="指定すると音声合成を途中でキャンセルできるようになります。",
     )
-    parser.add_argument("--init_processes", type=int, default=2)
+    parser.add_argument(
+        "--init_processes",
+        type=int,
+        default=2,
+        help="cancellable_synthesis機能の初期化時に生成するプロセス数です。",
+    )
     parser.add_argument(
         "--load_all_models", action="store_true", help="指定すると起動時に全ての音声合成モデルを読み込みます。"
     )


### PR DESCRIPTION
## 内容

`python run.py -h` で表示できる、引数のヘルプ文に抜けがあったため修正します。

## 関連 Issue

ref #672 

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他

Pythonのバージョンが上がった関係か、ヘルプの表記が少し変わっているみたいです。