### PR TITLE
`installed_library` APIの改善

### DIFF
--- a/run.py
+++ b/run.py
@@ -818,7 +818,7 @@ def generate_app(
 
     @app.get(
         "/installed_libraries",
-        response_model=List[DownloadableLibrary],
+        response_model=Dict[str, DownloadableLibrary],
         tags=["音声ライブラリ管理"],
     )
     def installed_libraries():

--- a/run.py
+++ b/run.py
@@ -35,6 +35,7 @@ from voicevox_engine.model import (
     AccentPhrase,
     AudioQuery,
     DownloadableLibrary,
+    InstalledLibrary,
     MorphableTargetInfo,
     ParseKanaBadRequest,
     ParseKanaError,
@@ -818,7 +819,7 @@ def generate_app(
 
     @app.get(
         "/installed_libraries",
-        response_model=Dict[str, DownloadableLibrary],
+        response_model=Dict[str, InstalledLibrary],
         tags=["音声ライブラリ管理"],
     )
     def installed_libraries():

--- a/voicevox_engine/downloadable_library.py
+++ b/voicevox_engine/downloadable_library.py
@@ -7,7 +7,7 @@ from typing import Dict
 
 from fastapi import HTTPException
 
-from voicevox_engine.model import DownloadableLibrary
+from voicevox_engine.model import DownloadableLibrary, InstalledLibrary
 
 __all__ = ["LibraryManager"]
 
@@ -59,12 +59,14 @@ class LibraryManager:
                 ]
             return list(map(DownloadableLibrary.parse_obj, libraries))
 
-    def installed_libraries(self) -> Dict[str, DownloadableLibrary]:
+    def installed_libraries(self) -> Dict[str, InstalledLibrary]:
         library = {}
         for library_dir in self.library_root_dir.iterdir():
             if library_dir.is_dir():
                 with open(library_dir / INFO_FILE, encoding="utf-8") as f:
                     library[library_dir] = json.load(f)
+                    # アンインストール出来ないライブラリを作る場合、何かしらの条件でFalseを設定する
+                    library[library_dir]["uninstallable"] = True
         return library
 
     def install_library(self, library_id: str, file: BytesIO):

--- a/voicevox_engine/downloadable_library.py
+++ b/voicevox_engine/downloadable_library.py
@@ -3,7 +3,7 @@ import json
 import zipfile
 from io import BytesIO
 from pathlib import Path
-from typing import List
+from typing import Dict
 
 from fastapi import HTTPException
 
@@ -59,12 +59,12 @@ class LibraryManager:
                 ]
             return list(map(DownloadableLibrary.parse_obj, libraries))
 
-    def installed_libraries(self) -> List[DownloadableLibrary]:
-        library = []
+    def installed_libraries(self) -> Dict[str, DownloadableLibrary]:
+        library = {}
         for library_dir in self.library_root_dir.iterdir():
             if library_dir.is_dir():
                 with open(library_dir / INFO_FILE, encoding="utf-8") as f:
-                    library.append(json.load(f))
+                    library[library_dir] = json.load(f)
         return library
 
     def install_library(self, library_id: str, file: BytesIO):

--- a/voicevox_engine/model.py
+++ b/voicevox_engine/model.py
@@ -141,6 +141,13 @@ class DownloadableLibrary(BaseModel):
     speakers: List[LibrarySpeaker] = Field(title="音声ライブラリに含まれる話者のリスト")
 
 
+class InstalledLibrary(DownloadableLibrary):
+    """
+    インストール済み音声ライブラリの情報
+    """
+    uninstallable: bool = Field(title="アンインストール可能かどうか")
+
+
 USER_DICT_MIN_PRIORITY = 0
 USER_DICT_MAX_PRIORITY = 10
 

--- a/voicevox_engine/model.py
+++ b/voicevox_engine/model.py
@@ -107,7 +107,6 @@ class ParseKanaBadRequest(BaseModel):
 
 
 class MorphableTargetInfo(BaseModel):
-
     is_morphable: bool = Field(title="指定した話者に対してモーフィングの可否")
     # FIXME: add reason property
     # reason: Optional[str] = Field(title="is_morphableがfalseである場合、その理由")
@@ -145,6 +144,7 @@ class InstalledLibrary(DownloadableLibrary):
     """
     インストール済み音声ライブラリの情報
     """
+
     uninstallable: bool = Field(title="アンインストール可能かどうか")
 
 


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->
題の通り
具体的には、インストール済みライブラリの`library_uuid`を返すことと、`uninstallable`フィールドの追加です。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->
VOICEVOX/voicevox_project#21

## その他

`uninstall_library`APIのために必要なコードになります。これがマージされ次第、`uninstall_library`APIのPRを開きます。
