### PR TITLE
CUDA 11.8.0, cuDNN 8.9.2に更新

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -67,13 +67,13 @@ jobs:
           - tag: nvidia
             target: runtime-nvidia-env
             base_image: ubuntu:20.04
-            base_runtime_image: nvidia/cuda:11.6.2-cudnn8-runtime-ubuntu20.04
+            base_runtime_image: nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu20.04
             onnxruntime_version: 1.13.1
             platforms: linux/amd64
           - tag: nvidia-ubuntu20.04
             target: runtime-nvidia-env
             base_image: ubuntu:20.04
-            base_runtime_image: nvidia/cuda:11.6.2-cudnn8-runtime-ubuntu20.04
+            base_runtime_image: nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu20.04
             onnxruntime_version: 1.13.1
             platforms: linux/amd64
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ jobs:
             architecture: "x64"
             voicevox_core_asset_prefix: voicevox_core-windows-x64-cuda
             onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.13.1/onnxruntime-win-x64-gpu-1.13.1.zip
-            cuda_version: "11.6.2"
+            cuda_version: "11.8.0"
             cudnn_url: https://developer.download.nvidia.com/compute/redist/cudnn/v8.4.1/local_installers/11.6/cudnn-windows-x86_64-8.4.1.50_cuda11.6-archive.zip
             zlib_url: http://www.winimage.com/zLibDll/zlib123dllx64.zip
             target: windows-nvidia
@@ -89,7 +89,7 @@ jobs:
             architecture: "x64"
             voicevox_core_asset_prefix: voicevox_core-linux-x64-gpu
             onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.13.1/onnxruntime-linux-x64-gpu-1.13.1.tgz
-            cuda_version: "11.6.2"
+            cuda_version: "11.8.0"
             cudnn_url: https://developer.download.nvidia.com/compute/redist/cudnn/v8.4.1/local_installers/11.6/cudnn-linux-x86_64-8.4.1.50_cuda11.6-archive.tar.xz
             target: linux-nvidia
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,7 +138,7 @@ jobs:
 
       - name: Setup CUDA
         if: matrix.cuda_version != '' && steps.cuda-dll-cache-restore.outputs.cache-hit != 'true'
-        uses: Jimver/cuda-toolkit@6974ecc945579a89135a1e1d9eac96ec361a1171 # v0.2.10
+        uses: Jimver/cuda-toolkit@v0.2.10
         id: cuda-toolkit
         with:
           method: network

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,7 +134,7 @@ jobs:
 
       - name: Setup CUDA
         if: matrix.cuda_version != '' && steps.cuda-dll-cache.outputs.cache-hit != 'true'
-        uses: Jimver/cuda-toolkit@v0.2.8
+        uses: Jimver/cuda-toolkit@6974ecc945579a89135a1e1d9eac96ec361a1171 # v0.2.10
         id: cuda-toolkit
         with:
           method: network

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,7 @@ jobs:
             voicevox_core_asset_prefix: voicevox_core-windows-x64-cuda
             onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.13.1/onnxruntime-win-x64-gpu-1.13.1.zip
             cuda_version: "11.8.0"
-            cudnn_url: https://developer.download.nvidia.com/compute/redist/cudnn/v8.4.1/local_installers/11.6/cudnn-windows-x86_64-8.4.1.50_cuda11.6-archive.zip
+            cudnn_url: https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/windows-x86_64/cudnn-windows-x86_64-8.9.2.26_cuda11-archive.zip
             zlib_url: http://www.winimage.com/zLibDll/zlib123dllx64.zip
             target: windows-nvidia
           # Mac CPU (x64 arch only)
@@ -90,7 +90,7 @@ jobs:
             voicevox_core_asset_prefix: voicevox_core-linux-x64-gpu
             onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.13.1/onnxruntime-linux-x64-gpu-1.13.1.tgz
             cuda_version: "11.8.0"
-            cudnn_url: https://developer.download.nvidia.com/compute/redist/cudnn/v8.4.1/local_installers/11.6/cudnn-linux-x86_64-8.4.1.50_cuda11.6-archive.tar.xz
+            cudnn_url: https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/linux-x86_64/cudnn-linux-x86_64-8.9.2.26_cuda11-archive.tar.xz
             target: linux-nvidia
 
     runs-on: ${{ matrix.os }}

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ build-linux-docker-nvidia-ubuntu20.04:
 		--target runtime-nvidia-env \
 		--progress plain \
 		--build-arg BASE_IMAGE=ubuntu:20.04 \
-		--build-arg BASE_RUNTIME_IMAGE=nvidia/cuda:11.6.2-cudnn8-runtime-ubuntu20.04 \
+		--build-arg BASE_RUNTIME_IMAGE=nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu20.04 \
 		--build-arg ONNXRUNTIME_URL=https://github.com/microsoft/onnxruntime/releases/download/v1.13.1/onnxruntime-linux-x64-gpu-1.13.1.tgz \
 		--build-arg VOICEVOX_CORE_LIBRARY_NAME=libcore_gpu_x64_nvidia.so $(ARGS)
 
@@ -68,7 +68,7 @@ build-linux-docker-nvidia-ubuntu18.04:
 		--target runtime-nvidia-env \
 		--progress plain \
 		--build-arg BASE_IMAGE=ubuntu:18.04 \
-		--build-arg BASE_RUNTIME_IMAGE=nvidia/cuda:11.6.2-cudnn8-runtime-ubuntu18.04 \
+		--build-arg BASE_RUNTIME_IMAGE=nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu18.04 \
 		--build-arg ONNXRUNTIME_URL=https://github.com/microsoft/onnxruntime/releases/download/v1.13.1/onnxruntime-linux-x64-gpu-1.13.1.tgz \
 		--build-arg VOICEVOX_CORE_LIBRARY_NAME=libcore_gpu_x64_nvidia.so $(ARGS)
 

--- a/docs/licenses/cudnn/LICENSE
+++ b/docs/licenses/cudnn/LICENSE
@@ -176,17 +176,31 @@ Reproduction of information in this document is permissible only if approved in 
 
 THIS DOCUMENT AND ALL NVIDIA DESIGN SPECIFICATIONS, REFERENCE BOARDS, FILES, DRAWINGS, DIAGNOSTICS, LISTS, AND OTHER DOCUMENTS (TOGETHER AND SEPARATELY, “MATERIALS”) ARE BEING PROVIDED “AS IS.” NVIDIA MAKES NO WARRANTIES, EXPRESSED, IMPLIED, STATUTORY, OR OTHERWISE WITH RESPECT TO THE MATERIALS, AND EXPRESSLY DISCLAIMS ALL IMPLIED WARRANTIES OF NONINFRINGEMENT, MERCHANTABILITY, AND FITNESS FOR A PARTICULAR PURPOSE. TO THE EXTENT NOT PROHIBITED BY LAW, IN NO EVENT WILL NVIDIA BE LIABLE FOR ANY DAMAGES, INCLUDING WITHOUT LIMITATION ANY DIRECT, INDIRECT, SPECIAL, INCIDENTAL, PUNITIVE, OR CONSEQUENTIAL DAMAGES, HOWEVER CAUSED AND REGARDLESS OF THE THEORY OF LIABILITY, ARISING OUT OF ANY USE OF THIS DOCUMENT, EVEN IF NVIDIA HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES. Notwithstanding any damages that customer might incur for any reason whatsoever, NVIDIA’s aggregate and cumulative liability towards customer for the products described herein shall be limited in accordance with the Terms of Sale for the product.
 
-ARM
+Arm
 
-ARM, AMBA and ARM Powered are registered trademarks of ARM Limited. Cortex, MPCore and Mali are trademarks of ARM Limited. "ARM" is used to represent ARM Holdings plc; its operating company ARM Limited; and the regional subsidiaries ARM Inc.; ARM KK; ARM Korea Limited.; ARM Taiwan Limited; ARM France SAS; ARM Consulting (Shanghai) Co. Ltd.; ARM Germany GmbH; ARM Embedded Technologies Pvt. Ltd.; ARM Norway, AS and ARM Sweden AB.
+Arm, AMBA and Arm Powered are registered trademarks of Arm Limited. Cortex, MPCore and Mali are trademarks of Arm Limited. "Arm" is used to represent Arm Holdings plc; its operating company Arm Limited; and the regional subsidiaries Arm Inc.; Arm KK; Arm Korea Limited.; Arm Taiwan Limited; Arm France SAS; Arm Consulting (Shanghai) Co. Ltd.; Arm Germany GmbH; Arm Embedded Technologies Pvt. Ltd.; Arm Norway, AS and Arm Sweden AB.
+
+HDMI
+
+HDMI, the HDMI logo, and High-Definition Multimedia Interface are trademarks or registered trademarks of HDMI Licensing LLC.
+
+Blackberry/QNX
+
+Copyright © 2020 BlackBerry Limited. All rights reserved.
+
+Trademarks, including but not limited to BLACKBERRY, EMBLEM Design, QNX, AVIAGE, MOMENTICS, NEUTRINO and QNX CAR are the trademarks or registered trademarks of BlackBerry Limited, used under license, and the exclusive rights to such trademarks are expressly reserved.
+
+Google
+
+Android, Android TV, Google Play and the Google Play logo are trademarks of Google, Inc.
 
 Trademarks
 
-NVIDIA, the NVIDIA logo, and CUDA, DRIVE, JetPack, Kepler, Maxwell, Pascal, Turing, Volta and Xavier are trademarks and/or registered trademarks of NVIDIA Corporation in the United States and other countries. Other company and product names may be trademarks of the respective companies with which they are associated.
+NVIDIA, the NVIDIA logo, and BlueField, CUDA, DALI, DRIVE, Hopper, JetPack, Jetson AGX Xavier, Jetson Nano, Maxwell, NGC, Nsight, Orin, Pascal, Quadro, Tegra, TensorRT, Triton, Turing and Volta are trademarks and/or registered trademarks of NVIDIA Corporation in the United States and other countries. Other company and product names may be trademarks of the respective companies with which they are associated.
 
 Copyright
 
-© 2017-2022 NVIDIA Corporation & affiliates. All rights reserved.
+© 2014-2023 NVIDIA Corporation & affiliates. All rights reserved.
 
 NVIDIA Corporation | 2788 San Tomas Expressway, Santa Clara, CA 95051
 

--- a/generate_licenses.py
+++ b/generate_licenses.py
@@ -301,14 +301,14 @@ def generate_licenses() -> List[License]:
     )
     # cudnn
     # license text from
-    # cuDNN v8.4.1 (May 27th, 2022), for CUDA 11.x, cuDNN Library for Windows
+    # cuDNN v8.9.2 (June 1st, 2023), for CUDA 11.x, cuDNN Library for Windows
     # https://developer.nvidia.com/rdp/cudnn-archive # noqa: B950
-    # https://developer.download.nvidia.com/compute/redist/cudnn/v8.4.1/local_installers/11.6/cudnn-windows-x86_64-8.4.1.50_cuda11.6-archive.zip # noqa: B950
-    # cudnn-windows-x86_64-8.4.1.50_cuda11.6-archive.zip (cudnn-windows-x86_64-8.4.1.50_cuda11.6-archive/LICENSE) # noqa: B950
+    # https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/windows-x86_64/cudnn-windows-x86_64-8.9.2.26_cuda11-archive.zip # noqa: B950
+    # cudnn-windows-x86_64-8.9.2.26_cuda11-archive.zip (cudnn-windows-x86_64-8.9.2.26_cuda11-archive/LICENSE) # noqa: B950
     licenses.append(
         License(
             name="cuDNN",
-            version="8.4.1",
+            version="8.9.2",
             license=None,
             text=Path("docs/licenses/cudnn/LICENSE").read_text(encoding="utf8"),
         )

--- a/generate_licenses.py
+++ b/generate_licenses.py
@@ -287,14 +287,14 @@ def generate_licenses() -> List[License]:
         )
 
     # cuda
-    # license text from CUDA 11.6.2
-    # https://developer.nvidia.com/cuda-11-6-2-download-archive?target_os=Windows&target_arch=x86_64&target_version=10&target_type=exe_local # noqa: B950
-    # https://developer.download.nvidia.com/compute/cuda/11.6.2/local_installers/cuda_11.6.2_511.65_windows.exe # noqa: B950
-    # cuda_11.6.2_511.65_windows.exe (cuda_documentation/Doc/EULA.txt)
+    # license text from CUDA 11.8.0
+    # https://developer.nvidia.com/cuda-11-8-0-download-archive?target_os=Windows&target_arch=x86_64&target_version=10&target_type=exe_local # noqa: B950
+    # https://developer.download.nvidia.com/compute/cuda/11.8.0/local_installers/cuda_11.8.0_522.06_windows.exe # noqa: B950
+    # cuda_11.8.0_522.06_windows.exe (cuda_documentation/Doc/EULA.txt)
     licenses.append(
         License(
             name="CUDA Toolkit",
-            version="11.6.2",
+            version="11.8.0",
             license=None,
             text=Path("docs/licenses/cuda/EULA.txt").read_text(encoding="utf8"),
         )


### PR DESCRIPTION
## 内容

先に #696 のマージが必要です（CIストレージ容量確保のため）。

Ubuntu 22.04のDockerイメージ提供 （ https://github.com/VOICEVOX/voicevox_engine/issues/660#issuecomment-1588934216 ）を経緯として、CUDA 11.xで最新のCUDA 11.8に更新します。ついでにcuDNNをCUDA 11.xと互換性がある最新のcuDNN 8.9.2に更新します。

- [x] CI Linuxバイナリビルド: CUDA 11.8.0、cuDNN 8.9.2に更新（旧: CUDA 11.6.2, cuDNN 8.4.1）
- [x] CI Windowsバイナリビルド: CUDA 11.8.0、cuDNN 8.9.2に更新（旧: CUDA 11.6.2, cuDNN 8.4.1）
- [x] CI Dockerビルド: CUDA 11.8.0に更新（旧: CUDA 11.6.2）
- [x] Makefile: Dockerローカルビルド用のベースイメージをCUDA 11.8.0に更新
    - Ubuntu 18.04用のターゲットが #650 で削除漏れていましたが、別PRで削除します
- [x] ライセンス: CUDA 11.8に更新（差分なし）
- [x] ライセンス: cuDNN 8.9.2に更新（軽微な差分あり）
- 動作テスト用ビルド: https://github.com/aoirint/voicevox_engine/releases/tag/0.15.0-aoirint.14 （ #696 の差分が含まれています）

```shell
docker pull aoirint/voicevox_engine:nvidia-ubuntu20.04-0.15.0-aoirint.14
docker run --rm --gpus all -p '127.0.0.1:50021:50021' aoirint/voicevox_engine:nvidia-ubuntu20.04-0.15.0-aoirint.14
```

### cuDNNのダウンロードURLについて

これまで使っていたURLではcuDNN 8.8.0以上のアーカイブが配布されていなかったため、URLを変更しました。通常のダウンロードURL（`https://developer.nvidia.com/downloads/compute/cudnn/secure/*`）はNVIDIAアカウントでの認証が必要ですが、以下のURLでは認証を要求されないため、CIで利用できます。

- 旧: https://developer.download.nvidia.com/compute/redist/cudnn/
- 新: https://developer.download.nvidia.com/compute/cudnn/redist/

### CUDA・ONNXRuntimeの互換性について

CUDAはマイナーバージョン（CUDA 11.x）で後方互換性があります。
CUDA 11.xは、LinuxではNVIDIAドライバ 450.80.02以上、WindowsではNVIDIAドライバ 452.39以上で動作します。

- https://docs.nvidia.com/deploy/cuda-compatibility/#minor-version-compatibility

ONNXRuntime 1.13.1はCUDA 11.6でビルドされていますが、CUDAの後方互換性から、CUDA 11.xで動くことが想定されています。

> Official ONNX Runtime GPU packages are now built with CUDA version 11.6 instead of 11.4, but should still be backwards compatible with 11.4

- https://github.com/microsoft/onnxruntime/releases/tag/v1.13.1

> Note: Because of CUDA Minor Version Compatibility, Onnx Runtime built with CUDA 11.4 should be compatible with any CUDA 11.x version. Please reference [Nvidia CUDA Minor Version Compatibility](https://docs.nvidia.com/deploy/cuda-compatibility/#minor-version-compatibility).

- https://onnxruntime.ai/docs/execution-providers/CUDA-ExecutionProvider.html#requirements

### （参考）CUDA・cuDNNライセンスファイルの更新について

ダウンロードしたWindows用exeファイルから7-zipで抽出しています。

```bash
wget 'https://developer.download.nvidia.com/compute/cuda/11.8.0/local_installers/cuda_11.8.0_522.06_windows.exe'
7z x 'cuda_11.8.0_522.06_windows.exe' 'cuda_documentation/Doc/EULA.txt'

wget 'https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/windows-x86_64/cudnn-windows-x86_64-8.9.2.26_cuda11-archive.zip'
7z x 'cudnn-windows-x86_64-8.9.2.26_cuda11-archive.zip' 'cudnn-windows-x86_64-8.9.2.26_cuda11-archive/LICENSE'
```

<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

- ref: #602 
- ref: #660 

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
