### PR TITLE
バイナリビルドCI: 7zとVVPPが同時にCIストレージを消費しないようにする

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -169,7 +169,7 @@ jobs:
             rm -f download/cuda/bin/libcudart.so.*.*.*
 
             # remove CUDA to reduce disk usage
-            rm -rf "${CUDA_ROOT}"
+            sudo rm -rf "${CUDA_ROOT}"
           fi
 
       # Download cuDNN

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -522,14 +522,51 @@ jobs:
           CERT_BASE64: ${{ secrets.CERT_BASE64 }}
           CERT_PASSWORD: ${{ secrets.CERT_PASSWORD }}
 
-      - name: Rearchive and split artifact
+      - name: Rename artifact directory for release
         shell: bash
         run: |
           mv dist/run/ "${{ matrix.target }}/"
 
+      # 7z archives
+      - name: Create 7z archives
+        shell: bash
+        run: |
           # Compress to artifact.7z.001, artifact.7z.002, ...
           7z -r -v1900m a "${{ steps.vars.outputs.package_name }}.7z" "${{ matrix.target }}/"
 
+          # Output splitted archive list
+          ls ${{ steps.vars.outputs.package_name }}.7z.* > archives_7z.txt
+          mv archives_7z.txt "${{ steps.vars.outputs.package_name }}.7z.txt"
+
+      - name: Upload 7z archives to artifact
+        if: github.event.inputs.upload_artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ steps.vars.outputs.package_name }}
+          path: |
+            ${{ steps.vars.outputs.package_name }}.7z.*
+
+      - name: Upload 7z archives to Release assets
+        if: needs.config.outputs.version != ''
+        uses: ncipollo/release-action@v1
+        with:
+          allowUpdates: true
+          prerelease: ${{ github.event.inputs.prerelease }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ needs.config.outputs.version }}
+          artifacts: >
+            ${{ steps.vars.outputs.package_name }}.7z.*
+          commit: ${{ github.sha }}
+
+      - name: Clean 7z archives to reduce disk usage
+        shell: bash
+        run: |
+          rm -f ${{ steps.vars.outputs.package_name }}.7z.*
+
+      # VVPP archives
+      - name: Create VVPP archives
+        shell: bash
+        run: |
           # Compress to artifact.001.vvppp,artifact.002.vvppp, ...
           (cd "${{ matrix.target }}" && 7z -r a "../compressed.zip")
           split -b 1900M --numeric-suffixes=1 -a 3 --additional-suffix .vvppp ./compressed.zip ./${{ steps.vars.outputs.package_name }}.
@@ -540,23 +577,20 @@ jobs:
           fi
 
           # Output splitted archive list
-          ls ${{ steps.vars.outputs.package_name }}.7z.* > archives_7z.txt
-          mv archives_7z.txt "${{ steps.vars.outputs.package_name }}.7z.txt"
           ls ${{ steps.vars.outputs.package_name }}*.vvppp ${{ steps.vars.outputs.package_name }}.vvpp > archives_vvpp.txt || true
           mv archives_vvpp.txt "${{ steps.vars.outputs.package_name }}.vvpp.txt"
 
-      - name: Upload to artifact
+      - name: Upload VVPP archives to artifact
         if: github.event.inputs.upload_artifact
         uses: actions/upload-artifact@v3
         with:
           name: ${{ steps.vars.outputs.package_name }}
           path: |
-            ${{ steps.vars.outputs.package_name }}.7z.*
             ${{ steps.vars.outputs.package_name }}.vvpp
             ${{ steps.vars.outputs.package_name }}*.vvppp
             ${{ steps.vars.outputs.package_name }}.vvpp.txt
 
-      - name: Upload to Release assets
+      - name: Upload VVPP archives to Release assets
         if: needs.config.outputs.version != ''
         uses: ncipollo/release-action@v1
         with:
@@ -565,7 +599,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ needs.config.outputs.version }}
           artifacts: >
-            ${{ steps.vars.outputs.package_name }}.7z.*,
             ${{ steps.vars.outputs.package_name }}.vvpp,
             ${{ steps.vars.outputs.package_name }}*.vvppp,
             ${{ steps.vars.outputs.package_name }}.vvpp.txt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -152,6 +152,7 @@ jobs:
           if [[ ${{ matrix.os }} == windows-* ]]; then
             mv "${CUDA_ROOT}/bin/"*.dll download/cuda/bin/
 
+            # remove CUDA to reduce disk usage
             rm -rf "${CUDA_ROOT}"
           else
             cp "${CUDA_ROOT}/lib64/"libcublas.so.* download/cuda/bin/
@@ -166,6 +167,9 @@ jobs:
             rm -f download/cuda/bin/libcufft.so.*.*
             rm -f download/cuda/bin/libcurand.so.*.*
             rm -f download/cuda/bin/libcudart.so.*.*.*
+
+            # remove CUDA to reduce disk usage
+            rm -rf "${CUDA_ROOT}"
           fi
 
       # Download cuDNN

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -522,7 +522,7 @@ jobs:
           CERT_BASE64: ${{ secrets.CERT_BASE64 }}
           CERT_PASSWORD: ${{ secrets.CERT_PASSWORD }}
 
-      - name: Rename artifact directory for release
+      - name: Rename artifact directory to archive
         shell: bash
         run: |
           mv dist/run/ "${{ matrix.target }}/"


### PR DESCRIPTION
## 内容

リリースCI（バイナリビルドCI）において、7zの圧縮・アップロードが終わったのち、アップロード済みの7zをローカルから削除してから、VVPPの圧縮・アップロードをするように変更します。
ついでに、Linux CUDA版ビルド時に、Windows CUDA版では削除しているCUDAディレクトリが削除されていなかったため、削除して容量を確保するようにします（CUDAのCIキャッシュでは、インストール先から必要なファイルだけをコピーして保持しているため、コピーが終わったインストール先ディレクトリは削除することができます）。

以前の実装では、リリースに関係する以下の4種類のファイルが同時にストレージを消費するようになっていました（ #695 の作業中にWindows CUDA版ビルド時のCIストレージが足りなくなったことで気づきました）。

- 7z/VVPP圧縮・アップロード時
    - アーカイブ前のディレクトリ
    - 7z
    - 分割前のzip
    - 分割後のvvpp/vvppp

このPRによって、保持されるファイルは以下のようになります。ストレージ使用量は、「アーカイブ前のディレクトリ」の最大4倍→最大3倍に減ります。

- 7z圧縮・アップロード時
    - アーカイブ前のディレクトリ
    - 7z
- VVPP圧縮・アップロード時
    - アーカイブ前のディレクトリ
    - 分割前のzip
    - 分割後のvvpp/vvppp

VVPP圧縮時に、「分割前のzip」を作成する必要がないように書き換えることができれば、最大2倍まで減らせそうですが、このPRでは変更量を減らすため、以前のVVVP圧縮実装を維持しています。

<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue

- #524

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
