### PR TITLE
Github Actionsでshell: bashを毎回書かなくても良いようにする

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -18,6 +18,10 @@ env:
   VOICEVOX_RESOURCE_VERSION: "0.14.3"
   VOICEVOX_CORE_VERSION: "0.14.4"
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   config: # 全 jobs で利用する定数の定義. `env` が利用できないコンテキストでも利用できる.
     runs-on: ubuntu-latest
@@ -26,7 +30,6 @@ jobs:
     steps:
       - name: declare variables
         id: vars
-        shell: bash
         run: |
           : # releaseタグ名か、workflow_dispatchでのバージョン名か、latestが入る
           echo "version_or_latest=${{ github.event.release.tag_name || github.event.inputs.version || 'latest' }}" >> $GITHUB_OUTPUT
@@ -111,7 +114,6 @@ jobs:
 
       # Merge VOICEVOX RESOURCE
       - name: Merge VOICEVOX RESOURCE
-        shell: bash
         env:
           DOWNLOAD_RESOURCE_PATH: download/resource
         run: bash build_util/process_voicevox_resource.bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,10 @@ env:
   VOICEVOX_RESOURCE_VERSION: "0.14.3"
   VOICEVOX_CORE_VERSION: "0.14.4"
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   config: # 全 jobs で利用する定数の定義. `env` が利用できないコンテキストでも利用できる.
     runs-on: ubuntu-latest
@@ -37,7 +41,6 @@ jobs:
     steps:
       - name: declare variables
         id: vars
-        shell: bash
         run: |
           : # release タグ名, または workflow_dispatch でのバージョン名. リリースでない (push event) 場合は空文字列
           echo "version=${{ github.event.release.tag_name || github.event.inputs.version }}" >> $GITHUB_OUTPUT
@@ -98,7 +101,6 @@ jobs:
     steps:
       - name: declare variables
         id: vars
-        shell: bash
         run: |
           echo "package_name=voicevox_engine-${{ matrix.target }}-${{ needs.config.outputs.version }}" >> $GITHUB_OUTPUT
 
@@ -109,7 +111,6 @@ jobs:
       #       so you need to install GNU 'sed' and 'split'.
       - name: Install GNU sed on macOS
         if: startsWith(matrix.os, 'macos-')
-        shell: bash
         run: |
           brew install gnu-sed coreutils
           echo "/usr/local/opt/gnu-sed/libexec/gnubin" >> $GITHUB_PATH
@@ -142,7 +143,6 @@ jobs:
 
       - name: Extract CUDA Dynamic Libraries
         if: matrix.cuda_version != '' && steps.cuda-dll-cache.outputs.cache-hit != 'true'
-        shell: bash
         run: |
           set -eux
 
@@ -171,7 +171,6 @@ jobs:
       # Download cuDNN
       - name: Export cuDNN url to calc hash
         if: matrix.cudnn_url != ''
-        shell: bash
         run: echo "${{ matrix.cudnn_url }}" > download/cudnn_url.txt
 
       - name: Prepare cuDNN cache
@@ -185,7 +184,6 @@ jobs:
 
       - name: Download and extract cuDNN Dynamic Libraries
         if: matrix.cudnn_url != '' && steps.cudnn-dll-cache.outputs.cache-hit != 'true'
-        shell: bash
         run: |
           set -eux
 
@@ -218,7 +216,6 @@ jobs:
       # Donwload zlib
       - name: Export zlib url to calc hash
         if: matrix.zlib_url != ''
-        shell: bash
         run: echo "${{ matrix.zlib_url }}" >> download/zlib_url.txt
 
       - name: Cache zlib
@@ -231,7 +228,6 @@ jobs:
 
       - name: Download zlib
         if: steps.zlib-cache.outputs.cache-hit != 'true' && matrix.zlib_url != ''
-        shell: bash
         run: |
           curl -L "${{ matrix.zlib_url }}" -o download/zlib.zip
           mkdir -p download/zlib
@@ -256,7 +252,6 @@ jobs:
           cache: pip
 
       - name: Install Python dependencies
-        shell: bash
         run: |
           python -m pip install -r requirements-dev.txt
 
@@ -283,13 +278,11 @@ jobs:
           fi
 
       - name: Create download directory
-        shell: bash
         run: mkdir -p download/
 
       # Donwload DirectML
       - name: Export DirectML url to calc hash
         if: endswith(matrix.target, '-directml')
-        shell: bash
         run: echo "${{ matrix.directml_url }}" >> download/directml_url.txt
 
       - name: Cache DirectML
@@ -302,7 +295,6 @@ jobs:
 
       - name: Download DirectML
         if: steps.directml-cache.outputs.cache-hit != 'true' && endswith(matrix.target, '-directml')
-        shell: bash
         run: |
           curl -L "${{ matrix.directml_url }}" -o download/directml.zip
           mkdir -p download/directml
@@ -315,7 +307,6 @@ jobs:
 
       # Download ONNX Runtime
       - name: Export ONNX Runtime url to calc hash
-        shell: bash
         run: echo "${{ matrix.onnxruntime_url }}" > download/onnxruntime_url.txt
 
       - name: Prepare ONNX Runtime cache
@@ -327,7 +318,6 @@ jobs:
 
       - name: Download ONNX Runtime (Windows)
         if: steps.onnxruntime-cache.outputs.cache-hit != 'true' && startsWith(matrix.os, 'windows-')
-        shell: bash
         run: |
           curl -L "${{ matrix.onnxruntime_url }}" > download/onnxruntime.zip
 
@@ -346,7 +336,6 @@ jobs:
 
       - name: Download ONNX Runtime (Mac/Linux)
         if: steps.onnxruntime-cache.outputs.cache-hit != 'true' && startsWith(matrix.os, 'windows-') != true
-        shell: bash
         run: |
           curl -L "${{ matrix.onnxruntime_url }}" > download/onnxruntime.tgz
           mkdir -p download/onnxruntime
@@ -371,7 +360,6 @@ jobs:
 
       # Merge VOICEVOX RESOURCE
       - name: Merge VOICEVOX RESOURCE
-        shell: bash
         env:
           DOWNLOAD_RESOURCE_PATH: download/resource
         run: bash build_util/process_voicevox_resource.bash
@@ -386,7 +374,6 @@ jobs:
 
       - name: Download VOICEVOX Core
         if: steps.voicevox-core-cache.outputs.cache-hit != 'true'
-        shell: bash
         env:
           VOICEVOX_CORE_ASSET_NAME: ${{ matrix.voicevox_core_asset_prefix }}-${{ env.VOICEVOX_CORE_VERSION }}
         run: |
@@ -409,12 +396,10 @@ jobs:
           rm download/${{ env.VOICEVOX_CORE_ASSET_NAME }}.zip
 
       - name: Copy VOICEVOX Core Models
-        shell: bash
         run: |
           cp -r download/core/model ./
 
       - name: Generate licenses.json
-        shell: bash
         run: |
           OUTPUT_LICENSE_JSON_PATH=engine_manifest_assets/dependency_licenses.json \
           bash build_util/create_venv_and_generate_licenses.bash
@@ -422,7 +407,6 @@ jobs:
           cp engine_manifest_assets/dependency_licenses.json licenses.json
 
       - name: Build run.py with PyInstaller
-        shell: bash
         run: |
           set -eux
 
@@ -448,7 +432,6 @@ jobs:
 
       - name: Create artifact directory with symlink
         if: startsWith(matrix.os, 'windows-')
-        shell: bash
         env:
           PYTHON_SITE_PACKAGES_DIR: C:/hostedtoolcache/windows/python/${{ steps.setup-python.outputs.python-version }}/x64/lib/site-packages
           # create symlink instead of copy (Git Bash)
@@ -485,7 +468,6 @@ jobs:
 
       - name: Create symlink of CUDA dependencies
         if: startsWith(matrix.os, 'ubuntu-') && endsWith(matrix.target, 'nvidia')
-        shell: bash
         run: |
           set -eux
 
@@ -511,7 +493,6 @@ jobs:
 
       - name: Code signing
         if: github.event.inputs.code_signing == 'true' && startsWith(matrix.os, 'windows-')
-        shell: bash
         run: |
           bash build_util/codesign.bash "dist/run/run.exe"
         env:
@@ -519,7 +500,6 @@ jobs:
           CERT_PASSWORD: ${{ secrets.CERT_PASSWORD }}
 
       - name: Rearchive and split artifact
-        shell: bash
         run: |
           mv dist/run/ "${{ matrix.target }}/"
 

--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -8,6 +8,10 @@ on:
       - completed
   workflow_dispatch:
 
+defaults:
+  run:
+    shell: bash
+    
 jobs:
   comment:
     runs-on: ubuntu-latest

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -2,7 +2,10 @@ name: Issue Labeler
 on:
   issues:
     types: [opened]
-
+defaults:
+  run:
+    shell: bash
+    
 jobs:
   triage:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-test-docker.yml
+++ b/.github/workflows/release-test-docker.yml
@@ -21,6 +21,10 @@ env:
   VERSION: |- # version指定時はversionを、それ以外はタグ名を使用
     ${{ (github.event.inputs || inputs).version }}
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   test:
     runs-on: [ ubuntu-20.04 ]
@@ -75,7 +79,6 @@ jobs:
       # - ステータスコードが `200` の場合は正常終了します
       # - ステータスコードが `200` 以外の場合は、5秒間スリープしてリトライします
       - name: Wait for container to start
-        shell: bash -xv {0}
         run: |
           url="http://127.0.0.1:50021/version"
           max_attempts=10
@@ -94,5 +97,4 @@ jobs:
           exit 1
 
       - name: Test
-        shell: bash
         run: python build_util/check_release_build.py --skip_run_process --dist_dir dist/

--- a/.github/workflows/release-test-docker.yml
+++ b/.github/workflows/release-test-docker.yml
@@ -80,6 +80,8 @@ jobs:
       # - ステータスコードが `200` 以外の場合は、5秒間スリープしてリトライします
       - name: Wait for container to start
         run: |
+          set +e # curlのエラーを無視する
+          
           url="http://127.0.0.1:50021/version"
           max_attempts=10
           sleep_interval=5

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -27,6 +27,10 @@ env:
   VERSION: |- # version指定時はversionを、それ以外はタグ名を使用
     ${{ (github.event.inputs || inputs).version }}
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   test:
     strategy:
@@ -51,7 +55,6 @@ jobs:
     steps:
       - name: declare variables
         id: vars
-        shell: bash
         run: |
           echo "release_url=${{ env.REPO_URL }}/releases/download/${{ env.VERSION }}" >> $GITHUB_OUTPUT
           echo "package_name=voicevox_engine-${{ matrix.target }}-${{ env.VERSION }}" >> $GITHUB_OUTPUT
@@ -64,7 +67,6 @@ jobs:
           cache: pip
 
       - name: Download
-        shell: bash -euxv {0}
         run: |
           mkdir -p download
           curl -L -o "download/list.txt" "${{ steps.vars.outputs.release_url }}/${{ steps.vars.outputs.package_name }}.7z.txt"
@@ -74,7 +76,6 @@ jobs:
 
       - name: chmod +x
         if: startsWith(matrix.target, 'linux') || startsWith(matrix.target, 'macos')
-        shell: bash
         run: chmod +x dist/run
 
       - name: Install libsndfile1
@@ -88,5 +89,4 @@ jobs:
           pip install -r requirements-test.txt
 
       - name: Test
-        shell: bash
         run: python build_util/check_release_build.py --dist_dir dist/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,13 +14,6 @@ jobs:
       matrix:
         os: [ubuntu-20.04, windows-latest] # [ubuntu-20.04, macos-latest, windows-latest]
         python: ["3.11.3"]
-        include:
-          - os: ubuntu-20.04
-            path: ~/.cache/pip
-          # - os: macos-latest
-          #   path: ~/Library/Caches/pip
-          - os: windows-latest
-            path: ~\AppData\Local\pip\Cache
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,10 @@ on:
       - "**"
   workflow_dispatch:
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -7,6 +7,10 @@ on:
       - "**"
   workflow_dispatch:
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   typos:
     runs-on: ubuntu-latest

--- a/.github/workflows/upload-gh-pages.yml
+++ b/.github/workflows/upload-gh-pages.yml
@@ -11,6 +11,10 @@ env:
   PUBLISH_BRANCH: "gh-pages"
   DESTINATION_DIR: "api"
 
+defaults:
+  run:
+    shell: bash
+  
 jobs:
   upload-doc:
     runs-on: ubuntu-20.04
@@ -28,12 +32,10 @@ jobs:
         run: sudo apt-get install libsndfile1
 
       - name: Install Python dependencies
-        shell: bash
         run: |
           pip install -r requirements.txt
 
       - name: Make documents
-        shell: bash
         run: |
           python make_docs.py
 


### PR DESCRIPTION
## 内容

shell: bashを不要にできるオプションがあったので指定してみました。
とりあえずubuntu以外でのOSで実行していたworkflowにのみ付けています。
https://docs.github.com/ja/actions/using-workflows/workflow-syntax-for-github-actions#defaultsrun

2023/06/19 14:30追記
shell: bashを付けるか付けないかでubuntu/mac上の挙動が変わり、かつ付けたときのほうが良さそうなので全部に付けました。