### PR TITLE
CI: Linux CUDA版のバイナリビルド成果物の共有ライブラリがシンボリックリンクにならないようにする

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -297,7 +297,7 @@ jobs:
         uses: actions/cache/restore@v3
         id: directml-cache-restore
         with:
-          key: directml-cache-v1-${{ hashFiles('download/directml_url.txt') }}
+          key: directml-cache-v2-${{ hashFiles('download/directml_url.txt') }}
           path: download/directml
 
       - name: Download DirectML

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,7 +129,7 @@ jobs:
         id: cuda-dll-cache-restore
         with:
           # update this key when ONNX Runtime CUDA dependency changed
-          key: ${{ matrix.os }}-cuda-dll-${{ matrix.cuda_version }}-v1
+          key: ${{ matrix.os }}-cuda-dll-${{ matrix.cuda_version }}-v2
           path: download/cuda
 
       - name: Setup CUDA

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -180,7 +180,7 @@ jobs:
         id: cudnn-dll-cache-restore
         with:
           # update this key when ONNX Runtime cuDNN dependency changed
-          key: ${{ matrix.os }}-cudnn-dll-${{ hashFiles('download/cudnn_url.txt') }}-v1
+          key: ${{ matrix.os }}-cudnn-dll-${{ hashFiles('download/cudnn_url.txt') }}-v2
           path: download/cudnn
 
       - name: Download and extract cuDNN Dynamic Libraries

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -484,7 +484,6 @@ jobs:
         if: startsWith(matrix.os, 'windows-')
         shell: bash
         env:
-          PYTHON_SITE_PACKAGES_DIR: C:/hostedtoolcache/windows/python/${{ steps.setup-python.outputs.python-version }}/x64/lib/site-packages
           # create symlink instead of copy (Git Bash)
           # https://qiita.com/ucho/items/c5ea0beb8acf2f1e4772
           MSYS: winsymlinks:nativestrict

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -544,6 +544,11 @@ jobs:
           mv download/cudnn/bin/libcudnn.so.* dist/run/
           mv download/cudnn/bin/libcudnn_*_infer.so.* dist/run/
 
+          # Remove source directories (already cached)
+          rm -rf download/onnxruntime
+          rm -rf download/cuda
+          rm -rf download/cudnn
+
       - name: Set @rpath to @executable_path
         if: startsWith(matrix.os, 'macos-')
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -226,7 +226,7 @@ jobs:
         uses: actions/cache/restore@v3
         id: zlib-cache-restore
         with:
-          key: zlib-cache-v1-${{ hashFiles('download/zlib_url.txt') }}
+          key: zlib-cache-v2-${{ hashFiles('download/zlib_url.txt') }}
           path: download/zlib
 
       - name: Download zlib

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -221,16 +221,16 @@ jobs:
         shell: bash
         run: echo "${{ matrix.zlib_url }}" >> download/zlib_url.txt
 
-      - name: Cache zlib
+      - name: Restore cached zlib
         if: matrix.zlib_url != ''
-        uses: actions/cache@v3
-        id: zlib-cache
+        uses: actions/cache/restore@v3
+        id: zlib-cache-restore
         with:
           key: zlib-cache-v1-${{ hashFiles('download/zlib_url.txt') }}
           path: download/zlib
 
       - name: Download zlib
-        if: steps.zlib-cache.outputs.cache-hit != 'true' && matrix.zlib_url != ''
+        if: steps.zlib-cache-restore.outputs.cache-hit != 'true' && matrix.zlib_url != ''
         shell: bash
         run: |
           curl -L "${{ matrix.zlib_url }}" -o download/zlib.zip
@@ -241,6 +241,13 @@ jobs:
           rm download/zlib.zip
           mv download/zlib/dll_${{ matrix.architecture }}/zlibwapi.dll download/zlib/zlibwapi.dll
           rm -r download/zlib/dll_${{ matrix.architecture }}
+
+      - name: Save zlib cache
+        if: matrix.zlib_url != ''
+        uses: actions/cache/save@v3
+        with:
+          key: ${{ steps.zlib-cache-restore.outputs.cache-primary-key }}
+          path: download/zlib
 
       - name: Setup MSVC
         if: startsWith(matrix.os, 'windows-')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -292,16 +292,16 @@ jobs:
         shell: bash
         run: echo "${{ matrix.directml_url }}" >> download/directml_url.txt
 
-      - name: Cache DirectML
+      - name: Restore cached DirectML
         if: endswith(matrix.target, '-directml')
-        uses: actions/cache@v3
-        id: directml-cache
+        uses: actions/cache/restore@v3
+        id: directml-cache-restore
         with:
           key: directml-cache-v1-${{ hashFiles('download/directml_url.txt') }}
           path: download/directml
 
       - name: Download DirectML
-        if: steps.directml-cache.outputs.cache-hit != 'true' && endswith(matrix.target, '-directml')
+        if: steps.directml-cache-restore.outputs.cache-hit != 'true' && endswith(matrix.target, '-directml')
         shell: bash
         run: |
           curl -L "${{ matrix.directml_url }}" -o download/directml.zip
@@ -312,6 +312,13 @@ jobs:
           rm download/directml.zip
           mv download/directml/bin/${{ matrix.architecture }}-win/DirectML.dll download/directml/DirectML.dll
           rm -r download/directml/bin
+
+      - name: Save DirectML cache
+        if: endswith(matrix.target, '-directml')
+        uses: actions/cache/save@v3
+        with:
+          key: ${{ steps.directml-cache-restore.outputs.cache-primary-key }}
+          path: download/directml
 
       # Download ONNX Runtime
       - name: Export ONNX Runtime url to calc hash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -505,11 +505,20 @@ jobs:
 
             # zlib
             mv download/zlib/zlibwapi.dll dist/run/
+
+            # Remove source directories (already cached)
+            rm -rf download/onnxruntime
+            rm -rf download/cuda
+            rm -rf download/cudnn
+            rm -rf download/zlib
           fi
 
           if [[ ${{ matrix.target }} == *-directml ]]; then
             # DirectML
             mv download/directml/DirectML.dll dist/run/
+
+            # Remove source directory (already cached)
+            rm -rf download/directml
           fi
 
       - name: Gather DLL dependencies to dist/run/ (Linux CUDA)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -322,7 +322,7 @@ jobs:
         uses: actions/cache/restore@v3
         id: onnxruntime-cache-restore
         with:
-          key: ${{ matrix.os }}-onnxruntime-${{ hashFiles('download/onnxruntime_url.txt') }}-v1
+          key: ${{ matrix.os }}-onnxruntime-${{ hashFiles('download/onnxruntime_url.txt') }}-v2
           path: download/onnxruntime
 
       - name: Download ONNX Runtime (Windows)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -480,40 +480,36 @@ jobs:
           LIBONNXRUNTIME_PATH="$LIBONNXRUNTIME_PATH" \
           pyinstaller --noconfirm run.spec
 
-      - name: Create artifact directory with symlink
+      - name: Gather DLL dependencies to dist/run/ (Windows)
         if: startsWith(matrix.os, 'windows-')
         shell: bash
-        env:
-          # create symlink instead of copy (Git Bash)
-          # https://qiita.com/ucho/items/c5ea0beb8acf2f1e4772
-          MSYS: winsymlinks:nativestrict
         run: |
           set -eux
 
-          # Copy DLL dependencies
+          # Move DLL dependencies (cache already saved)
 
           if [ -f "download/onnxruntime/lib/onnxruntime_providers_cuda.dll" ]; then
             # ONNX Runtime providers (PyInstaller does not copy dynamic loaded libraries)
-            ln -sf "$(pwd)/download/onnxruntime/lib"/onnxruntime_*.dll dist/run/
+            mv download/onnxruntime/lib/onnxruntime_*.dll dist/run/
 
             # CUDA
-            ln -sf "$(pwd)/download/cuda/bin"/cublas64_*.dll dist/run/
-            ln -sf "$(pwd)/download/cuda/bin"/cublasLt64_*.dll dist/run/
-            ln -sf "$(pwd)/download/cuda/bin"/cudart64_*.dll dist/run/
-            ln -sf "$(pwd)/download/cuda/bin"/cufft64_*.dll dist/run/
-            ln -sf "$(pwd)/download/cuda/bin"/curand64_*.dll dist/run/
+            mv download/cuda/bin/cublas64_*.dll dist/run/
+            mv download/cuda/bin/cublasLt64_*.dll dist/run/
+            mv download/cuda/bin/cudart64_*.dll dist/run/
+            mv download/cuda/bin/cufft64_*.dll dist/run/
+            mv download/cuda/bin/curand64_*.dll dist/run/
 
             # cuDNN
-            ln -sf "$(pwd)/download/cudnn/bin"/cudnn64_*.dll dist/run/
-            ln -sf "$(pwd)/download/cudnn/bin"/cudnn_*_infer64*.dll dist/run/
+            mv download/cudnn/bin/cudnn64_*.dll dist/run/
+            mv download/cudnn/bin/cudnn_*_infer64*.dll dist/run/
 
             # zlib
-            ln -sf "$(pwd)/download/zlib"/zlibwapi.dll dist/run/
+            mv download/zlib/zlibwapi.dll dist/run/
           fi
 
           if [[ ${{ matrix.target }} == *-directml ]]; then
             # DirectML
-            ln -sf "$(pwd)/download/directml"/DirectML.dll dist/run/
+            mv download/directml/DirectML.dll dist/run/
           fi
 
       - name: Create symlink of CUDA dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -174,17 +174,17 @@ jobs:
         shell: bash
         run: echo "${{ matrix.cudnn_url }}" > download/cudnn_url.txt
 
-      - name: Prepare cuDNN cache
+      - name: Restore cached cuDNN
         if: matrix.cudnn_url != ''
-        uses: actions/cache@v3
-        id: cudnn-dll-cache
+        uses: actions/cache/restore@v3
+        id: cudnn-dll-cache-restore
         with:
           # update this key when ONNX Runtime cuDNN dependency changed
           key: ${{ matrix.os }}-cudnn-dll-${{ hashFiles('download/cudnn_url.txt') }}-v1
           path: download/cudnn
 
       - name: Download and extract cuDNN Dynamic Libraries
-        if: matrix.cudnn_url != '' && steps.cudnn-dll-cache.outputs.cache-hit != 'true'
+        if: matrix.cudnn_url != '' && steps.cudnn-dll-cache-restore.outputs.cache-hit != 'true'
         shell: bash
         run: |
           set -eux
@@ -214,6 +214,13 @@ jobs:
 
             rm download/cudnn.tar.xz
           fi
+
+      - name: Save cuDNN cache
+        if: matrix.cudnn_url != ''
+        uses: actions/cache/save@v3
+        with:
+          key: ${{ steps.cudnn-dll-cache-restore.outputs.cache-primary-key }}
+          path: download/cudnn
 
       # Donwload zlib
       - name: Export zlib url to calc hash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,17 +123,17 @@ jobs:
           sudo apt-get install -y patchelf
 
       # Download CUDA
-      - name: Prepare CUDA DLL cache
+      - name: Restore cached CUDA
         if: matrix.cuda_version != ''
-        uses: actions/cache@v3
-        id: cuda-dll-cache
+        uses: actions/cache/restore@v3
+        id: cuda-dll-cache-restore
         with:
           # update this key when ONNX Runtime CUDA dependency changed
           key: ${{ matrix.os }}-cuda-dll-${{ matrix.cuda_version }}-v1
           path: download/cuda
 
       - name: Setup CUDA
-        if: matrix.cuda_version != '' && steps.cuda-dll-cache.outputs.cache-hit != 'true'
+        if: matrix.cuda_version != '' && steps.cuda-dll-cache-restore.outputs.cache-hit != 'true'
         uses: Jimver/cuda-toolkit@v0.2.8
         id: cuda-toolkit
         with:
@@ -141,7 +141,7 @@ jobs:
           cuda: ${{ matrix.cuda_version }}
 
       - name: Extract CUDA Dynamic Libraries
-        if: matrix.cuda_version != '' && steps.cuda-dll-cache.outputs.cache-hit != 'true'
+        if: matrix.cuda_version != '' && steps.cuda-dll-cache-restore.outputs.cache-hit != 'true'
         shell: bash
         run: |
           set -eux
@@ -167,6 +167,13 @@ jobs:
             rm -f download/cuda/bin/libcurand.so.*.*
             rm -f download/cuda/bin/libcudart.so.*.*.*
           fi
+
+      - name: Save CUDA cache
+        if: matrix.cuda_version != ''
+        uses: actions/cache/save@v3
+        with:
+          key: ${{ steps.cuda-dll-cache-restore.outputs.cache-primary-key }}
+          path: download/cuda
 
       # Download cuDNN
       - name: Export cuDNN url to calc hash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -318,15 +318,15 @@ jobs:
         shell: bash
         run: echo "${{ matrix.onnxruntime_url }}" > download/onnxruntime_url.txt
 
-      - name: Prepare ONNX Runtime cache
-        uses: actions/cache@v3
-        id: onnxruntime-cache
+      - name: Restore cached ONNX Runtime
+        uses: actions/cache/restore@v3
+        id: onnxruntime-cache-restore
         with:
           key: ${{ matrix.os }}-onnxruntime-${{ hashFiles('download/onnxruntime_url.txt') }}-v1
           path: download/onnxruntime
 
       - name: Download ONNX Runtime (Windows)
-        if: steps.onnxruntime-cache.outputs.cache-hit != 'true' && startsWith(matrix.os, 'windows-')
+        if: steps.onnxruntime-cache-restore.outputs.cache-hit != 'true' && startsWith(matrix.os, 'windows-')
         shell: bash
         run: |
           curl -L "${{ matrix.onnxruntime_url }}" > download/onnxruntime.zip
@@ -345,13 +345,19 @@ jobs:
           rm download/onnxruntime.zip
 
       - name: Download ONNX Runtime (Mac/Linux)
-        if: steps.onnxruntime-cache.outputs.cache-hit != 'true' && startsWith(matrix.os, 'windows-') != true
+        if: steps.onnxruntime-cache-restore.outputs.cache-hit != 'true' && startsWith(matrix.os, 'windows-') != true
         shell: bash
         run: |
           curl -L "${{ matrix.onnxruntime_url }}" > download/onnxruntime.tgz
           mkdir -p download/onnxruntime
           tar xf "download/onnxruntime.tgz" -C "download/onnxruntime" --strip-components 1
           rm download/onnxruntime.tgz
+
+      - name: Save ONNX Runtime cache
+        uses: actions/cache/save@v3
+        with:
+          key: ${{ steps.onnxruntime-cache-restore.outputs.cache-primary-key }}
+          path: download/onnxruntime
 
       # Download VOICEVOX RESOURCE
       - name: Prepare VOICEVOX RESOURCE cache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -512,26 +512,28 @@ jobs:
             mv download/directml/DirectML.dll dist/run/
           fi
 
-      - name: Create symlink of CUDA dependencies
+      - name: Gather DLL dependencies to dist/run/ (Linux CUDA)
         if: startsWith(matrix.os, 'ubuntu-') && endsWith(matrix.target, 'nvidia')
         shell: bash
         run: |
           set -eux
 
+          # Move DLL dependencies (cache already saved)
+
           # ONNX Runtime providers (PyInstaller does not copy dynamic loaded libraries)
           patchelf --set-rpath '$ORIGIN' "$(pwd)/download/onnxruntime/lib"/libonnxruntime_providers_*.so
-          ln -sf "$(pwd)/download/onnxruntime/lib"/libonnxruntime_*.so dist/run/
+          mv download/onnxruntime/lib/libonnxruntime_*.so dist/run/
 
           # CUDA
-          ln -sf "$(pwd)/download/cuda/bin"/libcublas.so.* dist/run/
-          ln -sf "$(pwd)/download/cuda/bin"/libcublasLt.so.* dist/run/
-          ln -sf "$(pwd)/download/cuda/bin"/libcudart.so.* dist/run/
-          ln -sf "$(pwd)/download/cuda/bin"/libcufft.so.* dist/run/
-          ln -sf "$(pwd)/download/cuda/bin"/libcurand.so.* dist/run/
+          mv download/cuda/bin/libcublas.so.* dist/run/
+          mv download/cuda/bin/libcublasLt.so.* dist/run/
+          mv download/cuda/bin/libcudart.so.* dist/run/
+          mv download/cuda/bin/libcufft.so.* dist/run/
+          mv download/cuda/bin/libcurand.so.* dist/run/
 
           # cuDNN
-          ln -sf "$(pwd)/download/cudnn/bin"/libcudnn.so.* dist/run/
-          ln -sf "$(pwd)/download/cudnn/bin"/libcudnn_*_infer.so.* dist/run/
+          mv download/cudnn/bin/libcudnn.so.* dist/run/
+          mv download/cudnn/bin/libcudnn_*_infer.so.* dist/run/
 
       - name: Set @rpath to @executable_path
         if: startsWith(matrix.os, 'macos-')


### PR DESCRIPTION
## 内容

`actions/cache/restore@v3`、`actions/cache/save@v3`を使ってキャッシュの保存タイミングを変更し、キャッシュ保存後に共有ライブラリの実体を`mv`するように変更する、というアプローチで、 #699 を修正します。

- https://github.com/VOICEVOX/voicevox_engine/pull/696#issuecomment-1596001447
- https://github.com/VOICEVOX/voicevox_engine/pull/696#issuecomment-1596023886
- https://github.com/VOICEVOX/voicevox_engine/pull/696#issuecomment-1596037886

<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue

- close #699 

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
