### PR TITLE
build.ymlでgnuのsedやsplitなどを.bashrc経由で使えるようにする

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,8 +113,8 @@ jobs:
         if: startsWith(matrix.os, 'macos-')
         run: |
           brew install gnu-sed coreutils
-          echo 'export PATH=/usr/local/opt/gnu-sed/libexec/gnubin:$PATH' >> $HOME/.bashrc
-          echo 'export PATH=/usr/local/opt/coreutils/libexec/gnubin:$PATH' >> $HOME/.bashrc
+          echo 'export PATH="/usr/local/opt/gnu-sed/libexec/gnubin:$PATH"' >> $HOME/.bashrc
+          echo 'export PATH="/usr/local/opt/coreutils/libexec/gnubin:$PATH"' >> $HOME/.bashrc
 
       # ONNX Runtime providersとCUDA周りをリンクするために使う
       - name: Install patchelf

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ env:
 
 defaults:
   run:
-    shell: bash
+    shell: bash -leo pipefail {0}
 
 jobs:
   config: # 全 jobs で利用する定数の定義. `env` が利用できないコンテキストでも利用できる.
@@ -113,8 +113,8 @@ jobs:
         if: startsWith(matrix.os, 'macos-')
         run: |
           brew install gnu-sed coreutils
-          echo "/usr/local/opt/gnu-sed/libexec/gnubin" >> $GITHUB_PATH
-          echo "/usr/local/opt/coreutils/libexec/gnubin" >> $GITHUB_PATH
+          echo "export PATH=/usr/local/opt/gnu-sed/libexec/gnubin:$PATH" >> $HOME/.bashrc
+          echo "export PATH=/usr/local/opt/coreutils/libexec/gnubin:$PATH" >> $HOME/.bashrc
 
       # ONNX Runtime providersとCUDA周りをリンクするために使う
       - name: Install patchelf

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,8 +113,8 @@ jobs:
         if: startsWith(matrix.os, 'macos-')
         run: |
           brew install gnu-sed coreutils
-          echo "export PATH=/usr/local/opt/gnu-sed/libexec/gnubin:$PATH" >> $HOME/.bashrc
-          echo "export PATH=/usr/local/opt/coreutils/libexec/gnubin:$PATH" >> $HOME/.bashrc
+          echo 'export PATH=/usr/local/opt/gnu-sed/libexec/gnubin:$PATH' >> $HOME/.bashrc
+          echo 'export PATH=/usr/local/opt/coreutils/libexec/gnubin:$PATH' >> $HOME/.bashrc
 
       # ONNX Runtime providersとCUDA周りをリンクするために使う
       - name: Install patchelf


### PR DESCRIPTION
## 内容

- https://github.com/VOICEVOX/voicevox_engine/issues/698

で出ていたエラーの解決です。

以前にmac環境でbsdではなくgnuのsedなどを使えるようにしたとき、actionsなどが利用するchmodなども置き換わってしまってエラーが発生するようになっていました。
グローバルなPATHを変えるのではなく、bashrcに書き込んでbash実行時のみPATHが変わるようにしてみました。

## 関連 Issue

close #698
<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他

actions内でbashを使っている場合にエラーになりますが･･･大丈夫かな～と踏んでいます。
`${{ matrix.sed }}`と書かなくて良くなる・初学者の転ばぬ先の杖になる・他にbashrcを利用したいときが出てきたときに便利かなと思ってこうしてみました。

なにか問題が起こったら`matrix`を使う方に書き換えましょう･･･！！

追記：問題になっているsetup-pythonはbashを使っているので、効果がないかもしれません･･･。
https://github.com/actions/setup-python/blob/3f824b7ca6388f5e27e362d31352e6456c8e3bfb/src/install-python.ts#L67