### PR TITLE
build.ymlでGNU版のsedとsplitをenvに入れて明示的に実行

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,8 +100,8 @@ jobs:
 
     env:
       # GNUコマンド
-      sed: ${{ matrix.os == 'macos-11' && 'gsed' || 'sed' }}
-      split: ${{ matrix.os == 'macos-11' && 'gsplit' || 'split' }}
+      sed: ${{ startsWith(matrix.os, 'macos-') && 'gsed' || 'sed' }}
+      split: ${{ startsWith(matrix.os, 'macos-') && 'gsplit' || 'split' }}
 
     steps:
       - name: declare variables

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,6 +98,11 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
+    env:
+      # GNUコマンド
+      sed: ${{ matrix.os == 'macos-11' && 'gsed' || 'sed' }}
+      split: ${{ matrix.os == 'macos-11' && 'gsplit' || 'split' }}
+
     steps:
       - name: declare variables
         id: vars
@@ -113,8 +118,6 @@ jobs:
         if: startsWith(matrix.os, 'macos-')
         run: |
           brew install gnu-sed coreutils
-          echo "/usr/local/opt/gnu-sed/libexec/gnubin" >> $GITHUB_PATH
-          echo "/usr/local/opt/coreutils/libexec/gnubin" >> $GITHUB_PATH
 
       # ONNX Runtime providersとCUDA周りをリンクするために使う
       - name: Install patchelf
@@ -414,7 +417,7 @@ jobs:
           mv -f engine_manifest.json.tmp engine_manifest.json
 
           # Replace version & specify dynamic libraries
-          sed -i "s/__version__ = \"latest\"/__version__ = \"${{ needs.config.outputs.version_or_latest }}\"/" voicevox_engine/__init__.py
+          $sed -i "s/__version__ = \"latest\"/__version__ = \"${{ needs.config.outputs.version_or_latest }}\"/" voicevox_engine/__init__.py
           if [[ ${{ matrix.os }} == windows-* ]]; then
             LIBCORE_PATH=download/core/voicevox_core.dll
             LIBONNXRUNTIME_PATH=download/onnxruntime/lib/onnxruntime.dll
@@ -508,7 +511,7 @@ jobs:
 
           # Compress to artifact.001.vvppp,artifact.002.vvppp, ...
           (cd "${{ matrix.target }}" && 7z -r a "../compressed.zip")
-          split -b 1900M --numeric-suffixes=1 -a 3 --additional-suffix .vvppp ./compressed.zip ./${{ steps.vars.outputs.package_name }}.
+          $split -b 1900M --numeric-suffixes=1 -a 3 --additional-suffix .vvppp ./compressed.zip ./${{ steps.vars.outputs.package_name }}.
 
           # Rename to artifact.vvpp if there are only artifact.001.vvppp
           if [ "$(ls ${{ steps.vars.outputs.package_name }}.*.vvppp | wc -l)" == 1 ]; then


### PR DESCRIPTION
## 内容

- https://github.com/VOICEVOX/voicevox_engine/issues/698

で出ていたエラーの解決です。

以前にmac環境でbsdではなくgnuのsedなどを使えるようにしたとき、actionsなどが利用するchmodなども置き換わってしまってエラーが発生するようになっていました。
グローバルなPATHを変えるのではなく、envに使用するコマンドを書き込むことで切り替えられるようにしました。

## 関連 Issue

close #698
<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
