### PR TITLE
DockerビルドCI: リリースビルド時にlatest（masterブランチ）のレイヤーキャッシュを使うようにする

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -128,6 +128,13 @@ jobs:
                 format('{0}:{1}-{2}', env.IMAGE_NAME, matrix.tag, needs.config.outputs.version_or_latest)
               ) || format('{0}:{1}', env.IMAGE_NAME, needs.config.outputs.version_or_latest)
             ) }}
+          IMAGE_CACHE_FROM:
+            |- # Always use the `latest` buildcache. :latest-buildcache or :{tag}-latest-buildcache
+            ${{ (
+              matrix.tag != '' && (
+                format('type=registry,ref={0}:{1}-latest-buildcache', env.IMAGE_NAME, matrix.tag)
+              ) || format('type=registry,ref={0}:latest-buildcache', env.IMAGE_NAME)
+            ) }}
         with:
           context: .
           builder: ${{ steps.buildx.outputs.name }}
@@ -144,7 +151,7 @@ jobs:
           target: ${{ matrix.target }}
           push: true
           tags: ${{ env.IMAGE_TAG }}
-          cache-from: type=registry,ref=${{ env.IMAGE_TAG }}-buildcache
+          cache-from: ${{ env.IMAGE_CACHE_FROM }}
           cache-to: type=registry,ref=${{ env.IMAGE_TAG }}-buildcache,mode=max
           platforms: ${{ matrix.platforms }}
 


### PR DESCRIPTION
## 内容

- #674 

の内容を実装します。

リリースビルド時のDockerイメージビルドが高速化されます。

Dockerイメージビルドが走るイベントごとのタグ対応表は以下のようになります。

### masterブランチpush時（変更なし）

<details>

|`matrix.tag`|Dockerイメージタグ|cache-from|cache-to|
|:--|:--|:--|:--|
|（空文字列）|latest|latest-buildcache|latest-buildcache|
|cpu|cpu-latest|cpu-latest-buildcache|cpu-latest-buildcache|
|cpu-ubuntu20.04|cpu-ubuntu20.04-latest|cpu-ubuntu20.04-latest-buildcache|cpu-ubuntu20.04-latest-buildcache|
|nvidia|nvidia-latest|nvidia-latest-buildcache|nvidia-latest-buildcache|
|nvidia-ubuntu20.04|nvidia-ubuntu20.04-latest|nvidia-ubuntu20.04-latest-buildcache|nvidia-ubuntu20.04-latest-buildcache|

</details>

### バージョン0.15.0リリース時（変更前）

|`matrix.tag`|Dockerイメージタグ|cache-from|cache-to（変更なし）|
|:--|:--|:--|:--|
|（空文字列）|0.15.0|0.15.0-buildcache|0.15.0-buildcache|
|cpu|cpu-0.15.0|cpu-0.15.0-buildcache|cpu-0.15.0-buildcache|
|cpu-ubuntu20.04|cpu-ubuntu20.04-0.15.0|cpu-ubuntu20.04-0.15.0-buildcache|cpu-ubuntu20.04-0.15.0-buildcache|
|nvidia|nvidia-0.15.0|nvidia-0.15.0-buildcache|nvidia-0.15.0-buildcache|
|nvidia-ubuntu20.04|nvidia-ubuntu20.04-0.15.0|nvidia-ubuntu20.04-0.15.0-buildcache|nvidia-ubuntu20.04-0.15.0-buildcache|

### バージョン0.15.0リリース時（変更後）

|`matrix.tag`|Dockerイメージタグ|cache-from|cache-to（変更なし）|
|:--|:--|:--|:--|
|（空文字列）|0.15.0|latest-buildcache|0.15.0-buildcache|
|cpu|cpu-0.15.0|cpu-latest-buildcache|cpu-0.15.0-buildcache|
|cpu-ubuntu20.04|cpu-ubuntu20.04-0.15.0|cpu-ubuntu20.04-latest-buildcache|cpu-ubuntu20.04-0.15.0-buildcache|
|nvidia|nvidia-0.15.0|nvidia-latest-buildcache|nvidia-0.15.0-buildcache|
|nvidia-ubuntu20.04|nvidia-ubuntu20.04-0.15.0|nvidia-ubuntu20.04-latest-buildcache|nvidia-ubuntu20.04-0.15.0-buildcache|


<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue

- close #674

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
