### PR TITLE
コアをロードするときにログを出すようにする

### DIFF
--- a/voicevox_engine/synthesis_engine/make_synthesis_engines.py
+++ b/voicevox_engine/synthesis_engine/make_synthesis_engines.py
@@ -81,6 +81,7 @@ def make_synthesis_engines(
                 core = CoreWrapper(use_gpu, core_dir, cpu_num_threads, load_all_models)
                 metas = json.loads(core.metas())
                 core_version = metas[0]["version"]
+                print(f"Info: Loading core {core_version}.")
                 if core_version in synthesis_engines:
                     print(
                         "Warning: Core loading is skipped because of version duplication.",
@@ -115,6 +116,7 @@ def make_synthesis_engines(
         from ..dev.synthesis_engine import MockSynthesisEngine
 
         if "0.0.0" not in synthesis_engines:
+            print("Info: Loading mock.")
             synthesis_engines["0.0.0"] = MockSynthesisEngine(
                 speakers=mock_metas(), supported_devices=mock_supported_devices()
             )


### PR DESCRIPTION
## 内容

過去のコアのロードが原因で起動が遅くなっていたのですが、原因にたどり着くまでに時間がかかったので、ログを出力するようにしてみました。

- https://github.com/VOICEVOX/voicevox_engine/issues/721
<!--
プルリクエストの内容説明を端的に記載してください。
-->


## その他

ロギング周りに課題がありそうだったので、loggingを使った仕組みに変えてもいいかも。
