### PR TITLE
ビルド時のmodelディレクトリの指定をオプショナルにする

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -436,10 +436,6 @@ jobs:
           rm -rf download/${{ env.VOICEVOX_CORE_ASSET_NAME }}
           rm download/${{ env.VOICEVOX_CORE_ASSET_NAME }}.zip
 
-      - name: Copy VOICEVOX Core Models
-        run: |
-          cp -r download/core/model ./
-
       - name: Generate licenses.json
         run: |
           OUTPUT_LICENSE_JSON_PATH=engine_manifest_assets/dependency_licenses.json \
@@ -467,6 +463,7 @@ jobs:
             LIBONNXRUNTIME_PATH=download/onnxruntime/lib/libonnxruntime.so
           fi
 
+          CORE_MODEL_DIR_PATH="download/core/model" \
           LIBCORE_PATH="$LIBCORE_PATH" \
           LIBONNXRUNTIME_PATH="$LIBONNXRUNTIME_PATH" \
           pyinstaller --noconfirm run.spec

--- a/README.md
+++ b/README.md
@@ -492,10 +492,14 @@ python -m pip install -r requirements-dev.txt
 OUTPUT_LICENSE_JSON_PATH=licenses.json \
 bash build_util/create_venv_and_generate_licenses.bash
 
-# ビルド自体はLIBCORE_PATH及びLIBONNXRUNTIME_PATHの指定がなくても可能です
+# モックでビルドする場合
+pyinstaller --noconfirm run.spec
+
+# 製品版でビルドする場合
+CORE_MODEL_DIR_PATH="/path/to/core_model" \
 LIBCORE_PATH="/path/to/libcore" \
-    LIBONNXRUNTIME_PATH="/path/to/libonnxruntime" \
-    pyinstaller --noconfirm run.spec
+LIBONNXRUNTIME_PATH="/path/to/libonnxruntime" \
+pyinstaller --noconfirm run.spec
 ```
 
 ## 依存関係

--- a/run.spec
+++ b/run.spec
@@ -1,7 +1,8 @@
 # -*- mode: python ; coding: utf-8 -*-
 # このファイルはPyInstallerによって自動生成されたもので、それをカスタマイズして使用しています。
-from PyInstaller.utils.hooks import collect_data_files
 import os
+
+from PyInstaller.utils.hooks import collect_data_files
 
 datas = [
     ('engine_manifest_assets', 'engine_manifest_assets'),
@@ -12,9 +13,15 @@ datas = [
     ('presets.yaml', '.'),
     ('default_setting.yml', '.'),
     ('ui_template', 'ui_template'),
-    ('model', 'model'),
 ]
 datas += collect_data_files('pyopenjtalk')
+
+core_model_dir_path = os.environ.get('CORE_MODEL_DIR_PATH')
+if core_model_dir_path:
+    print('CORE_MODEL_DIR_PATH is found:', core_model_dir_path)
+    if not os.path.isdir(core_model_dir_path):
+        raise Exception("CORE_MODEL_DIR_PATH was found, but it is not directory!")
+    datas += [(core_model_dir_path, "model")]
 
 # コアとONNX Runtimeはバイナリであるが、`binaries`に加えると
 # 依存関係のパスがPyInstallerに書き換えらるので、`datas`に加える

--- a/run.spec
+++ b/run.spec
@@ -1,8 +1,7 @@
 # -*- mode: python ; coding: utf-8 -*-
 # このファイルはPyInstallerによって自動生成されたもので、それをカスタマイズして使用しています。
-import os
-
 from PyInstaller.utils.hooks import collect_data_files
+import os
 
 datas = [
     ('engine_manifest_assets', 'engine_manifest_assets'),


### PR DESCRIPTION
## 内容

ビルド時、modelディレクトリだけREADMEから案内が漏れていました。
空のmodelディレクトリを作るか、指定可能にしてオプショナルにするかの方法があるのですが、LIBCORE辺りと揃えて指定するようにしてみました。

## その他

ちゃんと動くかこちらでテストビルド中です。
https://github.com/Hiroshiba/voicevox_engine/actions/runs/5870952817
