### PR TITLE
バイナリビルドCI: VVPPを圧縮しながら分割してCIストレージ容量を節約する

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -594,7 +594,7 @@ jobs:
           (cd "${{ matrix.target }}" && 7z -r -v1900M a "../compressed.zip")
 
           # Rename to artifact.001.vvppp, artifact.002.vvppp, ...
-          for FILE in $(ls "compressed.zip.*"); do
+          for FILE in $(ls "compressed.zip."*); do
             NUMBER=${FILE##*.} # 001
             mv "${FILE}" "${{ steps.vars.outputs.package_name }}.${NUMBER}.vvppp"
           done

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -589,9 +589,15 @@ jobs:
       # VVPP archives
       - name: Create VVPP archives
         run: |
-          # Compress to artifact.001.vvppp,artifact.002.vvppp, ...
-          (cd "${{ matrix.target }}" && 7z -r a "../compressed.zip")
-          $split -b 1900M --numeric-suffixes=1 -a 3 --additional-suffix .vvppp ./compressed.zip ./${{ steps.vars.outputs.package_name }}.
+          # Compress to compressed.zip.001, compressed.zip.002, ...
+          # NOTE: 1000th archive will be "compressed.zip.1000" after "compressed.zip.999". This is unconsidered as an extreme case.
+          (cd "${{ matrix.target }}" && 7z -r -v1900M a "../compressed.zip")
+
+          # Rename to artifact.001.vvppp, artifact.002.vvppp
+          for FILE in $(ls "compressed.zip.*"); do
+            NUMBER=${FILE##*.} # 001
+            mv "${FILE}" "${{ steps.vars.outputs.package_name }}.${NUMBER}.vvppp"
+          done
 
           # Rename to artifact.vvpp if there are only artifact.001.vvppp
           if [ "$(ls ${{ steps.vars.outputs.package_name }}.*.vvppp | wc -l)" == 1 ]; then

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -593,7 +593,7 @@ jobs:
           # NOTE: 1000th archive will be "compressed.zip.1000" after "compressed.zip.999". This is unconsidered as an extreme case.
           (cd "${{ matrix.target }}" && 7z -r -v1900M a "../compressed.zip")
 
-          # Rename to artifact.001.vvppp, artifact.002.vvppp
+          # Rename to artifact.001.vvppp, artifact.002.vvppp, ...
           for FILE in $(ls "compressed.zip.*"); do
             NUMBER=${FILE##*.} # 001
             mv "${FILE}" "${{ steps.vars.outputs.package_name }}.${NUMBER}.vvppp"


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->

- #734

の対策です。

リリースCI（バイナリビルドCI）において、VVPP作成時、7z版と同様に、7zコマンドのボリューム機能を使って、zipファイルとして圧縮しながら、同時に分割するように変更します。ボリューム機能で作成される分割ファイルは、`split`コマンドと同じく、`cat`コマンドなどでバイナリを結合すれば展開できます。

以前の実装では、バイナリビルド成果物を完全にzipファイルとして書き出してから、splitコマンドで分割していました。

このPRによって、CI実行環境のストレージを占有するビルド成果物のファイルは、「アーカイブ化前のディレクトリ・分割前のzip・分割後のvvpp/vvppp」の3つから、「アーカイブ化前のディレクトリ・分割後のvvpp/vvppp」の2つに減ります。

- 動作テスト用リリース: https://github.com/aoirint/voicevox_engine/releases/tag/0.15.0-aoirint.25
    - https://github.com/aoirint/voicevox_engine/actions/runs/6405247850

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

- ref #734 
- ref #696

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
