### PR TITLE
run.py: `__main__`実装を`main`関数スコープに移動させる

### DIFF
--- a/run.py
+++ b/run.py
@@ -1170,7 +1170,7 @@ def generate_app(
     return app
 
 
-if __name__ == "__main__":
+def main() -> None:
     multiprocessing.freeze_support()
 
     output_log_utf8 = os.getenv("VV_OUTPUT_LOG_UTF8", default="")
@@ -1354,3 +1354,7 @@ if __name__ == "__main__":
         host=args.host,
         port=args.port,
     )
+
+
+if __name__ == "__main__":
+    main()

--- a/run.py
+++ b/run.py
@@ -117,6 +117,7 @@ def generate_app(
     latest_core_version: str,
     setting_loader: SettingLoader,
     preset_manager: PresetManager,
+    cancellable_engine: CancellableEngine | None = None,
     root_dir: Optional[Path] = None,
     cors_policy_mode: CorsPolicyMode = CorsPolicyMode.localapps,
     allow_origin: Optional[List[str]] = None,
@@ -429,7 +430,7 @@ def generate_app(
         request: Request,
         core_version: Optional[str] = None,
     ):
-        if not args.enable_cancellable_synthesis:
+        if cancellable_engine is None:
             raise HTTPException(
                 status_code=404,
                 detail="実験的機能はデフォルトで無効になっています。使用するには引数を指定してください。",
@@ -1301,8 +1302,9 @@ def main() -> None:
     assert len(synthesis_engines) != 0, "音声合成エンジンがありません。"
     latest_core_version = get_latest_core_version(versions=synthesis_engines.keys())
 
-    cancellable_engine = None
-    if args.enable_cancellable_synthesis:
+    enable_cancellable_synthesis: bool = args.enable_cancellable_synthesis
+    cancellable_engine: CancellableEngine | None = None
+    if enable_cancellable_synthesis:
         cancellable_engine = CancellableEngine(args)
 
     root_dir: Path | None = args.voicevox_dir
@@ -1347,6 +1349,7 @@ def main() -> None:
             latest_core_version,
             setting_loader,
             preset_manager=preset_manager,
+            cancellable_engine=cancellable_engine,
             root_dir=root_dir,
             cors_policy_mode=cors_policy_mode,
             allow_origin=allow_origin,

--- a/run.py
+++ b/run.py
@@ -201,7 +201,7 @@ def generate_app(
 
     # @app.on_event("startup")
     # async def start_catch_disconnection():
-    #     if args.enable_cancellable_synthesis:
+    #     if cancellable_engine is not None:
     #         loop = asyncio.get_event_loop()
     #         _ = loop.create_task(cancellable_engine.catch_disconnection())
 

--- a/run.py
+++ b/run.py
@@ -1183,8 +1183,6 @@ def main() -> None:
             file=sys.stderr,
         )
 
-    default_cors_policy_mode = CorsPolicyMode.localapps
-
     parser = argparse.ArgumentParser(description="VOICEVOX のエンジンです。")
     parser.add_argument(
         "--host", type=str, default="127.0.0.1", help="接続を受け付けるホストアドレスです。"


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->

- #752 

の実装です。

`run.py`の`if __name__ == "__main__":`以下の実装を、新しく追加した`main`関数に移動させます。

`generate_app`関数内でグローバルスコープ変数（`run.py`のファイルスコープ変数）を参照することを防ぎ、`run.py`以外のテストなどから`generate_app`が呼び出された際の不具合を防ぎます。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

- close #752

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他

### `default_cors_policy_mode`変数の削除について

もともと未使用変数だったため削除しました。引数`--cors_policy_mode`が指定されなかった場合、リポジトリの`default_setting.yml`に記述された`localapps`が使用されます。

### `generate_app`関数内の`enable_cancellable_synthesis`判定について

`generate_app`関数に`enable_cancellable_synthesis: bool`引数を追加する代わりに、`cancellable_engine: CancellableEngine | None`引数を追加して、`is not None`で判定するようにしました。



Cancellable Engineを有効化するコマンド例（Windows）

```shell
poetry run python run.py --voicevox_dir "$HOME/AppData/Local/Programs/VOICEVOX" --enable_cancellable_synthesis --init_processes 2
```
