### PR TITLE
CancellableEngineが必要な引数だけを受け取るようにする

### DIFF
--- a/run.py
+++ b/run.py
@@ -1308,9 +1308,8 @@ if __name__ == "__main__":
     latest_core_version = get_latest_core_version(versions=synthesis_engines.keys())
 
     cancellable_engine = None
+    init_processes: int = args.init_processes
     if args.enable_cancellable_synthesis:
-        init_processes: int = args.init_processes
-
         cancellable_engine = CancellableEngine(
             init_processes=init_processes,
             use_gpu=use_gpu,

--- a/run.py
+++ b/run.py
@@ -1320,7 +1320,7 @@ if __name__ == "__main__":
             enable_mock=enable_mock,
         )
 
-    root_dir: Path | None = args.voicevox_dir
+    root_dir = voicevox_dir
     if root_dir is None:
         root_dir = engine_root()
 

--- a/run.py
+++ b/run.py
@@ -1286,6 +1286,7 @@ def main() -> None:
     if args.output_log_utf8:
         set_output_log_utf8()
 
+    # Synthesis Engine
     use_gpu: bool = args.use_gpu
     voicevox_dir: Path | None = args.voicevox_dir
     voicelib_dirs: list[Path] | None = args.voicelib_dir

--- a/run.py
+++ b/run.py
@@ -1306,6 +1306,7 @@ def main() -> None:
     assert len(synthesis_engines) != 0, "音声合成エンジンがありません。"
     latest_core_version = get_latest_core_version(versions=synthesis_engines.keys())
 
+    # Cancellable Engine
     enable_cancellable_synthesis: bool = args.enable_cancellable_synthesis
     init_processes: int = args.init_processes
 

--- a/run.py
+++ b/run.py
@@ -1323,7 +1323,7 @@ def main() -> None:
             enable_mock=enable_mock,
         )
 
-    root_dir: Path | None = None
+    root_dir: Path
     if voicevox_dir is not None:
         root_dir = voicevox_dir
     else:

--- a/run.py
+++ b/run.py
@@ -1320,8 +1320,10 @@ if __name__ == "__main__":
             enable_mock=enable_mock,
         )
 
-    root_dir = voicevox_dir
-    if root_dir is None:
+    root_dir: Path | None = None
+    if voicevox_dir is not None:
+        root_dir = voicevox_dir
+    else:
         root_dir = engine_root()
 
     setting_loader = SettingLoader(args.setting_file)

--- a/run.py
+++ b/run.py
@@ -1323,10 +1323,8 @@ def main() -> None:
             enable_mock=enable_mock,
         )
 
-    root_dir: Path
-    if voicevox_dir is not None:
-        root_dir = voicevox_dir
-    else:
+    root_dir: Path | None = voicevox_dir
+    if root_dir is None:
         root_dir = engine_root()
 
     setting_loader = SettingLoader(args.setting_file)

--- a/run.py
+++ b/run.py
@@ -1287,23 +1287,39 @@ if __name__ == "__main__":
     if args.output_log_utf8:
         set_output_log_utf8()
 
-    cpu_num_threads: Optional[int] = args.cpu_num_threads
+    use_gpu: bool = args.use_gpu
+    voicevox_dir: Path | None = args.voicevox_dir
+    voicelib_dirs: list[Path] | None = args.voicelib_dir
+    runtime_dirs: list[Path] | None = args.runtime_dir
+    enable_mock: bool = args.enable_mock
+    cpu_num_threads: int | None = args.cpu_num_threads
+    load_all_models: bool = args.load_all_models
 
     synthesis_engines = make_synthesis_engines(
-        use_gpu=args.use_gpu,
-        voicelib_dirs=args.voicelib_dir,
-        voicevox_dir=args.voicevox_dir,
-        runtime_dirs=args.runtime_dir,
+        use_gpu=use_gpu,
+        voicelib_dirs=voicelib_dirs,
+        voicevox_dir=voicevox_dir,
+        runtime_dirs=runtime_dirs,
         cpu_num_threads=cpu_num_threads,
-        enable_mock=args.enable_mock,
-        load_all_models=args.load_all_models,
+        enable_mock=enable_mock,
+        load_all_models=load_all_models,
     )
     assert len(synthesis_engines) != 0, "音声合成エンジンがありません。"
     latest_core_version = get_latest_core_version(versions=synthesis_engines.keys())
 
     cancellable_engine = None
     if args.enable_cancellable_synthesis:
-        cancellable_engine = CancellableEngine(args)
+        init_processes: int = args.init_processes
+
+        cancellable_engine = CancellableEngine(
+            init_processes=init_processes,
+            use_gpu=use_gpu,
+            voicelib_dirs=voicelib_dirs,
+            voicevox_dir=voicevox_dir,
+            runtime_dirs=runtime_dirs,
+            cpu_num_threads=cpu_num_threads,
+            enable_mock=enable_mock,
+        )
 
     root_dir: Path | None = args.voicevox_dir
     if root_dir is None:

--- a/voicevox_engine/cancellable_engine.py
+++ b/voicevox_engine/cancellable_engine.py
@@ -1,6 +1,8 @@
 import asyncio
 import queue
 from multiprocessing import Pipe, Process
+
+# NOTE: OS間でのConnectionとPipeConnectionの型ヒント共通化のため、非publicな型を参照している
 from multiprocessing.connection import _ConnectionBase as ConnectionBase
 from pathlib import Path
 from tempfile import NamedTemporaryFile

--- a/voicevox_engine/cancellable_engine.py
+++ b/voicevox_engine/cancellable_engine.py
@@ -4,7 +4,6 @@ from multiprocessing import Pipe, Process
 from multiprocessing.connection import Connection
 from pathlib import Path
 from tempfile import NamedTemporaryFile
-from typing import Optional
 
 import soundfile
 
@@ -104,7 +103,7 @@ class CancellableEngine:
         self,
         req: Request,
         proc: Process,
-        sub_proc_con: Optional[Connection],
+        sub_proc_con: Connection | None,
     ) -> None:
         """
         接続が切断された時の処理を行う関数
@@ -142,7 +141,7 @@ class CancellableEngine:
         query: AudioQuery,
         speaker_id: int,
         request: Request,
-        core_version: Optional[str],
+        core_version: str | None,
     ) -> str:
         """
         音声合成を行う関数

--- a/voicevox_engine/cancellable_engine.py
+++ b/voicevox_engine/cancellable_engine.py
@@ -212,8 +212,20 @@ def start_synthesis_subprocess(
 
     Parameters
     ----------
-    args: argparse.Namespace
-        起動時に作られたものをそのまま渡す
+    use_gpu: bool
+        音声ライブラリに GPU を使わせるか否か
+    voicelib_dirs: List[Path], optional
+        音声ライブラリ自体があるディレクトリのリスト
+    voicevox_dir: Path, optional
+        コンパイル済みのvoicevox、またはvoicevox_engineがあるディレクトリ
+    runtime_dirs: List[Path], optional
+        コアで使用するライブラリのあるディレクトリのリスト
+        None のとき、voicevox_dir、カレントディレクトリになる
+    cpu_num_threads: int, optional
+        音声ライブラリが、推論に用いるCPUスレッド数を設定する
+        Noneのとき、ライブラリ側の挙動により論理コア数の半分か、物理コア数が指定される
+    enable_mock: bool, optional
+        コア読み込みに失敗したとき、代わりにmockを使用するかどうか
     sub_proc_con: Connection
         メインプロセスと通信するためのPipe
     """

--- a/voicevox_engine/cancellable_engine.py
+++ b/voicevox_engine/cancellable_engine.py
@@ -1,7 +1,7 @@
 import asyncio
 import queue
 from multiprocessing import Pipe, Process
-from multiprocessing.connection import _ConnectionBase
+from multiprocessing.connection import _ConnectionBase as ConnectionBase
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 
@@ -27,7 +27,7 @@ class CancellableEngine:
         Requestは接続の監視に使用され、Processは通信切断時のプロセスキルに使用される
         クライアントから接続があるとListにTupleが追加される
         接続が切断、もしくは音声合成が終了すると削除される
-    procs_and_cons: queue.Queue[tuple[Process, _ConnectionBase]]
+    procs_and_cons: queue.Queue[tuple[Process, ConnectionBase]]
         音声合成の準備が終わっているプロセスのList
         （音声合成中のプロセスは入っていない）
     """
@@ -40,7 +40,7 @@ class CancellableEngine:
     enable_mock: bool
 
     watch_con_list: list[tuple[Request, Process]]
-    procs_and_cons: queue.Queue[tuple[Process, _ConnectionBase]]
+    procs_and_cons: queue.Queue[tuple[Process, ConnectionBase]]
 
     def __init__(
         self,
@@ -71,7 +71,7 @@ class CancellableEngine:
 
     def start_new_proc(
         self,
-    ) -> tuple[Process, _ConnectionBase]:
+    ) -> tuple[Process, ConnectionBase]:
         """
         新しく開始したプロセスを返す関数
 
@@ -79,7 +79,7 @@ class CancellableEngine:
         -------
         ret_proc: Process
             新規のプロセス
-        sub_proc_con1: _ConnectionBase
+        sub_proc_con1: ConnectionBase
             ret_procのプロセスと通信するためのPipe
         """
         sub_proc_con1, sub_proc_con2 = Pipe(True)
@@ -103,7 +103,7 @@ class CancellableEngine:
         self,
         req: Request,
         proc: Process,
-        sub_proc_con: _ConnectionBase | None,
+        sub_proc_con: ConnectionBase | None,
     ) -> None:
         """
         接続が切断された時の処理を行う関数
@@ -118,7 +118,7 @@ class CancellableEngine:
             https://fastapi.tiangolo.com/advanced/using-request-directly/
         proc: Process
             音声合成を行っていたプロセス
-        sub_proc_con: _ConnectionBase, optional
+        sub_proc_con: ConnectionBase, optional
             音声合成を行っていたプロセスとのPipe
             指定されていない場合、プロセスは再利用されず終了される
         """
@@ -203,7 +203,7 @@ def start_synthesis_subprocess(
     runtime_dirs: list[Path] | None,
     cpu_num_threads: int | None,
     enable_mock: bool,
-    sub_proc_con: _ConnectionBase,
+    sub_proc_con: ConnectionBase,
 ):
     """
     音声合成を行うサブプロセスで行うための関数
@@ -225,7 +225,7 @@ def start_synthesis_subprocess(
         Noneのとき、ライブラリ側の挙動により論理コア数の半分か、物理コア数が指定される
     enable_mock: bool, optional
         コア読み込みに失敗したとき、代わりにmockを使用するかどうか
-    sub_proc_con: _ConnectionBase
+    sub_proc_con: ConnectionBase
         メインプロセスと通信するためのPipe
     """
 

--- a/voicevox_engine/cancellable_engine.py
+++ b/voicevox_engine/cancellable_engine.py
@@ -204,7 +204,7 @@ def start_synthesis_subprocess(
     cpu_num_threads: int | None,
     enable_mock: bool,
     sub_proc_con: ConnectionBase,
-):
+) -> None:
     """
     音声合成を行うサブプロセスで行うための関数
     pickle化の関係でグローバルに書いている

--- a/voicevox_engine/cancellable_engine.py
+++ b/voicevox_engine/cancellable_engine.py
@@ -4,7 +4,7 @@ from multiprocessing import Pipe, Process
 from multiprocessing.connection import Connection
 from pathlib import Path
 from tempfile import NamedTemporaryFile
-from typing import List, Optional, Tuple
+from typing import Optional
 
 import soundfile
 
@@ -24,32 +24,32 @@ class CancellableEngine:
 
     Attributes
     ----------
-    watch_con_list: List[Tuple[Request, Process]]
+    watch_con_list: list[tuple[Request, Process]]
         Requestは接続の監視に使用され、Processは通信切断時のプロセスキルに使用される
         クライアントから接続があるとListにTupleが追加される
         接続が切断、もしくは音声合成が終了すると削除される
-    procs_and_cons: queue.Queue[Tuple[Process, Connection]]
+    procs_and_cons: queue.Queue[tuple[Process, Connection]]
         音声合成の準備が終わっているプロセスのList
         （音声合成中のプロセスは入っていない）
     """
 
     use_gpu: bool
-    voicelib_dirs: List[Path] | None
+    voicelib_dirs: list[Path] | None
     voicevox_dir: Path | None
-    runtime_dirs: List[Path] | None
+    runtime_dirs: list[Path] | None
     cpu_num_threads: int | None
     enable_mock: bool
 
-    watch_con_list: List[Tuple[Request, Process]]
-    procs_and_cons: queue.Queue[Tuple[Process, Connection]]
+    watch_con_list: list[tuple[Request, Process]]
+    procs_and_cons: queue.Queue[tuple[Process, Connection]]
 
     def __init__(
         self,
         init_processes: int,
         use_gpu: bool,
-        voicelib_dirs: List[Path] | None,
+        voicelib_dirs: list[Path] | None,
         voicevox_dir: Path | None,
-        runtime_dirs: List[Path] | None,
+        runtime_dirs: list[Path] | None,
         cpu_num_threads: int | None,
         enable_mock: bool,
     ) -> None:
@@ -72,7 +72,7 @@ class CancellableEngine:
 
     def start_new_proc(
         self,
-    ) -> Tuple[Process, Connection]:
+    ) -> tuple[Process, Connection]:
         """
         新しく開始したプロセスを返す関数
 
@@ -199,9 +199,9 @@ class CancellableEngine:
 
 def start_synthesis_subprocess(
     use_gpu: bool,
-    voicelib_dirs: List[Path] | None,
+    voicelib_dirs: list[Path] | None,
     voicevox_dir: Path | None,
-    runtime_dirs: List[Path] | None,
+    runtime_dirs: list[Path] | None,
     cpu_num_threads: int | None,
     enable_mock: bool,
     sub_proc_con: Connection,
@@ -214,11 +214,11 @@ def start_synthesis_subprocess(
     ----------
     use_gpu: bool
         音声ライブラリに GPU を使わせるか否か
-    voicelib_dirs: List[Path], optional
+    voicelib_dirs: list[Path], optional
         音声ライブラリ自体があるディレクトリのリスト
     voicevox_dir: Path, optional
         コンパイル済みのvoicevox、またはvoicevox_engineがあるディレクトリ
-    runtime_dirs: List[Path], optional
+    runtime_dirs: list[Path], optional
         コアで使用するライブラリのあるディレクトリのリスト
         None のとき、voicevox_dir、カレントディレクトリになる
     cpu_num_threads: int, optional


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->

CancellableEngineは、`run.py`で定義された`argparse.ArgumentParser`で`parse_args()`した`argparse.Namespace`を初期化時に受け取っていました。

`argparse.Namespace`にはメンバ情報・型情報がなく、起動引数（`args`）が変更されてもCancellableEngine側では気づけない状態だったため、CancellableEngineが必要な引数だけを受け取るようにしました。

Cancellable Engineを有効化するコマンド例（Windows）

```shell
poetry run python run.py --voicevox_dir "$HOME/AppData/Local/Programs/VOICEVOX" --enable_cancellable_synthesis --init_processes 2
```

Cancellable Synthesisを実行するコマンド例

```shell
echo -n "こんにちは、音声合成の世界へようこそ" >text.txt

curl -s \
    -X POST \
    "127.0.0.1:50021/audio_query?speaker=1"\
    --get --data-urlencode text@text.txt \
    > query.json

curl -s \
    -H "Content-Type: application/json" \
    -X POST \
    -d @query.json \
    -o audio.wav \
    "127.0.0.1:50021/cancellable_synthesis?speaker=1"
```

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

- #166
- #263 

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他

### CancellableEngine内での`enable_cancellable_synthesis`のチェックを削除

テストを作りにくくなるため削除しました。

### リファクタリング: `run.py`: `root_dir`の定義コード変更

`main`関数における`root_dir`変数は、`args.voicevox_dir`をもとに定義されます。
`make_synthesis_engines()`、`CancellableEngine()`に`args.voicevox_dir`を渡すため、`main`関数に`args.voicevox_dir`に型ヒントをつけた`voicevox_dir`変数を追加しました。

`root_dir`変数の定義でこれに対応するコードはいくつか考えられますが、`voicevox_dir`変数を参照しつつ型を読み取りやすくなるように変更しました。

#### 現状維持

`args.voicevox_dir`から2回別々に読み取るコードになり、起動引数の変更に対応しにくい。

```python
root_dir: Path | None = args.voicevox_dir
if root_dir is None:
    root_dir = engine_root()
```

#### `voicevox_dir`変数を参照 + 三項演算子

直前に https://github.com/VOICEVOX/voicevox_engine/pull/711/files#r1349680805 でリファクタリングとしてifブロックに統一しており、手戻りになる。
`voicevox_dir`変数を参照すれば`Any`型が関与しないため、三項演算子でもいいかなとは思います。

```python
root_dir = voicevox_dir if voicevox_dir is not None engine_root()
# または
root_dir: Path = voicevox_dir if voicevox_dir is not None engine_root()
```

#### （PR作成時点で採用）`voicevox_dir`変数を参照 + ifブロック

変更量が少なく済む。

```python
root_dir = voicevox_dir
if root_dir is None:
    root_dir = engine_root()

# または

root_dir: Path | None = voicevox_dir
if root_dir is None:
    root_dir = engine_root()
```

#### `voicevox_dir`変数を参照 + ifブロック + `root_dir`を初期化せずに型ヒントだけ付ける

`root_dir`が`not None`なことはこちらの方が伝わりやすそうですが長くなるので、第2候補くらいで悩む。

```python
root_dir: Path
if voicevox_dir is not None:
    root_dir = voicevox_dir
else:
    root_dir = engine_root()
```

### リファクタリング: 型ヒントの更新

変更した部分の周りの型ヒントを新しい記法に移行しました。

- Python 3.9で導入された記法: `List[Type] -> list[Type]`、`Tuple[Type] -> tuple[Type]`
    - 小文字の記法が導入されたことで`typing.List`や`typing.Tuple`は非推奨になったため、移行しました
    - https://docs.python.org/ja/3.11/library/typing.html#deprecated-typing-aliases
- Python 3.10で導入された記法: `Optional[Type] -> Type | None`
    - `typing.Optional`は非推奨化されていなさそうですが、省略記法が導入され`import typing`が消せるため変更しました
    - https://docs.python.org/ja/3.11/library/typing.html#typing.Optional

### 型ヒント`multiprocessing.connection.Connection`を`_ConnectionBase`に変更

multiprocessing.Pipeの返すtupleの中身の型（`tuple[T, T]`の`T`）に対する型ヒントを変更しました。

tupleの中身の型は、Linux/macOSでは`multiprocessing.connection.Connection`ですが、Windowsでは`multiprocessing.connection.PipeConnection`になっています（[Python 3.11の該当ソースコード@2bad6e7](https://github.com/python/cpython/blob/2bad6e715ad74da296c8081bd334ee20a68b77ae/Lib/multiprocessing/connection.py#L530-L589)）。

ConnectionとPipeConnectionはいずれも互いを継承しておらず、Windowsでは型が不一致（mypyの型エラー）になります。
また、Linux/macOSではPipeConnection型が定義されない（[Python 3.11の該当ソースコード@2bad6e7](https://github.com/python/cpython/blob/2bad6e715ad74da296c8081bd334ee20a68b77ae/Lib/multiprocessing/connection.py#L266-L361)）ため、ユニオン型（`Connection | PipeConnection`）にすることもできません（自前でうまく分岐を書けばできるかもですが）。

これらの型は共通の基底クラス`_ConnectionBase`を持つため、頭にアンダースコアがついてはいますが、型エラーを回避するため、型ヒントを`multiprocessing.connection._ConnectionBase`に変更しました。

頭にアンダースコア1つがついた名前は、Pythonの仕様としてアクセス禁止が定義されてはいなさそうですが、慣習として非publicなものとされていて、今後Pythonのマイナーバージョンアップで実装が変わる可能性がある点に注意が必要です。
アンダースコアが付いていない型が今後追加されることを期待して、`import as`で名前を変えています。

https://docs.python.org/ja/3/tutorial/classes.html#private-variables

> アンダースコアで始まる名前 (例えば _spam) は、 (関数であれメソッドであれデータメンバであれ) 非 public なAPIとして扱います。これらは、予告なく変更されるかもしれない実装の詳細として扱われるべきです。

https://peps.python.org/pep-0008/#descriptive-naming-styles

> `_single_leading_underscore`: weak “internal use” indicator. E.g. `from M import *` does not import objects whose names start with an underscore.

### `args.init_processes`の取り出し

`if enable_cancellable_synthesis:`の中で`args`から取り出してもいいかもですが、`enable_cancellable_synthesis`の値に関わらず`not None`なことが伝わるので、`if`ブロックの外で取り出しています。

（`args`に型付けする部分は`parse_args()`のすぐ下に全部移動させて、`make_synthesis_engines()`や`SettingLoader()`のようなクラスの初期化はその下か別の関数に移動させるリファクタリングを別PRでしてもいいかなとちょっと思いました）
