### PR TITLE
/connect_waves: HTTPExceptionをreturnではなくraiseするように修正

### DIFF
--- a/run.py
+++ b/run.py
@@ -626,7 +626,7 @@ def generate_app(
         try:
             waves_nparray, sampling_rate = connect_base64_waves(waves)
         except ConnectBase64WavesException as err:
-            return HTTPException(status_code=422, detail=str(err))
+            raise HTTPException(status_code=422, detail=str(err))
 
         with NamedTemporaryFile(delete=False) as f:
             soundfile.write(


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->

`ConnectBase64WavesException`が発生した場合に`HTTPException`が`return`されてしまっていたので、`raise`するように修正します。

`HTTPException`が`return`された場合、例外オブジェクトを`FileResponse`として返そうとしてHTTP 500になります（末尾参照）。

- FastAPIのドキュメント: https://fastapi.tiangolo.com/tutorial/handling-errors/#raise-an-httpexception-in-your-code

> Because it's a Python exception, you don't return it, you raise it.

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

- #109 
- #266

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他

### `/connect_waves`で`ConnectBase64WavesException`がキャッチされた場合のレスポンス

関数の先頭で疑似的にHTTPExceptionを`return`したときのエラー出力

<details>

```
INFO:     ***:*** - "POST /connect_waves HTTP/1.1" 500 Internal Server Error
ERROR:    Exception in ASGI application
Traceback (most recent call last):
  File "***\Lib\site-packages\uvicorn\protocols\http\h11_impl.py", line 373, in run_asgi
    result = await app(self.scope, self.receive, self.send)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "***\Lib\site-packages\uvicorn\middleware\proxy_headers.py", line 75, in __call__
    return await self.app(scope, receive, send)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "***\Lib\site-packages\fastapi\applications.py", line 208, in __call__
    await super().__call__(scope, receive, send)
  File "***\Lib\site-packages\starlette\applications.py", line 112, in __call__
    await self.middleware_stack(scope, receive, send)
  File "***\Lib\site-packages\starlette\middleware\errors.py", line 181, in __call__
    raise exc
  File "***\Lib\site-packages\starlette\middleware\errors.py", line 159, in __call__
    await self.app(scope, receive, _send)
  File "***\Lib\site-packages\starlette\middleware\base.py", line 53, in __call__
    async with anyio.create_task_group() as task_group:
  File "***\Lib\site-packages\anyio\_backends\_asyncio.py", line 597, in __aexit__
    raise exceptions[0]
  File "***\Lib\site-packages\starlette\middleware\base.py", line 30, in coro
    await self.app(scope, request.receive, send_stream.send)
  File "***\Lib\site-packages\starlette\middleware\cors.py", line 92, in __call__
    await self.simple_response(scope, receive, send, request_headers=headers)
  File "***\Lib\site-packages\starlette\middleware\cors.py", line 147, in simple_response
    await self.app(scope, receive, send)
  File "***\Lib\site-packages\starlette\exceptions.py", line 82, in __call__
    raise exc
  File "***\Lib\site-packages\starlette\exceptions.py", line 71, in __call__
    await self.app(scope, receive, sender)
  File "***\Lib\site-packages\starlette\routing.py", line 656, in __call__
    await route.handle(scope, receive, send)
  File "***\Lib\site-packages\starlette\routing.py", line 259, in handle
    await self.app(scope, receive, send)
  File "***\Lib\site-packages\starlette\routing.py", line 61, in app
    response = await func(request)
               ^^^^^^^^^^^^^^^^^^^
  File "***\Lib\site-packages\fastapi\routing.py", line 250, in app
    response = actual_response_class(response_data, **response_args)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "***\Lib\site-packages\starlette\responses.py", line 252, in __init__
    media_type = guess_type(filename or path)[0] or "text/plain"
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "***\Lib\site-packages\starlette\responses.py", line 30, in guess_type
    return mimetypes_guess_type(url, strict)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "***\Lib\mimetypes.py", line 307, in guess_type
    return _db.guess_type(url, strict)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "***\Lib\mimetypes.py", line 122, in guess_type
    url = os.fspath(url)
          ^^^^^^^^^^^^^^
TypeError: expected str, bytes or os.PathLike object, not dict
```

</details>
