### PR TITLE
run.py: ルーティング関数の戻り値に型ヒントを追加

### DIFF
--- a/run.py
+++ b/run.py
@@ -1115,7 +1115,7 @@ def generate_app(
                 detail=ParseKanaBadRequest(err).dict(),
             )
 
-    @app.get("/setting", response_class=HTMLResponse, tags=["設定"])
+    @app.get("/setting", response_class=Response, tags=["設定"])
     def setting_get(
         request: Request,
     ) -> Response:

--- a/run.py
+++ b/run.py
@@ -1068,8 +1068,8 @@ def generate_app(
 
     @app.get("/supported_devices", response_model=SupportedDevicesInfo, tags=["その他"])
     def supported_devices(
-        core_version: Optional[str] = None,
-    ):
+        core_version: str | None = None,
+    ) -> Response:
         supported_devices = get_engine(core_version).supported_devices
         if supported_devices is None:
             raise HTTPException(status_code=422, detail="非対応の機能です。")

--- a/run.py
+++ b/run.py
@@ -1094,7 +1094,9 @@ def generate_app(
             }
         },
     )
-    def validate_kana(text: str):
+    def validate_kana(
+        text: str,
+    ) -> bool:
         """
         テキストがAquesTalkライクな記法に従っているかどうかを判定します。
         従っていない場合はエラーが返ります。

--- a/run.py
+++ b/run.py
@@ -510,14 +510,14 @@ def generate_app(
 
     @app.post(
         "/morphable_targets",
-        response_model=List[Dict[str, MorphableTargetInfo]],
+        response_model=list[dict[str, MorphableTargetInfo]],
         tags=["音声合成"],
         summary="指定した話者に対してエンジン内の話者がモーフィングが可能か判定する",
     )
     def morphable_targets(
-        base_speakers: List[int],
-        core_version: Optional[str] = None,
-    ):
+        base_speakers: list[int],
+        core_version: str | None = None,
+    ) -> list[dict[str, MorphableTargetInfo]]:
         """
         指定されたベース話者に対してエンジン内の各話者がモーフィング機能を利用可能か返します。
         モーフィングの許可/禁止は`/speakers`の`speaker.supported_features.synthesis_morphing`に記載されています。

--- a/run.py
+++ b/run.py
@@ -816,16 +816,16 @@ def generate_app(
 
     @app.get(
         "/downloadable_libraries",
-        response_model=List[DownloadableLibrary],
+        response_model=list[DownloadableLibrary],
         tags=["音声ライブラリ管理"],
     )
-    def downloadable_libraries():
+    def downloadable_libraries() -> list[DownloadableLibrary]:
         """
         ダウンロード可能な音声ライブラリの情報を返します。
 
         Returns
         -------
-        ret_data: List[DownloadableLibrary]
+        ret_data: list[DownloadableLibrary]
         """
         if not engine_manifest_data.supported_features.manage_library:
             raise HTTPException(status_code=404, detail="この機能は実装されていません")

--- a/run.py
+++ b/run.py
@@ -738,10 +738,10 @@ def generate_app(
             media_type="application/json",
         )
 
-    @app.get("/speakers", response_model=List[Speaker], tags=["その他"])
+    @app.get("/speakers", response_model=list[Speaker], tags=["その他"])
     def speakers(
-        core_version: Optional[str] = None,
-    ):
+        core_version: str | None = None,
+    ) -> list[Speaker]:
         engine = get_engine(core_version)
         return metas_store.load_combined_metas(engine=engine)
 

--- a/run.py
+++ b/run.py
@@ -689,7 +689,7 @@ def generate_app(
         return id
 
     @app.post("/update_preset", response_model=int, tags=["その他"])
-    def update_preset(preset: Preset):
+    def update_preset(preset: Preset) -> int:
         """
         既存のプリセットを更新します
 

--- a/run.py
+++ b/run.py
@@ -731,8 +731,8 @@ def generate_app(
     def version() -> str:
         return __version__
 
-    @app.get("/core_versions", response_model=List[str], tags=["その他"])
-    def core_versions() -> List[str]:
+    @app.get("/core_versions", response_model=list[str], tags=["その他"])
+    def core_versions() -> list[str]:
         return Response(
             content=json.dumps(list(synthesis_engines.keys())),
             media_type="application/json",

--- a/run.py
+++ b/run.py
@@ -333,29 +333,29 @@ def generate_app(
 
     @app.post(
         "/mora_data",
-        response_model=List[AccentPhrase],
+        response_model=list[AccentPhrase],
         tags=["クエリ編集"],
         summary="アクセント句から音高・音素長を得る",
     )
     def mora_data(
-        accent_phrases: List[AccentPhrase],
+        accent_phrases: list[AccentPhrase],
         speaker: int,
-        core_version: Optional[str] = None,
-    ):
+        core_version: str | None = None,
+    ) -> list[AccentPhrase]:
         engine = get_engine(core_version)
         return engine.replace_mora_data(accent_phrases, speaker_id=speaker)
 
     @app.post(
         "/mora_length",
-        response_model=List[AccentPhrase],
+        response_model=list[AccentPhrase],
         tags=["クエリ編集"],
         summary="アクセント句から音素長を得る",
     )
     def mora_length(
-        accent_phrases: List[AccentPhrase],
+        accent_phrases: list[AccentPhrase],
         speaker: int,
-        core_version: Optional[str] = None,
-    ):
+        core_version: str | None = None,
+    ) -> list[AccentPhrase]:
         engine = get_engine(core_version)
         return engine.replace_phoneme_length(
             accent_phrases=accent_phrases, speaker_id=speaker

--- a/run.py
+++ b/run.py
@@ -1079,7 +1079,7 @@ def generate_app(
         )
 
     @app.get("/engine_manifest", response_model=EngineManifest, tags=["その他"])
-    def engine_manifest():
+    def engine_manifest() -> EngineManifest:
         return engine_manifest_data
 
     @app.post(

--- a/run.py
+++ b/run.py
@@ -625,7 +625,9 @@ def generate_app(
         tags=["その他"],
         summary="base64エンコードされた複数のwavデータを一つに結合する",
     )
-    def connect_waves(waves: List[str]):
+    def connect_waves(
+        waves: list[str],
+    ) -> FileResponse:
         """
         base64エンコードされたwavデータを一纏めにし、wavファイルで返します。
         """

--- a/run.py
+++ b/run.py
@@ -560,7 +560,7 @@ def generate_app(
         target_speaker: int,
         morph_rate: float = Query(..., ge=0.0, le=1.0),  # noqa: B008
         core_version: Optional[str] = None,
-    ):
+    ) -> FileResponse:
         """
         指定された2人の話者で音声を合成、指定した割合でモーフィングした音声を得ます。
         モーフィングの割合は`morph_rate`で指定でき、0.0でベースの話者、1.0でターゲットの話者に近づきます。

--- a/run.py
+++ b/run.py
@@ -19,7 +19,7 @@ import uvicorn
 from fastapi import FastAPI, Form, HTTPException, Query, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.openapi.utils import get_openapi
-from fastapi.responses import HTMLResponse, JSONResponse
+from fastapi.responses import JSONResponse
 from fastapi.templating import Jinja2Templates
 from pydantic import ValidationError, conint
 from starlette.background import BackgroundTask

--- a/run.py
+++ b/run.py
@@ -1139,9 +1139,9 @@ def generate_app(
     @app.post("/setting", response_class=HTMLResponse, tags=["設定"])
     def setting_post(
         request: Request,
-        cors_policy_mode: Optional[str] = Form(None),  # noqa: B008
-        allow_origin: Optional[str] = Form(None),  # noqa: B008
-    ):
+        cors_policy_mode: str | None = Form(None),  # noqa: B008
+        allow_origin: str | None = Form(None),  # noqa: B008
+    ) -> Response:
         settings = Setting(
             cors_policy_mode=cors_policy_mode,
             allow_origin=allow_origin,

--- a/run.py
+++ b/run.py
@@ -711,7 +711,7 @@ def generate_app(
         return id
 
     @app.post("/delete_preset", status_code=204, tags=["その他"])
-    def delete_preset(id: int):
+    def delete_preset(id: int) -> Response:
         """
         既存のプリセットを削除します
 

--- a/run.py
+++ b/run.py
@@ -252,8 +252,10 @@ def generate_app(
         summary="音声合成用のクエリをプリセットを用いて作成する",
     )
     def audio_query_from_preset(
-        text: str, preset_id: int, core_version: Optional[str] = None
-    ):
+        text: str,
+        preset_id: int,
+        core_version: str | None = None,
+    ) -> AudioQuery:
         """
         クエリの初期値を得ます。ここで得られたクエリはそのまま音声合成に利用できます。各値の意味は`Schemas`を参照してください。
         """

--- a/run.py
+++ b/run.py
@@ -833,16 +833,16 @@ def generate_app(
 
     @app.get(
         "/installed_libraries",
-        response_model=Dict[str, InstalledLibrary],
+        response_model=dict[str, InstalledLibrary],
         tags=["音声ライブラリ管理"],
     )
-    def installed_libraries():
+    def installed_libraries() -> dict[str, InstalledLibrary]:
         """
         インストールした音声ライブラリの情報を返します。
 
         Returns
         -------
-        ret_data: List[DownloadableLibrary]
+        ret_data: dict[str, InstalledLibrary]
         """
         if not engine_manifest_data.supported_features.manage_library:
             raise HTTPException(status_code=404, detail="この機能は実装されていません")

--- a/run.py
+++ b/run.py
@@ -897,8 +897,8 @@ def generate_app(
         skip_reinit: bool = Query(  # noqa: B008
             False, description="既に初期化済みの話者の再初期化をスキップするかどうか"
         ),
-        core_version: Optional[str] = None,
-    ):
+        core_version: str | None = None,
+    ) -> Response:
         """
         指定されたspeaker_idの話者を初期化します。
         実行しなくても他のAPIは使用できますが、初回実行時に時間がかかることがあります。

--- a/run.py
+++ b/run.py
@@ -918,15 +918,15 @@ def generate_app(
         engine = get_engine(core_version)
         return engine.is_initialized_speaker_synthesis(speaker)
 
-    @app.get("/user_dict", response_model=Dict[str, UserDictWord], tags=["ユーザー辞書"])
-    def get_user_dict_words():
+    @app.get("/user_dict", response_model=dict[str, UserDictWord], tags=["ユーザー辞書"])
+    def get_user_dict_words() -> dict[str, UserDictWord]:
         """
         ユーザー辞書に登録されている単語の一覧を返します。
         単語の表層形(surface)は正規化済みの物を返します。
 
         Returns
         -------
-        Dict[str, UserDictWord]
+        dict[str, UserDictWord]
             単語のUUIDとその詳細
         """
         try:

--- a/run.py
+++ b/run.py
@@ -397,8 +397,8 @@ def generate_app(
             default=True,
             description="疑問系のテキストが与えられたら語尾を自動調整する",
         ),
-        core_version: Optional[str] = None,
-    ):
+        core_version: str | None = None,
+    ) -> FileResponse:
         engine = get_engine(core_version)
         wave = engine.synthesis(
             query=query,

--- a/run.py
+++ b/run.py
@@ -363,15 +363,15 @@ def generate_app(
 
     @app.post(
         "/mora_pitch",
-        response_model=List[AccentPhrase],
+        response_model=list[AccentPhrase],
         tags=["クエリ編集"],
         summary="アクセント句から音高を得る",
     )
     def mora_pitch(
-        accent_phrases: List[AccentPhrase],
+        accent_phrases: list[AccentPhrase],
         speaker: int,
-        core_version: Optional[str] = None,
-    ):
+        core_version: str | None = None,
+    ) -> list[AccentPhrase]:
         engine = get_engine(core_version)
         return engine.replace_mora_pitch(
             accent_phrases=accent_phrases, speaker_id=speaker

--- a/run.py
+++ b/run.py
@@ -1046,14 +1046,15 @@ def generate_app(
 
     @app.post("/import_user_dict", status_code=204, tags=["ユーザー辞書"])
     def import_user_dict_words(
-        import_dict_data: Dict[str, UserDictWord], override: bool
-    ):
+        import_dict_data: dict[str, UserDictWord],
+        override: bool,
+    ) -> Response:
         """
         他のユーザー辞書をインポートします。
 
         Parameters
         ----------
-        import_dict_data: Dict[str, UserDictWord]
+        import_dict_data: dict[str, UserDictWord]
             インポートするユーザー辞書のデータ
         override: bool
             重複したエントリがあった場合、上書きするかどうか

--- a/run.py
+++ b/run.py
@@ -559,7 +559,7 @@ def generate_app(
         base_speaker: int,
         target_speaker: int,
         morph_rate: float = Query(..., ge=0.0, le=1.0),  # noqa: B008
-        core_version: Optional[str] = None,
+        core_version: str | None = None,
     ) -> FileResponse:
         """
         指定された2人の話者で音声を合成、指定した割合でモーフィングした音声を得ます。

--- a/run.py
+++ b/run.py
@@ -1136,7 +1136,7 @@ def generate_app(
             },
         )
 
-    @app.post("/setting", response_class=HTMLResponse, tags=["設定"])
+    @app.post("/setting", response_class=Response, tags=["設定"])
     def setting_post(
         request: Request,
         cors_policy_mode: str | None = Form(None),  # noqa: B008

--- a/run.py
+++ b/run.py
@@ -877,7 +877,7 @@ def generate_app(
         status_code=204,
         tags=["音声ライブラリ管理"],
     )
-    def uninstall_library(library_uuid: str):
+    def uninstall_library(library_uuid: str) -> Response:
         """
         音声ライブラリをアンインストールします。
 

--- a/run.py
+++ b/run.py
@@ -732,7 +732,7 @@ def generate_app(
         return __version__
 
     @app.get("/core_versions", response_model=list[str], tags=["その他"])
-    def core_versions() -> list[str]:
+    def core_versions() -> Response:
         return Response(
             content=json.dumps(list(synthesis_engines.keys())),
             media_type="application/json",

--- a/run.py
+++ b/run.py
@@ -650,14 +650,14 @@ def generate_app(
             background=BackgroundTask(delete_file, f.name),
         )
 
-    @app.get("/presets", response_model=List[Preset], tags=["その他"])
-    def get_presets():
+    @app.get("/presets", response_model=list[Preset], tags=["その他"])
+    def get_presets() -> list[Preset]:
         """
         エンジンが保持しているプリセットの設定を返します
 
         Returns
         -------
-        presets: List[Preset]
+        presets: list[Preset]
             プリセットのリスト
         """
         try:

--- a/run.py
+++ b/run.py
@@ -1024,7 +1024,9 @@ def generate_app(
             raise HTTPException(status_code=422, detail="ユーザー辞書の更新に失敗しました。")
 
     @app.delete("/user_dict_word/{word_uuid}", status_code=204, tags=["ユーザー辞書"])
-    def delete_user_dict_word(word_uuid: str):
+    def delete_user_dict_word(
+        word_uuid: str,
+    ) -> Response:
         """
         ユーザー辞書に登録されている言葉を削除します。
 

--- a/run.py
+++ b/run.py
@@ -853,7 +853,7 @@ def generate_app(
         status_code=204,
         tags=["音声ライブラリ管理"],
     )
-    async def install_library(library_uuid: str, request: Request):
+    async def install_library(library_uuid: str, request: Request) -> Response:
         """
         音声ライブラリをインストールします。
         音声ライブラリのZIPファイルをリクエストボディとして送信してください。

--- a/run.py
+++ b/run.py
@@ -472,10 +472,10 @@ def generate_app(
         summary="複数まとめて音声合成する",
     )
     def multi_synthesis(
-        queries: List[AudioQuery],
+        queries: list[AudioQuery],
         speaker: int,
-        core_version: Optional[str] = None,
-    ):
+        core_version: str | None = None,
+    ) -> FileResponse:
         engine = get_engine(core_version)
         sampling_rate = queries[0].outputSamplingRate
 

--- a/run.py
+++ b/run.py
@@ -940,9 +940,9 @@ def generate_app(
         surface: str,
         pronunciation: str,
         accent_type: int,
-        word_type: Optional[WordTypes] = None,
-        priority: Optional[conint(ge=MIN_PRIORITY, le=MAX_PRIORITY)] = None,
-    ):
+        word_type: WordTypes | None = None,
+        priority: conint(ge=MIN_PRIORITY, le=MAX_PRIORITY) | None = None,
+    ) -> Response:
         """
         ユーザー辞書に言葉を追加します。
 

--- a/run.py
+++ b/run.py
@@ -625,9 +625,7 @@ def generate_app(
         tags=["その他"],
         summary="base64エンコードされた複数のwavデータを一つに結合する",
     )
-    def connect_waves(
-        waves: list[str],
-    ) -> FileResponse:
+    def connect_waves(waves: list[str]) -> FileResponse:
         """
         base64エンコードされたwavデータを一纏めにし、wavファイルで返します。
         """
@@ -1030,9 +1028,7 @@ def generate_app(
             raise HTTPException(status_code=422, detail="ユーザー辞書の更新に失敗しました。")
 
     @app.delete("/user_dict_word/{word_uuid}", status_code=204, tags=["ユーザー辞書"])
-    def delete_user_dict_word(
-        word_uuid: str,
-    ) -> Response:
+    def delete_user_dict_word(word_uuid: str) -> Response:
         """
         ユーザー辞書に登録されている言葉を削除します。
 
@@ -1100,9 +1096,7 @@ def generate_app(
             }
         },
     )
-    def validate_kana(
-        text: str,
-    ) -> bool:
+    def validate_kana(text: str) -> bool:
         """
         テキストがAquesTalkライクな記法に従っているかどうかを判定します。
         従っていない場合はエラーが返ります。
@@ -1122,9 +1116,7 @@ def generate_app(
             )
 
     @app.get("/setting", response_class=Response, tags=["設定"])
-    def setting_get(
-        request: Request,
-    ) -> Response:
+    def setting_get(request: Request) -> Response:
         settings = setting_loader.load_setting_file()
 
         cors_policy_mode = settings.cors_policy_mode

--- a/run.py
+++ b/run.py
@@ -982,9 +982,9 @@ def generate_app(
         pronunciation: str,
         accent_type: int,
         word_uuid: str,
-        word_type: Optional[WordTypes] = None,
-        priority: Optional[conint(ge=MIN_PRIORITY, le=MAX_PRIORITY)] = None,
-    ):
+        word_type: WordTypes | None = None,
+        priority: conint(ge=MIN_PRIORITY, le=MAX_PRIORITY) | None = None,
+    ) -> Response:
         """
         ユーザー辞書に登録されている言葉を更新します。
 

--- a/run.py
+++ b/run.py
@@ -12,7 +12,7 @@ from functools import lru_cache
 from io import BytesIO, TextIOWrapper
 from pathlib import Path
 from tempfile import NamedTemporaryFile, TemporaryFile
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 import soundfile
 import uvicorn
@@ -746,7 +746,10 @@ def generate_app(
         return metas_store.load_combined_metas(engine=engine)
 
     @app.get("/speaker_info", response_model=SpeakerInfo, tags=["その他"])
-    def speaker_info(speaker_uuid: str, core_version: Optional[str] = None):
+    def speaker_info(
+        speaker_uuid: str,
+        core_version: str | None = None,
+    ) -> dict[str, Any]:
         """
         指定されたspeaker_uuidに関する情報をjson形式で返します。
         画像や音声はbase64エンコードされたものが返されます。

--- a/run.py
+++ b/run.py
@@ -908,7 +908,10 @@ def generate_app(
         return Response(status_code=204)
 
     @app.get("/is_initialized_speaker", response_model=bool, tags=["その他"])
-    def is_initialized_speaker(speaker: int, core_version: Optional[str] = None):
+    def is_initialized_speaker(
+        speaker: int,
+        core_version: str | None = None,
+    ) -> bool:
         """
         指定されたspeaker_idの話者が初期化されているかどうかを返します。
         """

--- a/run.py
+++ b/run.py
@@ -667,7 +667,7 @@ def generate_app(
         return presets
 
     @app.post("/add_preset", response_model=int, tags=["その他"])
-    def add_preset(preset: Preset):
+    def add_preset(preset: Preset) -> int:
         """
         新しいプリセットを追加します
 

--- a/run.py
+++ b/run.py
@@ -222,7 +222,11 @@ def generate_app(
         tags=["クエリ作成"],
         summary="音声合成用のクエリを作成する",
     )
-    def audio_query(text: str, speaker: int, core_version: Optional[str] = None):
+    def audio_query(
+        text: str,
+        speaker: int,
+        core_version: str | None = None,
+    ) -> AudioQuery:
         """
         クエリの初期値を得ます。ここで得られたクエリはそのまま音声合成に利用できます。各値の意味は`Schemas`を参照してください。
         """

--- a/run.py
+++ b/run.py
@@ -434,8 +434,8 @@ def generate_app(
         query: AudioQuery,
         speaker: int,
         request: Request,
-        core_version: Optional[str] = None,
-    ):
+        core_version: str | None = None,
+    ) -> FileResponse:
         if cancellable_engine is None:
             raise HTTPException(
                 status_code=404,

--- a/run.py
+++ b/run.py
@@ -1116,7 +1116,9 @@ def generate_app(
             )
 
     @app.get("/setting", response_class=HTMLResponse, tags=["設定"])
-    def setting_get(request: Request):
+    def setting_get(
+        request: Request,
+    ) -> Response:
         settings = setting_loader.load_setting_file()
 
         cors_policy_mode = settings.cors_policy_mode

--- a/run.py
+++ b/run.py
@@ -289,7 +289,7 @@ def generate_app(
 
     @app.post(
         "/accent_phrases",
-        response_model=List[AccentPhrase],
+        response_model=list[AccentPhrase],
         tags=["クエリ編集"],
         summary="テキストからアクセント句を得る",
         responses={
@@ -303,8 +303,8 @@ def generate_app(
         text: str,
         speaker: int,
         is_kana: bool = False,
-        core_version: Optional[str] = None,
-    ):
+        core_version: str | None = None,
+    ) -> list[AccentPhrase]:
         """
         テキストからアクセント句を得ます。
         is_kanaが`true`のとき、テキストは次のようなAquesTalkライクな記法に従う読み仮名として処理されます。デフォルトは`false`です。

--- a/run.py
+++ b/run.py
@@ -853,7 +853,10 @@ def generate_app(
         status_code=204,
         tags=["音声ライブラリ管理"],
     )
-    async def install_library(library_uuid: str, request: Request) -> Response:
+    async def install_library(
+        library_uuid: str,
+        request: Request,
+    ) -> Response:
         """
         音声ライブラリをインストールします。
         音声ライブラリのZIPファイルをリクエストボディとして送信してください。


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->
`run.py`のルーティング関数（`@app.get`などがついている関数）の戻り値に型ヒントを追加し、mypyの`no-untyped-def`エラーをルーティング関数に限って解消します。

誤ったオブジェクトを返すことによる不具合を型レベルで防げます。

変更量を少なくするため、ルーティング関数以外は変更していません。

合わせて変更した点

- 変更した部分の周りの型ヒントを新しい記法に移行
    - Python 3.9で導入された記法: `List[Type] -> list[Type]`、`Tuple[Type] -> tuple[Type]`
    - Python 3.10で導入された記法: `Optional[Type] -> Type | None`
- `/core_versions`の戻り値の型が実際には`Response`だが`list[str]`で型ヒントがついていたのを`Response`に修正
    - `list[str]`にする場合、`Response`ではないオブジェクトを返すように修正が必要
- `/installed_libraries`のdocstringの戻り値の型の誤りを修正
- `setting_get()`, `setting_post()`の`response_class`を`HTMLResponse`から`Response`に変更
    - これらの関数では`startlette.templating._TemplateResponse`型が返るが、この型は`HTMLResponse`を継承しておらず、`Response`を直接継承している
    - 先月`HTMLResponse`を継承する変更がマージされているが、まだリリースされていない
        - https://github.com/encode/starlette/pull/2274
    - `Response`を継承したオブジェクトを返すと`response_class`は無視される（[FastAPIのソースコード@c1adce4](https://github.com/tiangolo/fastapi/blob/c1adce4fe93a0035e69988f7e051cfab97d8acef/fastapi/routing.py#L277-L280)）ので、実は設定する必要がない。そのままでもいいかもしれないけれど、戻り値の型との不一致は混乱するので避けたい

未修正な点（ルーティング関数内のmypy型エラー出力）

<details>

```
run.py:637: error: Incompatible return value type (got "HTTPException", expected "FileResponse")  [return-value]
run.py:770: error: Unsupported left operand type for / ("None")  [operator]
run.py:770: note: Left operand is of type "Optional[Path]"
run.py:774: error: Unsupported left operand type for / ("None")  [operator]
run.py:774: note: Left operand is of type "Optional[Path]"
run.py:781: error: Unsupported left operand type for / ("None")  [operator]
run.py:781: note: Left operand is of type "Optional[Path]"
run.py:785: error: Unsupported left operand type for / ("None")  [operator]
run.py:785: note: Left operand is of type "Optional[Path]"
run.py:795: error: Unsupported left operand type for / ("None")  [operator]
run.py:795: note: Left operand is of type "Optional[Path]"
run.py:950: error: Invalid type comment or annotation  [valid-type]
run.py:950: note: Suggestion: use conint[...] instead of conint(...)
run.py:992: error: Invalid type comment or annotation  [valid-type]
run.py:992: note: Suggestion: use conint[...] instead of conint(...)
```

</details>

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

- #263 
- #763
- #119 

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他

### mypyを実行

```shell
poetry run mypy .
```
