### PR TITLE
mainブランチ更新時に最新版が-devにリリースされるようにする

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,7 @@ on:
       code_signing:
         description: "コード署名する"
         type: boolean
+        default: false
       upload_artifact:
         description: "デバッグ用に成果物をartifactにアップロードするか"
         type: boolean

--- a/.github/workflows/release_latest_dev.yml
+++ b/.github/workflows/release_latest_dev.yml
@@ -1,0 +1,49 @@
+name: Release latest dev build
+
+# masterブランチが更新されるたびに開発版をビルドしてデプロイする。
+# バージョン（タグ）は最新リリースのバージョンを`X.Y.Z`としたときの`X.Y+1.0-dev`。
+
+on:
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - "docs/**"
+      - "test/**"
+
+jobs:
+  latest-dev-build:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'VOICEVOX'
+    steps:
+      - name: Trigger workflow_dispatch
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const latest_release = await github.rest.repos.getLatestRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo
+            });
+            const split_version = latest_release.data.tag_name.split('.');
+            const dev_version = `${split_version[0]}.${parseInt(split_version[1]) + 1}.0-dev`;
+            github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'build.yml',
+              ref: 'master',
+              inputs: {
+                version: dev_version,
+                prerelease: true
+              }
+            })
+            github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'build-docker.yml',
+              ref: 'master',
+              inputs: {
+                version: dev_version
+              }
+            })
+            console.log(`Triggered workflow_dispatch for ${dev_version}`);


### PR DESCRIPTION
## 内容

- https://github.com/VOICEVOX/voicevox_engine/issues/241

の解決プルリクエストです。
[エディターの方](https://github.com/VOICEVOX/voicevox/pull/1484)で便利だったのでエンジンの方でも作ってみました。

## 関連 Issue

- https://github.com/VOICEVOX/voicevox/pull/1484

resolve #241


## その他

コードは基本的にエディター側と一緒です。
デフォルトブランチの名称がmain→masterになっていることと、docker版のビルドのために2つ実行しているだけです。

