### PR TITLE
BaseLibraryInfoモデル(+α)の追加と、LibraryManagerクラスがあるファイルのリネーム

### DIFF
--- a/test/test_library_manager.py
+++ b/test/test_library_manager.py
@@ -10,7 +10,7 @@ from zipfile import ZipFile
 
 from fastapi import HTTPException
 
-from voicevox_engine.downloadable_library import LibraryManager
+from voicevox_engine.library_manager import LibraryManager
 
 vvlib_manifest_name = "vvlib_manifest.json"
 

--- a/voicevox_engine/library_manager.py
+++ b/voicevox_engine/library_manager.py
@@ -11,7 +11,11 @@ from fastapi import HTTPException
 from pydantic import ValidationError
 from semver.version import Version
 
-from voicevox_engine.model import DownloadableLibrary, InstalledLibrary, VvlibManifest
+from voicevox_engine.model import (
+    DownloadableLibraryInfo,
+    InstalledLibraryInfo,
+    VvlibManifest,
+)
 
 __all__ = ["LibraryManager"]
 
@@ -76,9 +80,9 @@ class LibraryManager:
                     )
                     for i in range(1, 4)
                 ]
-            return list(map(DownloadableLibrary.parse_obj, libraries))
+            return list(map(DownloadableLibraryInfo.parse_obj, libraries))
 
-    def installed_libraries(self) -> Dict[str, InstalledLibrary]:
+    def installed_libraries(self) -> Dict[str, InstalledLibraryInfo]:
         library = {}
         for library_dir in self.library_root_dir.iterdir():
             if library_dir.is_dir():

--- a/voicevox_engine/model.py
+++ b/voicevox_engine/model.py
@@ -127,9 +127,9 @@ class LibrarySpeaker(BaseModel):
     speaker_info: SpeakerInfo = Field(title="話者の追加情報")
 
 
-class DownloadableLibrary(BaseModel):
+class BaseLibraryInfo(BaseModel):
     """
-    ダウンロード可能な音声ライブラリの情報
+    音声ライブラリの情報
     """
 
     name: str = Field(title="音声ライブラリの名前")
@@ -140,7 +140,16 @@ class DownloadableLibrary(BaseModel):
     speakers: List[LibrarySpeaker] = Field(title="音声ライブラリに含まれる話者のリスト")
 
 
-class InstalledLibrary(DownloadableLibrary):
+# 今後InstalledLibraryInfo同様に拡張する可能性を考え、モデルを分けている
+class DownloadableLibraryInfo(BaseLibraryInfo):
+    """
+    ダウンロード可能な音声ライブラリの情報
+    """
+
+    pass
+
+
+class InstalledLibraryInfo(BaseLibraryInfo):
     """
     インストール済み音声ライブラリの情報
     """


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->
- https://github.com/VOICEVOX/voicevox/pull/1584#pullrequestreview-1651939647 で挙げられているややこしさを根幹から修正するため、`BaseLibraryInfo`モデルを作成し、それを継承する形で`DownloadLibraryInfo`と`InstalledLibraryInfo`を作りました。
  - ついでに、すべて`LibraryInfo`で統一しました(`Library`そのものではないため)
- `downloadable_library.py`についても、中身の`LibraryManager`クラスは`DownloadableLibrary`のみを取り扱うものではないため、実態に合わせてリネームしました。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->
- ref VOICEVOX/voicevox#1584

## その他

これがマージされ次第、エディタ側の`project-library-manage`のOpenAPIモデルを更新します。
