### PR TITLE
`generate_frame_scale_features` の解体

### DIFF
--- a/test/test_acoustic_feature_extractor.py
+++ b/test/test_acoustic_feature_extractor.py
@@ -28,7 +28,8 @@ class TestOjtPhoneme(TestCase):
         self.assertEqual(OjtPhoneme.phoneme_list[41], "v")
 
     def test_const(self):
-        self.assertEqual(OjtPhoneme.num_phoneme, 45)
+        TRUE_NUM_PHONEME = 45
+        self.assertEqual(OjtPhoneme.num_phoneme, TRUE_NUM_PHONEME)
         self.assertEqual(OjtPhoneme.space_phoneme, "pau")
 
     def test_convert(self):

--- a/test/test_synthesis_engine.py
+++ b/test/test_synthesis_engine.py
@@ -162,13 +162,13 @@ def test_calc_frame_per_phoneme():
 
     # Expects
     #                      Pre k  o  N pau h  i  h  O Pst
-    true_frm_per_phoneme = [1, 1, 2, 2, 1, 1, 2, 2, 1, 3]
-    true_frm_per_phoneme = numpy.array(true_frm_per_phoneme, dtype=numpy.int32)
+    true_frame_per_phoneme = [1, 1, 2, 2, 1, 1, 2, 2, 1, 3]
+    true_frame_per_phoneme = numpy.array(true_frame_per_phoneme, dtype=numpy.int32)
 
     # Outputs
-    frm_per_phnm = calc_frame_per_phoneme(query, moras)
+    frame_per_phoneme = calc_frame_per_phoneme(query, moras)
 
-    assert numpy.array_equal(frm_per_phnm, true_frm_per_phoneme)
+    assert numpy.array_equal(frame_per_phoneme, true_frame_per_phoneme)
 
 
 def test_calc_frame_pitch():
@@ -185,8 +185,8 @@ def test_calc_frame_pitch():
     phoneme_str = "pau k o N pau h i h O pau"
     phonemes = [OjtPhoneme(p, 0, 0) for p in phoneme_str.split()]
     #              Pre k  o  N pau h  i  h  O Pst
-    frm_per_phnm = [1, 1, 2, 2, 1, 1, 2, 2, 1, 3]
-    frm_per_phnm = numpy.array(frm_per_phnm, dtype=numpy.int32)
+    frame_per_phoneme = [1, 1, 2, 2, 1, 1, 2, 2, 1, 3]
+    frame_per_phoneme = numpy.array(frame_per_phoneme, dtype=numpy.int32)
 
     # Expects - x4 value scaled -> mean=300 var x0.5 intonation scaling
     #           pau   ko     ko     ko      N      N
@@ -198,7 +198,7 @@ def test_calc_frame_pitch():
     true_f0 = numpy.array(true1_f0 + true2_f0 + true3_f0, dtype=numpy.float32)
 
     # Outputs
-    f0 = calc_frame_pitch(query, moras, phonemes, frm_per_phnm)
+    f0 = calc_frame_pitch(query, moras, phonemes, frame_per_phoneme)
 
     assert numpy.array_equal(f0, true_f0)
 
@@ -208,22 +208,22 @@ def test_calc_frame_phoneme():
     # Inputs
     phoneme_str = "pau k o N pau h i h O pau"
     phonemes = [OjtPhoneme(p, 0, 0) for p in phoneme_str.split()]
-    #              Pre k  o  N pau h  i  h  O Pst
-    frm_per_phnm = [1, 1, 2, 2, 1, 1, 2, 2, 1, 3]
-    n_frm = sum(frm_per_phnm)
-    frm_per_phnm = numpy.array(frm_per_phnm, dtype=numpy.int32)
+    #                   Pre k  o  N pau h  i  h  O Pst
+    frame_per_phoneme = [1, 1, 2, 2, 1, 1, 2, 2, 1, 3]
+    n_frame = sum(frame_per_phoneme)
+    frame_per_phoneme = numpy.array(frame_per_phoneme, dtype=numpy.int32)
 
     # Expects
-    #                  Pr  k   o   o  N  N pau  h   i   i   h   h  O Pt Pt Pt
-    phoneme_ids_frm = [0, 23, 30, 30, 4, 4, 0, 19, 21, 21, 19, 19, 5, 0, 0, 0]
-    true_phoneme_frm = numpy.zeros([n_frm, 45], dtype=numpy.float32)
-    for frm_idx, phoneme_idx in enumerate(phoneme_ids_frm):
-        true_phoneme_frm[frm_idx, phoneme_idx] = 1.0
+    #              Pr  k   o   o  N  N pau  h   i   i   h   h  O Pt Pt Pt
+    phoneme_ids = [0, 23, 30, 30, 4, 4, 0, 19, 21, 21, 19, 19, 5, 0, 0, 0]
+    true_frame_phoneme = numpy.zeros([n_frame, 45], dtype=numpy.float32)
+    for frame_idx, phoneme_idx in enumerate(phoneme_ids):
+        true_frame_phoneme[frame_idx, phoneme_idx] = 1.0
 
     # Outputs
-    phoneme_frm = calc_frame_phoneme(phonemes, frm_per_phnm)
+    frame_phoneme = calc_frame_phoneme(phonemes, frame_per_phoneme)
 
-    assert numpy.array_equal(phoneme_frm, true_phoneme_frm)
+    assert numpy.array_equal(frame_phoneme, true_frame_phoneme)
 
 
 def test_feat_to_framescale():
@@ -247,23 +247,23 @@ def test_feat_to_framescale():
     phoneme_data_list = [OjtPhoneme(p, 0, 0) for p in phoneme_str.split()]
 
     # Expects
-    # frm_per_phnm
-    #                   Pre k  o  N pau h  i  h  O Pst
-    true_frm_per_phnm = [1, 1, 2, 2, 1, 1, 2, 2, 1, 3]
-    n_frm = sum(true_frm_per_phnm)
-    true_frm_per_phnm = numpy.array(true_frm_per_phnm, dtype=numpy.int32)
+    # frame_per_phoneme
+    #                        Pre k  o  N pau h  i  h  O Pst
+    true_frame_per_phoneme = [1, 1, 2, 2, 1, 1, 2, 2, 1, 3]
+    n_frame = sum(true_frame_per_phoneme)
+    true_frame_per_phoneme = numpy.array(true_frame_per_phoneme, dtype=numpy.int32)
     # phoneme
-    #               Pr  k   o   o  N  N pau  h   i   i   h   h  O Pt Pt Pt
-    phoneme_frms = [0, 23, 30, 30, 4, 4, 0, 19, 21, 21, 19, 19, 5, 0, 0, 0]
-    true_phoneme = numpy.zeros([n_frm, 45], dtype=numpy.float32)
-    for frm_idx, phoneme_idx in enumerate(phoneme_frms):
-        true_phoneme[frm_idx, phoneme_idx] = 1.0
+    #                     Pr  k   o   o  N  N pau  h   i   i   h   h  O Pt Pt Pt
+    frame_phoneme_idxs = [0, 23, 30, 30, 4, 4, 0, 19, 21, 21, 19, 19, 5, 0, 0, 0]
+    true_frame_phoneme = numpy.zeros([n_frame, 45], dtype=numpy.float32)
+    for frame_idx, phoneme_idx in enumerate(frame_phoneme_idxs):
+        true_frame_phoneme[frame_idx, phoneme_idx] = 1.0
     # Pitch
-    #        Pre   ko      N    pau   hi    hO   Pst
+    #          Pre   ko      N    pau   hi    hO   Pst
     true_f0 = [0.0, 200.0, 200.0, 0.0, 500.0, 0.0, 0.0]  # mean 300
     true_f0 = [0.0, 250.0, 250.0, 0.0, 400.0, 0.0, 0.0]  # intonationScale 0.5
-    #                paw ko  N pau hi hO paw
-    # frm_per_vowel = [1, 3,  2, 1, 3, 3, 3]
+    #                   paw ko  N pau hi hO paw
+    # frame_per_vowel = [1, 3,  2, 1, 3, 3, 3]
     #           pau   ko     ko     ko      N      N
     true1_f0 = [0.0, 250.0, 250.0, 250.0, 250.0, 250.0]
     #           pau   hi     hi     hi
@@ -272,14 +272,14 @@ def test_feat_to_framescale():
     true3_f0 = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
     true_f0 = numpy.array(true1_f0 + true2_f0 + true3_f0, dtype=numpy.float32)
 
-    assert true_frm_per_phnm.shape[0] == len(phoneme_data_list), "Prerequisites"
+    assert true_frame_per_phoneme.shape[0] == len(phoneme_data_list), "Prerequisites"
 
     # Outputs
-    frm_per_phnm = calc_frame_per_phoneme(query, flatten_moras)
-    f0 = calc_frame_pitch(query, flatten_moras, phoneme_data_list, frm_per_phnm)
-    phoneme = calc_frame_phoneme(phoneme_data_list, frm_per_phnm)
+    frame_per_phoneme = calc_frame_per_phoneme(query, flatten_moras)
+    f0 = calc_frame_pitch(query, flatten_moras, phoneme_data_list, frame_per_phoneme)
+    frame_phoneme = calc_frame_phoneme(phoneme_data_list, frame_per_phoneme)
 
-    assert numpy.array_equal(phoneme, true_phoneme)
+    assert numpy.array_equal(frame_phoneme, true_frame_phoneme)
     assert numpy.array_equal(f0, true_f0)
 
 

--- a/test/test_synthesis_engine.py
+++ b/test/test_synthesis_engine.py
@@ -24,7 +24,6 @@ from voicevox_engine.synthesis_engine.synthesis_engine import (
     unvoiced_mora_phoneme_list,
 )
 
-
 TRUE_NUM_PHONEME = 45
 
 

--- a/test/test_synthesis_engine.py
+++ b/test/test_synthesis_engine.py
@@ -133,6 +133,7 @@ def _gen_mora(
     vowel_length: float,
     pitch: float,
 ) -> Mora:
+    """Generate Mora with positional arguments for test simplicity."""
     return Mora(
         text=text,
         consonant=consonant,
@@ -159,16 +160,15 @@ def test_calc_frame_per_phoneme():
         _gen_mora("ホ", "h", 4 * 0.01067, "O", 2 * 0.01067, 0.0),
     ]
 
-    # Ground Truths
-    #                 Pre k  o  N pau h  i  h  O Pst
-    frm_per_phoneme_gt = [1, 1, 2, 2, 1, 1, 2, 2, 1, 3]
-    frm_per_phoneme_gt = numpy.array(frm_per_phoneme_gt, dtype=numpy.int32)
+    # Expects
+    #                      Pre k  o  N pau h  i  h  O Pst
+    true_frm_per_phoneme = [1, 1, 2, 2, 1, 1, 2, 2, 1, 3]
+    true_frm_per_phoneme = numpy.array(true_frm_per_phoneme, dtype=numpy.int32)
 
-    frm_per_phnm_pred = calc_frame_per_phoneme(query, moras)
+    # Outputs
+    frm_per_phnm = calc_frame_per_phoneme(query, moras)
 
-    assert numpy.array_equal(
-        frm_per_phnm_pred, frm_per_phoneme_gt
-    ), "Unmatched frame_per_phoneme"
+    assert numpy.array_equal(frm_per_phnm, true_frm_per_phoneme)
 
 
 def test_calc_frame_pitch():
@@ -188,18 +188,19 @@ def test_calc_frame_pitch():
     frm_per_phnm = [1, 1, 2, 2, 1, 1, 2, 2, 1, 3]
     frm_per_phnm = numpy.array(frm_per_phnm, dtype=numpy.int32)
 
-    # Ground Truths - x4 value scaled -> mean=300 var x0.5 intonation scaling
-    #          pau   ko     ko     ko      N      N
-    f0_gt_1 = [0.0, 250.0, 250.0, 250.0, 250.0, 250.0]
-    #          pau   hi     hi     hi
-    f0_gt_2 = [0.0, 400.0, 400.0, 400.0]
-    #          hO   hO   hO   paw  paw  paw
-    f0_gt_3 = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
-    f0_gt = numpy.array(f0_gt_1 + f0_gt_2 + f0_gt_3, dtype=numpy.float32)
+    # Expects - x4 value scaled -> mean=300 var x0.5 intonation scaling
+    #           pau   ko     ko     ko      N      N
+    true1_f0 = [0.0, 250.0, 250.0, 250.0, 250.0, 250.0]
+    #           pau   hi     hi     hi
+    true2_f0 = [0.0, 400.0, 400.0, 400.0]
+    #           hO   hO   hO   paw  paw  paw
+    true3_f0 = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    true_f0 = numpy.array(true1_f0 + true2_f0 + true3_f0, dtype=numpy.float32)
 
-    f0_pred = calc_frame_pitch(query, moras, phonemes, frm_per_phnm)
+    # Outputs
+    f0 = calc_frame_pitch(query, moras, phonemes, frm_per_phnm)
 
-    assert numpy.array_equal(f0_pred, f0_gt)
+    assert numpy.array_equal(f0, true_f0)
 
 
 def test_calc_frame_phoneme():
@@ -212,16 +213,17 @@ def test_calc_frame_phoneme():
     n_frm = sum(frm_per_phnm)
     frm_per_phnm = numpy.array(frm_per_phnm, dtype=numpy.int32)
 
-    # Ground Truths
+    # Expects
     #                  Pr  k   o   o  N  N pau  h   i   i   h   h  O Pt Pt Pt
     phoneme_ids_frm = [0, 23, 30, 30, 4, 4, 0, 19, 21, 21, 19, 19, 5, 0, 0, 0]
-    phoneme_frm_gt = numpy.zeros([n_frm, 45], dtype=numpy.float32)
+    true_phoneme_frm = numpy.zeros([n_frm, 45], dtype=numpy.float32)
     for frm_idx, phoneme_idx in enumerate(phoneme_ids_frm):
-        phoneme_frm_gt[frm_idx, phoneme_idx] = 1.0
+        true_phoneme_frm[frm_idx, phoneme_idx] = 1.0
 
-    phoneme_frm_pred = calc_frame_phoneme(phonemes, frm_per_phnm)
+    # Outputs
+    phoneme_frm = calc_frame_phoneme(phonemes, frm_per_phnm)
 
-    assert numpy.array_equal(phoneme_frm_pred, phoneme_frm_gt)
+    assert numpy.array_equal(phoneme_frm, true_phoneme_frm)
 
 
 def test_feat_to_framescale():
@@ -244,41 +246,41 @@ def test_feat_to_framescale():
     phoneme_str = "pau k o N pau h i h O pau"
     phoneme_data_list = [OjtPhoneme(p, 0, 0) for p in phoneme_str.split()]
 
-    # Ground Truths
-    #                 Pre k  o  N pau h  i  h  O Pst
-    frm_per_phoneme = [1, 1, 2, 2, 1, 1, 2, 2, 1, 3]
-    n_frm = sum(frm_per_phoneme)
-    frm_per_phoneme = numpy.array(frm_per_phoneme, dtype=numpy.int32)
-
+    # Expects
+    # frm_per_phnm
+    #                   Pre k  o  N pau h  i  h  O Pst
+    true_frm_per_phnm = [1, 1, 2, 2, 1, 1, 2, 2, 1, 3]
+    n_frm = sum(true_frm_per_phnm)
+    true_frm_per_phnm = numpy.array(true_frm_per_phnm, dtype=numpy.int32)
+    # phoneme
     #               Pr  k   o   o  N  N pau  h   i   i   h   h  O Pt Pt Pt
     phoneme_frms = [0, 23, 30, 30, 4, 4, 0, 19, 21, 21, 19, 19, 5, 0, 0, 0]
-    phoneme_gt = numpy.zeros([n_frm, 45], dtype=numpy.float32)
+    true_phoneme = numpy.zeros([n_frm, 45], dtype=numpy.float32)
     for frm_idx, phoneme_idx in enumerate(phoneme_frms):
-        phoneme_gt[frm_idx, phoneme_idx] = 1.0
-
-    # Pitch - x4 value & x0.5 variance
+        true_phoneme[frm_idx, phoneme_idx] = 1.0
+    # Pitch
     #        Pre   ko      N    pau   hi    hO   Pst
-    f0_gt = [0.0, 200.0, 200.0, 0.0, 500.0, 0.0, 0.0]  # mean 300
-    f0_gt = [0.0, 250.0, 250.0, 0.0, 400.0, 0.0, 0.0]  # intonationScale 0.5
+    true_f0 = [0.0, 200.0, 200.0, 0.0, 500.0, 0.0, 0.0]  # mean 300
+    true_f0 = [0.0, 250.0, 250.0, 0.0, 400.0, 0.0, 0.0]  # intonationScale 0.5
     #                paw ko  N pau hi hO paw
     # frm_per_vowel = [1, 3,  2, 1, 3, 3, 3]
-    #          pau   ko     ko     ko      N      N
-    f0_gt_1 = [0.0, 250.0, 250.0, 250.0, 250.0, 250.0]
-    #          pau   hi     hi     hi
-    f0_gt_2 = [0.0, 400.0, 400.0, 400.0]
-    #          hO   hO   hO   paw  paw  paw
-    f0_gt_3 = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
-    f0_gt = numpy.array(f0_gt_1 + f0_gt_2 + f0_gt_3, dtype=numpy.float32)
+    #           pau   ko     ko     ko      N      N
+    true1_f0 = [0.0, 250.0, 250.0, 250.0, 250.0, 250.0]
+    #           pau   hi     hi     hi
+    true2_f0 = [0.0, 400.0, 400.0, 400.0]
+    #           hO   hO   hO   paw  paw  paw
+    true3_f0 = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    true_f0 = numpy.array(true1_f0 + true2_f0 + true3_f0, dtype=numpy.float32)
 
-    assert frm_per_phoneme.shape[0] == len(phoneme_data_list), "Prerequisites"
+    assert true_frm_per_phnm.shape[0] == len(phoneme_data_list), "Prerequisites"
 
-    # Inference
+    # Outputs
     frm_per_phnm = calc_frame_per_phoneme(query, flatten_moras)
-    f0_pred = calc_frame_pitch(query, flatten_moras, phoneme_data_list, frm_per_phnm)
-    phoneme_pred = calc_frame_phoneme(phoneme_data_list, frm_per_phnm)
+    f0 = calc_frame_pitch(query, flatten_moras, phoneme_data_list, frm_per_phnm)
+    phoneme = calc_frame_phoneme(phoneme_data_list, frm_per_phnm)
 
-    assert numpy.array_equal(phoneme_pred, phoneme_gt), "Wrong phoneme onehot frames"
-    assert numpy.array_equal(f0_pred, f0_gt), "Wrong frame-wise phoneme onehot"
+    assert numpy.array_equal(phoneme, true_phoneme)
+    assert numpy.array_equal(f0, true_f0)
 
 
 class TestSynthesisEngine(TestCase):

--- a/test/test_synthesis_engine.py
+++ b/test/test_synthesis_engine.py
@@ -1,7 +1,7 @@
 import math
 from copy import deepcopy
 from random import random
-from typing import List, Optional, Union
+from typing import Union
 from unittest import TestCase
 from unittest.mock import Mock
 
@@ -100,7 +100,7 @@ class MockCore:
 
 
 def _gen_query(
-    accent_phrases: Optional[List[AccentPhrase]] = None,
+    accent_phrases: list[AccentPhrase] | None = None,
     speedScale: float = 1.0,
     pitchScale: float = 1.0,
     intonationScale: float = 1.0,
@@ -127,8 +127,8 @@ def _gen_query(
 
 def _gen_mora(
     text: str,
-    consonant: Optional[str],
-    consonant_length: Optional[float],
+    consonant: str | None,
+    consonant_length: float | None,
     vowel: str,
     vowel_length: float,
     pitch: float,

--- a/test/test_synthesis_engine.py
+++ b/test/test_synthesis_engine.py
@@ -25,6 +25,9 @@ from voicevox_engine.synthesis_engine.synthesis_engine import (
 )
 
 
+TRUE_NUM_PHONEME = 45
+
+
 def yukarin_s_mock(length: int, phoneme_list: numpy.ndarray, style_id: numpy.ndarray):
     result = []
     # mockとしての適当な処理、特に意味はない
@@ -216,7 +219,7 @@ def test_calc_frame_phoneme():
     # Expects
     #              Pr  k   o   o  N  N pau  h   i   i   h   h  O Pt Pt Pt
     phoneme_ids = [0, 23, 30, 30, 4, 4, 0, 19, 21, 21, 19, 19, 5, 0, 0, 0]
-    true_frame_phoneme = numpy.zeros([n_frame, 45], dtype=numpy.float32)
+    true_frame_phoneme = numpy.zeros([n_frame, TRUE_NUM_PHONEME], dtype=numpy.float32)
     for frame_idx, phoneme_idx in enumerate(phoneme_ids):
         true_frame_phoneme[frame_idx, phoneme_idx] = 1.0
 
@@ -255,7 +258,7 @@ def test_feat_to_framescale():
     # phoneme
     #                     Pr  k   o   o  N  N pau  h   i   i   h   h  O Pt Pt Pt
     frame_phoneme_idxs = [0, 23, 30, 30, 4, 4, 0, 19, 21, 21, 19, 19, 5, 0, 0, 0]
-    true_frame_phoneme = numpy.zeros([n_frame, 45], dtype=numpy.float32)
+    true_frame_phoneme = numpy.zeros([n_frame, TRUE_NUM_PHONEME], dtype=numpy.float32)
     for frame_idx, phoneme_idx in enumerate(frame_phoneme_idxs):
         true_frame_phoneme[frame_idx, phoneme_idx] = 1.0
     # Pitch

--- a/voicevox_engine/synthesis_engine/synthesis_engine.py
+++ b/voicevox_engine/synthesis_engine/synthesis_engine.py
@@ -221,7 +221,7 @@ def calc_frame_phoneme(phonemes: List[OjtPhoneme], frm_per_phnm):
     Returns
     -------
     phoneme : NDArray[]
-        フレームごとの基本周波数系列
+        フレームごとの音素系列
     """
     # Index化
     phoneme_ids_phnm = numpy.array([p.phoneme_id for p in phonemes], dtype=numpy.int64)

--- a/voicevox_engine/synthesis_engine/synthesis_engine.py
+++ b/voicevox_engine/synthesis_engine/synthesis_engine.py
@@ -170,7 +170,7 @@ def calc_frame_pitch(
     query: AudioQuery, moras: List[Mora], phonemes: List[OjtPhoneme], frm_per_phnm
 ):
     """
-    フレームスケールピッチの生成
+    フレームごとのピッチの生成
     Parameters
     ----------
     query : AudioQuery
@@ -184,7 +184,7 @@ def calc_frame_pitch(
     Returns
     -------
     f0 : NDArray[]
-        フレームスケール基本周波数系列
+        フレームごとの基本周波数系列
     """
     # モーラ（前後の無音含む）スケール基本周波数
     f0_mora = numpy.array(
@@ -200,7 +200,7 @@ def calc_frame_pitch(
     if not numpy.isnan(mean_f0):
         f0_mora[voiced] = (f0_mora[voiced] - mean_f0) * query.intonationScale + mean_f0
 
-    # フレームスケール化
+    # フレームごとのピッチ化
     # 母音インデックスに基づき "音素あたりのフレーム長" を "モーラあたりのフレーム長" に集約
     vowel_indexes = numpy.array(split_mora(phonemes)[2])
     frm_per_mora = [a.sum() for a in numpy.split(frm_per_phnm, vowel_indexes[:-1] + 1)]
@@ -211,22 +211,22 @@ def calc_frame_pitch(
 
 def calc_frame_phoneme(phonemes: List[OjtPhoneme], frm_per_phnm):
     """
-    フレームスケール音素列の生成
+    フレームごとの音素列の生成
     Parameters
     ----------
     phonemes : List[OjtPhoneme]
         音素列
     frm_per_phnm: NDArray
-        音素（前後の無音含む）あたりのフレーム長。端数丸め。
+        音素あたりのフレーム長。端数丸め。
     Returns
     -------
     phoneme : NDArray[]
-        フレームスケール基本周波数系列
+        フレームごとの基本周波数系列
     """
     # Index化
     phoneme_ids_phnm = numpy.array([p.phoneme_id for p in phonemes], dtype=numpy.int64)
 
-    # フレームスケール化
+    # フレームごとの音素列化
     phoneme_frm = numpy.repeat(phoneme_ids_phnm, frm_per_phnm)
 
     # Onehot化

--- a/voicevox_engine/synthesis_engine/synthesis_engine.py
+++ b/voicevox_engine/synthesis_engine/synthesis_engine.py
@@ -208,7 +208,7 @@ def calc_frame_pitch(
     frame_per_mora = [
         a.sum() for a in numpy.split(frame_per_phoneme, vowel_indexes[:-1] + 1)
     ]
-    # モーラ内vowelの基本周波数を子音にも割当てフレーム化
+    # モーラの基本周波数を子音・母音に割当てフレーム化
     frame_f0 = numpy.repeat(f0, frame_per_mora)
     return frame_f0
 

--- a/voicevox_engine/synthesis_engine/synthesis_engine.py
+++ b/voicevox_engine/synthesis_engine/synthesis_engine.py
@@ -138,7 +138,7 @@ def calc_frame_per_phoneme(query: AudioQuery, moras: List[Mora]):
         モーラ列
     Returns
     -------
-    frm_per_phnm : NDArray[]
+    frame_per_phoneme : NDArray[]
         音素（前後の無音含む）あたりのフレーム長。端数丸め。
     """
     # 音素（前後の無音含む）あたりの継続長

--- a/voicevox_engine/synthesis_engine/synthesis_engine.py
+++ b/voicevox_engine/synthesis_engine/synthesis_engine.py
@@ -209,7 +209,7 @@ def calc_frame_pitch(
     return f0_frm
 
 
-def calc_frame_phoneme(phonemes: List[OjtPhoneme], frm_per_phnm):
+def calc_frame_phoneme(phonemes: List[OjtPhoneme], frm_per_phnm: numpy.ndarray):
     """
     フレームごとの音素列の生成
     Parameters

--- a/voicevox_engine/synthesis_engine/synthesis_engine.py
+++ b/voicevox_engine/synthesis_engine/synthesis_engine.py
@@ -189,6 +189,7 @@ def calc_frame_pitch(
     f0 : NDArray[]
         フレームごとの基本周波数系列
     """
+    # TODO: Better function name (c.f. VOICEVOX/voicevox_engine#790)
     # モーラ（前後の無音含む）スケール基本周波数
     f0_mora = numpy.array(
         [0] + [mora.pitch for mora in moras] + [0], dtype=numpy.float32
@@ -228,6 +229,7 @@ def calc_frame_phoneme(phonemes: List[OjtPhoneme], frame_per_phoneme: numpy.ndar
     phoneme : NDArray[]
         フレームごとの音素系列
     """
+    # TODO: Better function name (c.f. VOICEVOX/voicevox_engine#790)
     # Index化
     phoneme_ids_phoneme = numpy.array(
         [p.phoneme_id for p in phonemes], dtype=numpy.int64

--- a/voicevox_engine/synthesis_engine/synthesis_engine.py
+++ b/voicevox_engine/synthesis_engine/synthesis_engine.py
@@ -191,9 +191,7 @@ def calc_frame_pitch(
     """
     # TODO: Better function name (c.f. VOICEVOX/voicevox_engine#790)
     # モーラ（前後の無音含む）ごとの基本周波数
-    f0 = numpy.array(
-        [0] + [mora.pitch for mora in moras] + [0], dtype=numpy.float32
-    )
+    f0 = numpy.array([0] + [mora.pitch for mora in moras] + [0], dtype=numpy.float32)
 
     # 音高スケールによる補正
     f0 *= 2**query.pitchScale
@@ -231,9 +229,7 @@ def calc_frame_phoneme(phonemes: List[OjtPhoneme], frame_per_phoneme: numpy.ndar
     """
     # TODO: Better function name (c.f. VOICEVOX/voicevox_engine#790)
     # Index化
-    phoneme_ids = numpy.array(
-        [p.phoneme_id for p in phonemes], dtype=numpy.int64
-    )
+    phoneme_ids = numpy.array([p.phoneme_id for p in phonemes], dtype=numpy.int64)
 
     # フレームごとの音素化
     frame_phoneme = numpy.repeat(phoneme_ids, frame_per_phoneme)

--- a/voicevox_engine/synthesis_engine/synthesis_engine.py
+++ b/voicevox_engine/synthesis_engine/synthesis_engine.py
@@ -167,7 +167,7 @@ def calc_frame_per_phoneme(query: AudioQuery, moras: List[Mora]):
 
 
 def calc_frame_pitch(
-    query: AudioQuery, moras: List[Mora], phonemes: List[OjtPhoneme], frm_per_phnm
+    query: AudioQuery, moras: List[Mora], phonemes: List[OjtPhoneme], frm_per_phnm: numpy.ndarray
 ):
     """
     フレームごとのピッチの生成

--- a/voicevox_engine/synthesis_engine/synthesis_engine.py
+++ b/voicevox_engine/synthesis_engine/synthesis_engine.py
@@ -237,33 +237,6 @@ def calc_frame_phoneme(phonemes: List[OjtPhoneme], frm_per_phnm):
     return phoneme_frm
 
 
-def generate_frame_scale_features(
-    query: AudioQuery, flatten_moras: List[Mora], phoneme_data_list: List[OjtPhoneme]
-):
-    """
-    フレームごとの特徴量の生成
-    Parameters
-    ----------
-    query : List[AccentPhrase]
-        音声合成クエリ
-    flatten_moras : List[Mora]
-        モーラ列
-    phoneme_data_list : List[OjtPhoneme]
-        音素列
-    Returns
-    -------
-    phoneme : NDArray[]
-        フレームごとの音素onehotベクトル列
-    f0 : NDArray[]
-        フレームごとの基本周波数系列
-    """
-    frm_per_phnm = calc_frame_per_phoneme(query, flatten_moras)
-    f0 = calc_frame_pitch(query, flatten_moras, phoneme_data_list, frm_per_phnm)
-    phoneme = calc_frame_phoneme(phoneme_data_list, frm_per_phnm)
-
-    return phoneme, f0
-
-
 class SynthesisEngine(SynthesisEngineBase):
     def __init__(
         self,
@@ -547,9 +520,9 @@ class SynthesisEngine(SynthesisEngineBase):
         # AccentPhraseをすべてMoraおよびOjtPhonemeの形に分解し、処理可能な形にする
         flatten_moras, phoneme_data_list = pre_process(query.accent_phrases)
 
-        phoneme, f0 = generate_frame_scale_features(
-            query, flatten_moras, phoneme_data_list
-        )
+        frm_per_phnm = calc_frame_per_phoneme(query, flatten_moras)
+        f0 = calc_frame_pitch(query, flatten_moras, phoneme_data_list, frm_per_phnm)
+        phoneme = calc_frame_phoneme(phoneme_data_list, frm_per_phnm)
 
         # 今まで生成された情報をdecode_forwardにかけ、推論器によって音声波形を生成する
         with self.mutex:


### PR DESCRIPTION
## 内容
#784 で切り出された第2前処理関数 `generate_frame_scale_features` の更なる切り出し。  

3機能が混在していたため、以下の3つに分解：

- `calc_frame_per_phoneme`
- `calc_frame_pitch`
- `calc_frame_phoneme`

## 関連 Issue
resolve #783

## その他
diff が上手く効かなくてreviewしづらそうです🥺  
commit log は段階的になっておりdiffが上手く効いています。  
なので最初に commit log を見て変更概要をご理解いただければと思います。 