### PR TITLE
`OjtPhoneme.convert()` の廃止

### DIFF
--- a/test/test_acoustic_feature_extractor.py
+++ b/test/test_acoustic_feature_extractor.py
@@ -6,10 +6,10 @@ from voicevox_engine.acoustic_feature_extractor import OjtPhoneme
 class TestOjtPhoneme(TestCase):
     def setUp(self):
         super().setUp()
-        str_hello_hiho = "sil k o N n i ch i w a pau h i h o d e s U sil"
-        self.ojt_hello_hiho = OjtPhoneme.convert(
-            [OjtPhoneme(s, i, i + 1) for i, s in enumerate(str_hello_hiho.split())]
-        )
+        hello_hiho = "sil k o N n i ch i w a pau h i h o d e s U sil".split()
+        self.ojt_hello_hiho = [
+            OjtPhoneme(s, i, i + 1) for i, s in enumerate(hello_hiho)
+        ]
 
     def test_repr_(self):
         self.assertEqual(
@@ -32,10 +32,8 @@ class TestOjtPhoneme(TestCase):
         self.assertEqual(OjtPhoneme.space_phoneme, "pau")
 
     def test_convert(self):
-        ojt_str_hello_hiho = " ".join([p.phoneme for p in self.ojt_hello_hiho])
-        self.assertEqual(
-            ojt_str_hello_hiho, "pau k o N n i ch i w a pau h i h o d e s U pau"
-        )
+        sil_phoneme = OjtPhoneme("sil", 0, 0)
+        self.assertEqual(sil_phoneme.phoneme, "pau")
 
     def test_equal(self):
         # ojt_hello_hihoの10番目の"a"と比較

--- a/voicevox_engine/acoustic_feature_extractor.py
+++ b/voicevox_engine/acoustic_feature_extractor.py
@@ -1,5 +1,3 @@
-from typing import List
-
 import numpy
 
 
@@ -73,6 +71,10 @@ class OjtPhoneme:
         start: float,
         end: float,
     ):
+        # `sil`-to-`pau` (silent to space_phoneme) conversion
+        if "sil" in phoneme:
+            phoneme = self.space_phoneme
+
         self.phoneme = phoneme
         self.start = numpy.round(start, decimals=2)
         self.end = numpy.round(end, decimals=2)
@@ -108,23 +110,3 @@ class OjtPhoneme:
         array = numpy.zeros(self.num_phoneme, dtype=bool)
         array[self.phoneme_id] = True
         return array
-
-    @classmethod
-    def convert(cls, phonemes: List["OjtPhoneme"]) -> List["OjtPhoneme"]:
-        """
-        最初と最後のsil(silent)をspace_phoneme(pau)に置き換え(変換)する
-        Parameters
-        ----------
-        phonemes : List[OjtPhoneme]
-            変換したいphonemeのリスト
-
-        Returns
-        -------
-        phonemes : List[OjtPhoneme]
-            変換されたphonemeのリスト
-        """
-        if "sil" in phonemes[0].phoneme:
-            phonemes[0].phoneme = cls.space_phoneme
-        if "sil" in phonemes[-1].phoneme:
-            phonemes[-1].phoneme = cls.space_phoneme
-        return phonemes

--- a/voicevox_engine/synthesis_engine/synthesis_engine.py
+++ b/voicevox_engine/synthesis_engine/synthesis_engine.py
@@ -57,7 +57,6 @@ def to_phoneme_data_list(phoneme_str_list: List[str]):
         OjtPhoneme(phoneme=p, start=i, end=i + 1)
         for i, p in enumerate(phoneme_str_list)
     ]
-    phoneme_data_list = OjtPhoneme.convert(phoneme_data_list)
     return phoneme_data_list
 
 


### PR DESCRIPTION
## 内容
`OjtPhoneme.convert()` の機能移植、廃止。  

## 関連 Issue
resolve #786
