### PR TITLE
`to_phoneme_data_list()` の廃止

### DIFF
--- a/test/test_synthesis_engine.py
+++ b/test/test_synthesis_engine.py
@@ -18,7 +18,6 @@ from voicevox_engine.synthesis_engine.synthesis_engine import (
     pre_process,
     split_mora,
     to_flatten_moras,
-    to_phoneme_data_list,
     unvoiced_mora_phoneme_list,
 )
 
@@ -296,10 +295,6 @@ class TestSynthesisEngine(TestCase):
             + [self.accent_phrases_hello_hiho[0].pause_mora]
             + self.accent_phrases_hello_hiho[1].moras,
         )
-
-    def test_to_phoneme_data_list(self):
-        phoneme_data_list = to_phoneme_data_list(self.str_list_hello_hiho)
-        self.assertEqual(phoneme_data_list, self.phoneme_data_list_hello_hiho)
 
     def test_split_mora(self):
         consonant_phoneme_list, vowel_phoneme_list, vowel_indexes = split_mora(

--- a/voicevox_engine/synthesis_engine/synthesis_engine.py
+++ b/voicevox_engine/synthesis_engine/synthesis_engine.py
@@ -41,25 +41,6 @@ def to_flatten_moras(accent_phrases: List[AccentPhrase]) -> List[Mora]:
     )
 
 
-def to_phoneme_data_list(phoneme_str_list: List[str]):
-    """
-    phoneme文字列のリストを、OjtPhonemeクラスのリストに変換する
-    Parameters
-    ----------
-    phoneme_str_list : List[str]
-        phoneme文字列のリスト
-    Returns
-    -------
-    phoneme_list : List[OjtPhoneme]
-        変換されたOjtPhonemeクラスのリスト
-    """
-    phoneme_data_list = [
-        OjtPhoneme(phoneme=p, start=i, end=i + 1)
-        for i, p in enumerate(phoneme_str_list)
-    ]
-    return phoneme_data_list
-
-
 def split_mora(phoneme_list: List[OjtPhoneme]):
     """
     OjtPhonemeのリストから、
@@ -121,7 +102,10 @@ def pre_process(
     phoneme_str_list = list(chain.from_iterable(phoneme_each_mora))
     phoneme_str_list = ["pau"] + phoneme_str_list + ["pau"]
 
-    phoneme_data_list = to_phoneme_data_list(phoneme_str_list)
+    phoneme_data_list = [
+        OjtPhoneme(phoneme=p, start=i, end=i + 1)
+        for i, p in enumerate(phoneme_str_list)
+    ]
 
     return flatten_moras, phoneme_data_list
 


### PR DESCRIPTION
## 内容
`to_phoneme_data_list()` 関数の廃止

## 関連 Issue
resolve #796 
