### PR TITLE
廃止: `OjtPhoneme.__eq__()`

### DIFF
--- a/test/test_acoustic_feature_extractor.py
+++ b/test/test_acoustic_feature_extractor.py
@@ -6,6 +6,7 @@ from voicevox_engine.acoustic_feature_extractor import OjtPhoneme
 class TestOjtPhoneme(TestCase):
     def setUp(self):
         super().setUp()
+        # list_idx      0 1 2 3 4 5  6 7 8 9  10 1 2 3 4 5 6 7 8   9
         hello_hiho = "sil k o N n i ch i w a pau h i h o d e s U sil".split()
         self.ojt_hello_hiho = [
             OjtPhoneme(s, i, i + 1) for i, s in enumerate(hello_hiho)
@@ -37,14 +38,8 @@ class TestOjtPhoneme(TestCase):
         self.assertEqual(sil_phoneme.phoneme, "pau")
 
     def test_equal(self):
-        # ojt_hello_hihoの10番目の"a"と比較
-        true_ojt_phoneme = OjtPhoneme("a", 9, 10)
-
-        false_ojt_phoneme_1 = OjtPhoneme("k", 9, 10)
-        false_ojt_phoneme_2 = OjtPhoneme("a", 10, 11)
-        self.assertTrue(self.ojt_hello_hiho[9] == true_ojt_phoneme)
-        self.assertFalse(self.ojt_hello_hiho[9] == false_ojt_phoneme_1)
-        self.assertFalse(self.ojt_hello_hiho[9] == false_ojt_phoneme_2)
+        self.assertTrue(self.ojt_hello_hiho[9].phoneme_id == OjtPhoneme("a", 9, 10).phoneme_id)
+        self.assertFalse(self.ojt_hello_hiho[9].phoneme_id == OjtPhoneme("k", 9, 10).phoneme_id)
 
     def test_phoneme_id(self):
         ojt_str_hello_hiho = " ".join([str(p.phoneme_id) for p in self.ojt_hello_hiho])

--- a/test/test_acoustic_feature_extractor.py
+++ b/test/test_acoustic_feature_extractor.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 from voicevox_engine.acoustic_feature_extractor import OjtPhoneme
 
 
-def is_same_OjtPhoneme(p1: OjtPhoneme, p2: OjtPhoneme) -> bool:
+def is_same_phoneme(p1: OjtPhoneme, p2: OjtPhoneme) -> bool:
     """2つのOjtPhonemeが同じ`.phoneme`/`.start`/`.end`を持つ"""
     return p1.phoneme == p2.phoneme and p1.start == p2.start and p1.end == p2.end
 
@@ -48,9 +48,9 @@ class TestOjtPhoneme(TestCase):
 
         false_ojt_phoneme_1 = OjtPhoneme("k", 9, 10)
         false_ojt_phoneme_2 = OjtPhoneme("a", 10, 11)
-        assert is_same_OjtPhoneme(self.ojt_hello_hiho[9], true_ojt_phoneme)
-        assert not is_same_OjtPhoneme(self.ojt_hello_hiho[9], false_ojt_phoneme_1)
-        assert not is_same_OjtPhoneme(self.ojt_hello_hiho[9], false_ojt_phoneme_2)
+        self.assertTrue(is_same_phoneme(self.ojt_hello_hiho[9], true_ojt_phoneme))
+        self.assertFalse(is_same_phoneme(self.ojt_hello_hiho[9], false_ojt_phoneme_1))
+        self.assertFalse(is_same_phoneme(self.ojt_hello_hiho[9], false_ojt_phoneme_2))
 
     def test_phoneme_id(self):
         ojt_str_hello_hiho = " ".join([str(p.phoneme_id) for p in self.ojt_hello_hiho])

--- a/test/test_acoustic_feature_extractor.py
+++ b/test/test_acoustic_feature_extractor.py
@@ -38,8 +38,12 @@ class TestOjtPhoneme(TestCase):
         self.assertEqual(sil_phoneme.phoneme, "pau")
 
     def test_equal(self):
-        self.assertTrue(self.ojt_hello_hiho[9].phoneme_id == OjtPhoneme("a", 9, 10).phoneme_id)
-        self.assertFalse(self.ojt_hello_hiho[9].phoneme_id == OjtPhoneme("k", 9, 10).phoneme_id)
+        self.assertTrue(
+            self.ojt_hello_hiho[9].phoneme_id == OjtPhoneme("a", 9, 10).phoneme_id
+        )
+        self.assertFalse(
+            self.ojt_hello_hiho[9].phoneme_id == OjtPhoneme("k", 9, 10).phoneme_id
+        )
 
     def test_phoneme_id(self):
         ojt_str_hello_hiho = " ".join([str(p.phoneme_id) for p in self.ojt_hello_hiho])

--- a/test/test_acoustic_feature_extractor.py
+++ b/test/test_acoustic_feature_extractor.py
@@ -3,6 +3,11 @@ from unittest import TestCase
 from voicevox_engine.acoustic_feature_extractor import OjtPhoneme
 
 
+def is_same_OjtPhoneme(p1: OjtPhoneme, p2: OjtPhoneme) -> bool:
+    """2つのOjtPhonemeが同じ`.phoneme`/`.start`/`.end`を持つ"""
+    return p1.phoneme == p2.phoneme and p1.start == p2.start and p1.end == p2.end
+
+
 class TestOjtPhoneme(TestCase):
     def setUp(self):
         super().setUp()
@@ -38,12 +43,14 @@ class TestOjtPhoneme(TestCase):
         self.assertEqual(sil_phoneme.phoneme, "pau")
 
     def test_equal(self):
-        self.assertTrue(
-            self.ojt_hello_hiho[9].phoneme_id == OjtPhoneme("a", 9, 10).phoneme_id
-        )
-        self.assertFalse(
-            self.ojt_hello_hiho[9].phoneme_id == OjtPhoneme("k", 9, 10).phoneme_id
-        )
+        # ojt_hello_hihoの10番目の"a"と比較
+        true_ojt_phoneme = OjtPhoneme("a", 9, 10)
+
+        false_ojt_phoneme_1 = OjtPhoneme("k", 9, 10)
+        false_ojt_phoneme_2 = OjtPhoneme("a", 10, 11)
+        assert is_same_OjtPhoneme(self.ojt_hello_hiho[9], true_ojt_phoneme)
+        assert not is_same_OjtPhoneme(self.ojt_hello_hiho[9], false_ojt_phoneme_1)
+        assert not is_same_OjtPhoneme(self.ojt_hello_hiho[9], false_ojt_phoneme_2)
 
     def test_phoneme_id(self):
         ojt_str_hello_hiho = " ".join([str(p.phoneme_id) for p in self.ojt_hello_hiho])

--- a/test/test_synthesis_engine.py
+++ b/test/test_synthesis_engine.py
@@ -430,7 +430,12 @@ class TestSynthesisEngine(TestCase):
             ],
         )
         self.assertEqual(
-            list(map(lambda p: p.phoneme_id if p is not None else p, consonant_phoneme_list)),
+            list(
+                map(
+                    lambda p: p.phoneme_id if p is not None else p,
+                    consonant_phoneme_list,
+                )
+            ),
             [
                 None,
                 OjtPhoneme(phoneme="k", start=1, end=2).phoneme_id,
@@ -455,7 +460,9 @@ class TestSynthesisEngine(TestCase):
         mora_index = 0
         phoneme_index = 1
 
-        self.assertEqual(phoneme_data_list[0].phoneme_id, OjtPhoneme("pau", 0, 1).phoneme_id)
+        self.assertEqual(
+            phoneme_data_list[0].phoneme_id, OjtPhoneme("pau", 0, 1).phoneme_id
+        )
         for accent_phrase in self.accent_phrases_hello_hiho:
             moras = accent_phrase.moras
             for mora in moras:
@@ -464,7 +471,9 @@ class TestSynthesisEngine(TestCase):
                 if mora.consonant is not None:
                     self.assertEqual(
                         phoneme_data_list[phoneme_index].phoneme_id,
-                        OjtPhoneme(mora.consonant, phoneme_index, phoneme_index + 1).phoneme_id,
+                        OjtPhoneme(
+                            mora.consonant, phoneme_index, phoneme_index + 1
+                        ).phoneme_id,
                     )
                     phoneme_index += 1
                 self.assertEqual(

--- a/test/test_synthesis_engine.py
+++ b/test/test_synthesis_engine.py
@@ -23,7 +23,7 @@ from voicevox_engine.synthesis_engine.synthesis_engine import (
     unvoiced_mora_phoneme_list,
 )
 
-from .test_acoustic_feature_extractor import is_same_OjtPhoneme
+from .test_acoustic_feature_extractor import is_same_phoneme
 
 TRUE_NUM_PHONEME = 45
 
@@ -39,7 +39,7 @@ def is_same_OjtPhoneme_list(
             return False
         elif p2 is None:  # OjtOhoneme vs None -> not equal
             return False
-        elif is_same_OjtPhoneme(p1, p2):
+        elif is_same_phoneme(p1, p2):
             pass
         else:
             return False
@@ -433,39 +433,43 @@ class TestSynthesisEngine(TestCase):
 
         self.assertEqual(vowel_indexes, [0, 2, 3, 5, 7, 9, 10, 12, 14, 16, 18, 19])
 
-        assert is_same_OjtPhoneme_list(
-            vowel_phoneme_list,
-            [
-                OjtPhoneme(phoneme="pau", start=0, end=1),
-                OjtPhoneme(phoneme="o", start=2, end=3),
-                OjtPhoneme(phoneme="N", start=3, end=4),
-                OjtPhoneme(phoneme="i", start=5, end=6),
-                OjtPhoneme(phoneme="i", start=7, end=8),
-                OjtPhoneme(phoneme="a", start=9, end=10),
-                OjtPhoneme(phoneme="pau", start=10, end=11),
-                OjtPhoneme(phoneme="i", start=12, end=13),
-                OjtPhoneme(phoneme="o", start=14, end=15),
-                OjtPhoneme(phoneme="e", start=16, end=17),
-                OjtPhoneme(phoneme="U", start=18, end=19),
-                OjtPhoneme(phoneme="pau", start=19, end=20),
-            ],
+        self.assertTrue(
+            is_same_OjtPhoneme_list(
+                vowel_phoneme_list,
+                [
+                    OjtPhoneme(phoneme="pau", start=0, end=1),
+                    OjtPhoneme(phoneme="o", start=2, end=3),
+                    OjtPhoneme(phoneme="N", start=3, end=4),
+                    OjtPhoneme(phoneme="i", start=5, end=6),
+                    OjtPhoneme(phoneme="i", start=7, end=8),
+                    OjtPhoneme(phoneme="a", start=9, end=10),
+                    OjtPhoneme(phoneme="pau", start=10, end=11),
+                    OjtPhoneme(phoneme="i", start=12, end=13),
+                    OjtPhoneme(phoneme="o", start=14, end=15),
+                    OjtPhoneme(phoneme="e", start=16, end=17),
+                    OjtPhoneme(phoneme="U", start=18, end=19),
+                    OjtPhoneme(phoneme="pau", start=19, end=20),
+                ],
+            )
         )
-        assert is_same_OjtPhoneme_list(
-            consonant_phoneme_list,
-            [
-                None,
-                OjtPhoneme(phoneme="k", start=1, end=2),
-                None,
-                OjtPhoneme(phoneme="n", start=4, end=5),
-                OjtPhoneme(phoneme="ch", start=6, end=7),
-                OjtPhoneme(phoneme="w", start=8, end=9),
-                None,
-                OjtPhoneme(phoneme="h", start=11, end=12),
-                OjtPhoneme(phoneme="h", start=13, end=14),
-                OjtPhoneme(phoneme="d", start=15, end=16),
-                OjtPhoneme(phoneme="s", start=17, end=18),
-                None,
-            ],
+        self.assertTrue(
+            is_same_OjtPhoneme_list(
+                consonant_phoneme_list,
+                [
+                    None,
+                    OjtPhoneme(phoneme="k", start=1, end=2),
+                    None,
+                    OjtPhoneme(phoneme="n", start=4, end=5),
+                    OjtPhoneme(phoneme="ch", start=6, end=7),
+                    OjtPhoneme(phoneme="w", start=8, end=9),
+                    None,
+                    OjtPhoneme(phoneme="h", start=11, end=12),
+                    OjtPhoneme(phoneme="h", start=13, end=14),
+                    OjtPhoneme(phoneme="d", start=15, end=16),
+                    OjtPhoneme(phoneme="s", start=17, end=18),
+                    None,
+                ],
+            )
         )
 
     def test_pre_process(self):
@@ -476,34 +480,44 @@ class TestSynthesisEngine(TestCase):
         mora_index = 0
         phoneme_index = 1
 
-        assert is_same_OjtPhoneme(phoneme_data_list[0], OjtPhoneme("pau", 0, 1))
+        self.assertTrue(is_same_phoneme(phoneme_data_list[0], OjtPhoneme("pau", 0, 1)))
         for accent_phrase in self.accent_phrases_hello_hiho:
             moras = accent_phrase.moras
             for mora in moras:
                 self.assertEqual(flatten_moras[mora_index], mora)
                 mora_index += 1
                 if mora.consonant is not None:
-                    assert is_same_OjtPhoneme(
-                        phoneme_data_list[phoneme_index],
-                        OjtPhoneme(mora.consonant, phoneme_index, phoneme_index + 1),
+                    self.assertTrue(
+                        is_same_phoneme(
+                            phoneme_data_list[phoneme_index],
+                            OjtPhoneme(
+                                mora.consonant, phoneme_index, phoneme_index + 1
+                            ),
+                        )
                     )
                     phoneme_index += 1
-                assert is_same_OjtPhoneme(
-                    phoneme_data_list[phoneme_index],
-                    OjtPhoneme(mora.vowel, phoneme_index, phoneme_index + 1),
+                self.assertTrue(
+                    is_same_phoneme(
+                        phoneme_data_list[phoneme_index],
+                        OjtPhoneme(mora.vowel, phoneme_index, phoneme_index + 1),
+                    )
                 )
                 phoneme_index += 1
             if accent_phrase.pause_mora:
                 self.assertEqual(flatten_moras[mora_index], accent_phrase.pause_mora)
                 mora_index += 1
-                assert is_same_OjtPhoneme(
-                    phoneme_data_list[phoneme_index],
-                    OjtPhoneme("pau", phoneme_index, phoneme_index + 1),
+                self.assertTrue(
+                    is_same_phoneme(
+                        phoneme_data_list[phoneme_index],
+                        OjtPhoneme("pau", phoneme_index, phoneme_index + 1),
+                    )
                 )
                 phoneme_index += 1
-        assert is_same_OjtPhoneme(
-            phoneme_data_list[phoneme_index],
-            OjtPhoneme("pau", phoneme_index, phoneme_index + 1),
+        self.assertTrue(
+            is_same_phoneme(
+                phoneme_data_list[phoneme_index],
+                OjtPhoneme("pau", phoneme_index, phoneme_index + 1),
+            )
         )
 
     def test_replace_phoneme_length(self):

--- a/test/test_synthesis_engine.py
+++ b/test/test_synthesis_engine.py
@@ -32,6 +32,9 @@ def is_same_OjtPhoneme_list(
     p1s: list[OjtPhoneme | None], p2s: list[OjtPhoneme | None]
 ) -> bool:
     """2つのOjtPhonemeリストで全要素ペアが同じ`.phoneme`/`.start`/`.end`を持つ"""
+    if len(p1s) != len(p2s):
+      return False
+
     for p1, p2 in zip(p1s, p2s):
         if p1 is None and p2 is None:  # None vs None -> equal
             pass

--- a/test/test_synthesis_engine.py
+++ b/test/test_synthesis_engine.py
@@ -31,7 +31,7 @@ TRUE_NUM_PHONEME = 45
 def is_same_OjtPhoneme_list(
     p1s: list[OjtPhoneme | None], p2s: list[OjtPhoneme | None]
 ) -> bool:
-    """2つのOjtPhonemeが同じ`.phoneme`/`.start`/`.end`を持つ"""
+    """2つのOjtPhonemeリストで全要素ペアが同じ`.phoneme`/`.start`/`.end`を持つ"""
     for p1, p2 in zip(p1s, p2s):
         if p1 is None and p2 is None:  # None vs None -> equal
             pass
@@ -39,7 +39,7 @@ def is_same_OjtPhoneme_list(
             return False
         elif p2 is None:  # OjtOhoneme vs None -> not equal
             return False
-        elif p1.phoneme == p2.phoneme and p1.start == p2.start and p1.end == p2.end:
+        elif is_same_OjtPhoneme(p1, p2):
             pass
         else:
             return False

--- a/test/test_synthesis_engine.py
+++ b/test/test_synthesis_engine.py
@@ -413,36 +413,36 @@ class TestSynthesisEngine(TestCase):
 
         self.assertEqual(vowel_indexes, [0, 2, 3, 5, 7, 9, 10, 12, 14, 16, 18, 19])
         self.assertEqual(
-            vowel_phoneme_list,
+            list(map(lambda p: p.phoneme_id, vowel_phoneme_list)),
             [
-                OjtPhoneme(phoneme="pau", start=0, end=1),
-                OjtPhoneme(phoneme="o", start=2, end=3),
-                OjtPhoneme(phoneme="N", start=3, end=4),
-                OjtPhoneme(phoneme="i", start=5, end=6),
-                OjtPhoneme(phoneme="i", start=7, end=8),
-                OjtPhoneme(phoneme="a", start=9, end=10),
-                OjtPhoneme(phoneme="pau", start=10, end=11),
-                OjtPhoneme(phoneme="i", start=12, end=13),
-                OjtPhoneme(phoneme="o", start=14, end=15),
-                OjtPhoneme(phoneme="e", start=16, end=17),
-                OjtPhoneme(phoneme="U", start=18, end=19),
-                OjtPhoneme(phoneme="pau", start=19, end=20),
+                OjtPhoneme(phoneme="pau", start=0, end=1).phoneme_id,
+                OjtPhoneme(phoneme="o", start=2, end=3).phoneme_id,
+                OjtPhoneme(phoneme="N", start=3, end=4).phoneme_id,
+                OjtPhoneme(phoneme="i", start=5, end=6).phoneme_id,
+                OjtPhoneme(phoneme="i", start=7, end=8).phoneme_id,
+                OjtPhoneme(phoneme="a", start=9, end=10).phoneme_id,
+                OjtPhoneme(phoneme="pau", start=10, end=11).phoneme_id,
+                OjtPhoneme(phoneme="i", start=12, end=13).phoneme_id,
+                OjtPhoneme(phoneme="o", start=14, end=15).phoneme_id,
+                OjtPhoneme(phoneme="e", start=16, end=17).phoneme_id,
+                OjtPhoneme(phoneme="U", start=18, end=19).phoneme_id,
+                OjtPhoneme(phoneme="pau", start=19, end=20).phoneme_id,
             ],
         )
         self.assertEqual(
-            consonant_phoneme_list,
+            list(map(lambda p: p.phoneme_id if p is not None else p, consonant_phoneme_list)),
             [
                 None,
-                OjtPhoneme(phoneme="k", start=1, end=2),
+                OjtPhoneme(phoneme="k", start=1, end=2).phoneme_id,
                 None,
-                OjtPhoneme(phoneme="n", start=4, end=5),
-                OjtPhoneme(phoneme="ch", start=6, end=7),
-                OjtPhoneme(phoneme="w", start=8, end=9),
+                OjtPhoneme(phoneme="n", start=4, end=5).phoneme_id,
+                OjtPhoneme(phoneme="ch", start=6, end=7).phoneme_id,
+                OjtPhoneme(phoneme="w", start=8, end=9).phoneme_id,
                 None,
-                OjtPhoneme(phoneme="h", start=11, end=12),
-                OjtPhoneme(phoneme="h", start=13, end=14),
-                OjtPhoneme(phoneme="d", start=15, end=16),
-                OjtPhoneme(phoneme="s", start=17, end=18),
+                OjtPhoneme(phoneme="h", start=11, end=12).phoneme_id,
+                OjtPhoneme(phoneme="h", start=13, end=14).phoneme_id,
+                OjtPhoneme(phoneme="d", start=15, end=16).phoneme_id,
+                OjtPhoneme(phoneme="s", start=17, end=18).phoneme_id,
                 None,
             ],
         )
@@ -455,7 +455,7 @@ class TestSynthesisEngine(TestCase):
         mora_index = 0
         phoneme_index = 1
 
-        self.assertEqual(phoneme_data_list[0], OjtPhoneme("pau", 0, 1))
+        self.assertEqual(phoneme_data_list[0].phoneme_id, OjtPhoneme("pau", 0, 1).phoneme_id)
         for accent_phrase in self.accent_phrases_hello_hiho:
             moras = accent_phrase.moras
             for mora in moras:
@@ -463,26 +463,26 @@ class TestSynthesisEngine(TestCase):
                 mora_index += 1
                 if mora.consonant is not None:
                     self.assertEqual(
-                        phoneme_data_list[phoneme_index],
-                        OjtPhoneme(mora.consonant, phoneme_index, phoneme_index + 1),
+                        phoneme_data_list[phoneme_index].phoneme_id,
+                        OjtPhoneme(mora.consonant, phoneme_index, phoneme_index + 1).phoneme_id,
                     )
                     phoneme_index += 1
                 self.assertEqual(
-                    phoneme_data_list[phoneme_index],
-                    OjtPhoneme(mora.vowel, phoneme_index, phoneme_index + 1),
+                    phoneme_data_list[phoneme_index].phoneme_id,
+                    OjtPhoneme(mora.vowel, phoneme_index, phoneme_index + 1).phoneme_id,
                 )
                 phoneme_index += 1
             if accent_phrase.pause_mora:
                 self.assertEqual(flatten_moras[mora_index], accent_phrase.pause_mora)
                 mora_index += 1
                 self.assertEqual(
-                    phoneme_data_list[phoneme_index],
-                    OjtPhoneme("pau", phoneme_index, phoneme_index + 1),
+                    phoneme_data_list[phoneme_index].phoneme_id,
+                    OjtPhoneme("pau", phoneme_index, phoneme_index + 1).phoneme_id,
                 )
                 phoneme_index += 1
         self.assertEqual(
-            phoneme_data_list[phoneme_index],
-            OjtPhoneme("pau", phoneme_index, phoneme_index + 1),
+            phoneme_data_list[phoneme_index].phoneme_id,
+            OjtPhoneme("pau", phoneme_index, phoneme_index + 1).phoneme_id,
         )
 
     def test_replace_phoneme_length(self):

--- a/test/test_synthesis_engine.py
+++ b/test/test_synthesis_engine.py
@@ -28,12 +28,12 @@ from .test_acoustic_feature_extractor import is_same_phoneme
 TRUE_NUM_PHONEME = 45
 
 
-def is_same_OjtPhoneme_list(
+def is_same_ojt_phoneme_list(
     p1s: list[OjtPhoneme | None], p2s: list[OjtPhoneme | None]
 ) -> bool:
     """2つのOjtPhonemeリストで全要素ペアが同じ`.phoneme`/`.start`/`.end`を持つ"""
     if len(p1s) != len(p2s):
-      return False
+        return False
 
     for p1, p2 in zip(p1s, p2s):
         if p1 is None and p2 is None:  # None vs None -> equal
@@ -437,7 +437,7 @@ class TestSynthesisEngine(TestCase):
         self.assertEqual(vowel_indexes, [0, 2, 3, 5, 7, 9, 10, 12, 14, 16, 18, 19])
 
         self.assertTrue(
-            is_same_OjtPhoneme_list(
+            is_same_ojt_phoneme_list(
                 vowel_phoneme_list,
                 [
                     OjtPhoneme(phoneme="pau", start=0, end=1),
@@ -456,7 +456,7 @@ class TestSynthesisEngine(TestCase):
             )
         )
         self.assertTrue(
-            is_same_OjtPhoneme_list(
+            is_same_ojt_phoneme_list(
                 consonant_phoneme_list,
                 [
                     None,

--- a/test/test_synthesis_engine.py
+++ b/test/test_synthesis_engine.py
@@ -23,7 +23,27 @@ from voicevox_engine.synthesis_engine.synthesis_engine import (
     unvoiced_mora_phoneme_list,
 )
 
+from .test_acoustic_feature_extractor import is_same_OjtPhoneme
+
 TRUE_NUM_PHONEME = 45
+
+
+def is_same_OjtPhoneme_list(
+    p1s: list[OjtPhoneme | None], p2s: list[OjtPhoneme | None]
+) -> bool:
+    """2つのOjtPhonemeが同じ`.phoneme`/`.start`/`.end`を持つ"""
+    for p1, p2 in zip(p1s, p2s):
+        if p1 is None and p2 is None:  # None vs None -> equal
+            pass
+        elif p1 is None:  # None vs OjtOhoneme -> not equal
+            return False
+        elif p2 is None:  # OjtOhoneme vs None -> not equal
+            return False
+        elif p1.phoneme == p2.phoneme and p1.start == p2.start and p1.end == p2.end:
+            pass
+        else:
+            return False
+    return True
 
 
 def yukarin_s_mock(length: int, phoneme_list: numpy.ndarray, style_id: numpy.ndarray):
@@ -412,42 +432,38 @@ class TestSynthesisEngine(TestCase):
         )
 
         self.assertEqual(vowel_indexes, [0, 2, 3, 5, 7, 9, 10, 12, 14, 16, 18, 19])
-        self.assertEqual(
-            list(map(lambda p: p.phoneme_id, vowel_phoneme_list)),
+
+        assert is_same_OjtPhoneme_list(
+            vowel_phoneme_list,
             [
-                OjtPhoneme(phoneme="pau", start=0, end=1).phoneme_id,
-                OjtPhoneme(phoneme="o", start=2, end=3).phoneme_id,
-                OjtPhoneme(phoneme="N", start=3, end=4).phoneme_id,
-                OjtPhoneme(phoneme="i", start=5, end=6).phoneme_id,
-                OjtPhoneme(phoneme="i", start=7, end=8).phoneme_id,
-                OjtPhoneme(phoneme="a", start=9, end=10).phoneme_id,
-                OjtPhoneme(phoneme="pau", start=10, end=11).phoneme_id,
-                OjtPhoneme(phoneme="i", start=12, end=13).phoneme_id,
-                OjtPhoneme(phoneme="o", start=14, end=15).phoneme_id,
-                OjtPhoneme(phoneme="e", start=16, end=17).phoneme_id,
-                OjtPhoneme(phoneme="U", start=18, end=19).phoneme_id,
-                OjtPhoneme(phoneme="pau", start=19, end=20).phoneme_id,
+                OjtPhoneme(phoneme="pau", start=0, end=1),
+                OjtPhoneme(phoneme="o", start=2, end=3),
+                OjtPhoneme(phoneme="N", start=3, end=4),
+                OjtPhoneme(phoneme="i", start=5, end=6),
+                OjtPhoneme(phoneme="i", start=7, end=8),
+                OjtPhoneme(phoneme="a", start=9, end=10),
+                OjtPhoneme(phoneme="pau", start=10, end=11),
+                OjtPhoneme(phoneme="i", start=12, end=13),
+                OjtPhoneme(phoneme="o", start=14, end=15),
+                OjtPhoneme(phoneme="e", start=16, end=17),
+                OjtPhoneme(phoneme="U", start=18, end=19),
+                OjtPhoneme(phoneme="pau", start=19, end=20),
             ],
         )
-        self.assertEqual(
-            list(
-                map(
-                    lambda p: p.phoneme_id if p is not None else p,
-                    consonant_phoneme_list,
-                )
-            ),
+        assert is_same_OjtPhoneme_list(
+            consonant_phoneme_list,
             [
                 None,
-                OjtPhoneme(phoneme="k", start=1, end=2).phoneme_id,
+                OjtPhoneme(phoneme="k", start=1, end=2),
                 None,
-                OjtPhoneme(phoneme="n", start=4, end=5).phoneme_id,
-                OjtPhoneme(phoneme="ch", start=6, end=7).phoneme_id,
-                OjtPhoneme(phoneme="w", start=8, end=9).phoneme_id,
+                OjtPhoneme(phoneme="n", start=4, end=5),
+                OjtPhoneme(phoneme="ch", start=6, end=7),
+                OjtPhoneme(phoneme="w", start=8, end=9),
                 None,
-                OjtPhoneme(phoneme="h", start=11, end=12).phoneme_id,
-                OjtPhoneme(phoneme="h", start=13, end=14).phoneme_id,
-                OjtPhoneme(phoneme="d", start=15, end=16).phoneme_id,
-                OjtPhoneme(phoneme="s", start=17, end=18).phoneme_id,
+                OjtPhoneme(phoneme="h", start=11, end=12),
+                OjtPhoneme(phoneme="h", start=13, end=14),
+                OjtPhoneme(phoneme="d", start=15, end=16),
+                OjtPhoneme(phoneme="s", start=17, end=18),
                 None,
             ],
         )
@@ -460,38 +476,34 @@ class TestSynthesisEngine(TestCase):
         mora_index = 0
         phoneme_index = 1
 
-        self.assertEqual(
-            phoneme_data_list[0].phoneme_id, OjtPhoneme("pau", 0, 1).phoneme_id
-        )
+        assert is_same_OjtPhoneme(phoneme_data_list[0], OjtPhoneme("pau", 0, 1))
         for accent_phrase in self.accent_phrases_hello_hiho:
             moras = accent_phrase.moras
             for mora in moras:
                 self.assertEqual(flatten_moras[mora_index], mora)
                 mora_index += 1
                 if mora.consonant is not None:
-                    self.assertEqual(
-                        phoneme_data_list[phoneme_index].phoneme_id,
-                        OjtPhoneme(
-                            mora.consonant, phoneme_index, phoneme_index + 1
-                        ).phoneme_id,
+                    assert is_same_OjtPhoneme(
+                        phoneme_data_list[phoneme_index],
+                        OjtPhoneme(mora.consonant, phoneme_index, phoneme_index + 1),
                     )
                     phoneme_index += 1
-                self.assertEqual(
-                    phoneme_data_list[phoneme_index].phoneme_id,
-                    OjtPhoneme(mora.vowel, phoneme_index, phoneme_index + 1).phoneme_id,
+                assert is_same_OjtPhoneme(
+                    phoneme_data_list[phoneme_index],
+                    OjtPhoneme(mora.vowel, phoneme_index, phoneme_index + 1),
                 )
                 phoneme_index += 1
             if accent_phrase.pause_mora:
                 self.assertEqual(flatten_moras[mora_index], accent_phrase.pause_mora)
                 mora_index += 1
-                self.assertEqual(
-                    phoneme_data_list[phoneme_index].phoneme_id,
-                    OjtPhoneme("pau", phoneme_index, phoneme_index + 1).phoneme_id,
+                assert is_same_OjtPhoneme(
+                    phoneme_data_list[phoneme_index],
+                    OjtPhoneme("pau", phoneme_index, phoneme_index + 1),
                 )
                 phoneme_index += 1
-        self.assertEqual(
-            phoneme_data_list[phoneme_index].phoneme_id,
-            OjtPhoneme("pau", phoneme_index, phoneme_index + 1).phoneme_id,
+        assert is_same_OjtPhoneme(
+            phoneme_data_list[phoneme_index],
+            OjtPhoneme("pau", phoneme_index, phoneme_index + 1),
         )
 
     def test_replace_phoneme_length(self):

--- a/voicevox_engine/acoustic_feature_extractor.py
+++ b/voicevox_engine/acoustic_feature_extractor.py
@@ -82,11 +82,6 @@ class OjtPhoneme:
     def __repr__(self):
         return f"Phoneme(phoneme='{self.phoneme}', start={self.start}, end={self.end})"
 
-    def __eq__(self, o: object):
-        return isinstance(o, OjtPhoneme) and (
-            self.phoneme == o.phoneme and self.start == o.start and self.end == o.end
-        )
-
     @property
     def phoneme_id(self):
         """

--- a/voicevox_engine/acoustic_feature_extractor.py
+++ b/voicevox_engine/acoustic_feature_extractor.py
@@ -82,6 +82,10 @@ class OjtPhoneme:
     def __repr__(self):
         return f"Phoneme(phoneme='{self.phoneme}', start={self.start}, end={self.end})"
 
+    def __eq__(self, o: object):
+        """Deprecated."""
+        raise NotImplementedError
+
     @property
     def phoneme_id(self):
         """


### PR DESCRIPTION
## 内容
`OjtPhoneme.__eq__()` の廃止  

## 関連 Issue
resolve #787  

## 廃止ロジック
（issueで述べた通り、特殊 `__eq__()` の廃止は機械的検出が難しいです。よって「`OjtPhoneme.__eq__()` は問題なく廃止できる」ことの確認手順を以下に記します。必要であればレビュー時にご利用ください。）  

`OjtPhoneme` のインスタンス化は `pre_process()` 内の[一箇所](https://github.com/VOICEVOX/voicevox_engine/blob/95fc58638e883912d5999ba0a7ec74330a5533a5/voicevox_engine/synthesis_engine/synthesis_engine.py#L106)のみ。  
`pre_process()` は以下の3箇所でコール。  

① `.replace_phoneme_length()`:  
https://github.com/VOICEVOX/voicevox_engine/blob/95fc58638e883912d5999ba0a7ec74330a5533a5/voicevox_engine/synthesis_engine/synthesis_engine.py#L262

② `.replace_mora_pitch()`:  
https://github.com/VOICEVOX/voicevox_engine/blob/95fc58638e883912d5999ba0a7ec74330a5533a5/voicevox_engine/synthesis_engine/synthesis_engine.py#L315

③ `._synthesis_impl()`:  
https://github.com/VOICEVOX/voicevox_engine/blob/95fc58638e883912d5999ba0a7ec74330a5533a5/voicevox_engine/synthesis_engine/synthesis_engine.py#L451

`OjtPhoneme` インスタンスを含んだ戻り値である `phoneme_data_list` は以下のいずれかの方法で利用される:

- A. 返り値 `consonant_phoneme_data_list`/`vowel_phoneme_data_list` を利用する `split_mora()` への引数
- B. 返り値 `vowel_indexes_data`のみを利用する `split_mora()` への引数
- C. `.phoneme_id` アクセッサによる音素ID取り出し  

①ではBとC、②ではA、③ではBとCの方法で利用されている。  

B利用では音素IDのEqualチェックがなされているが、`OjtPhoneme` のEqualチェックは不使用。よって影響無し。  
https://github.com/VOICEVOX/voicevox_engine/blob/95fc58638e883912d5999ba0a7ec74330a5533a5/voicevox_engine/synthesis_engine/synthesis_engine.py#L64-L66

C利用では音素IDを取り出すだけなので、`OjtPhoneme` のEqualチェックは不使用。よって影響無し。  
https://github.com/VOICEVOX/voicevox_engine/blob/95fc58638e883912d5999ba0a7ec74330a5533a5/voicevox_engine/synthesis_engine/synthesis_engine.py#L268-L270

ゆえに検討すべきなのは②のA利用 (`.replace_mora_pitch()`内における、`consonant_phoneme_data_list`/`vowel_phoneme_data_list` を利用する `split_mora()`) のみ。  

まず `split_mora()` 内では音素IDに基づく `OjtPhoneme` の母音/子音分割がなされているだけなのでEqualチェックは不使用。  

次に返り値である `consonant_phoneme_data_list` の利用時には、`OjtPhoneme` の***Equalチェックをcallしている***。  
https://github.com/VOICEVOX/voicevox_engine/blob/95fc58638e883912d5999ba0a7ec74330a5533a5/voicevox_engine/synthesis_engine/synthesis_engine.py#L401-L403
しかし単なるNoneチェックであるため、特殊`__eq__()` であってもbuilt-in `__eq__()` であっても結果は同じ。  
以降では音素ID取り出しに使われるだけ。よって影響無し。  

最後の `vowel_phoneme_data_list` は2箇所で利用。  
1つ目は音素IDを取り出すだけなので、`OjtPhoneme` のEqualチェックは不使用。よって影響無し。  
https://github.com/VOICEVOX/voicevox_engine/blob/95fc58638e883912d5999ba0a7ec74330a5533a5/voicevox_engine/synthesis_engine/synthesis_engine.py#L398

2つ目は音素IDのEqualチェックがなされているが、`OjtPhoneme` のEqualチェックは不使用。よって影響無し。 
https://github.com/VOICEVOX/voicevox_engine/blob/95fc58638e883912d5999ba0a7ec74330a5533a5/voicevox_engine/synthesis_engine/synthesis_engine.py#L422-L423

これらの調査により、全ての `OjtPhoneme` インスタンスで特殊 `__eq__()` が不要だとわかる。  
よって本リファクタリングは成立する。  

## その他
このように変更影響検討の労力が激増するため、built-inメソッドの変更は厳に慎むべきと私は考えています（別プロジェクトでも同様の経験あり）。  