### PR TITLE
FIX: arm64環境でDockerが動作しない問題へのワークアラウンド

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -185,6 +185,8 @@ WORKDIR /opt/voicevox_engine
 
 # ca-certificates: pyopenjtalk dictionary download
 # build-essential: pyopenjtalk local build
+# libsndfile1: soundfile shared object for arm64
+# ref: https://github.com/VOICEVOX/voicevox_engine/issues/770
 RUN <<EOF
     set -eux
 
@@ -195,7 +197,8 @@ RUN <<EOF
         cmake \
         ca-certificates \
         build-essential \
-        gosu
+        gosu \
+        libsndfile1
     apt-get clean
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
 ## 内容

 arm64環境でDockerが動作しない問題への一時的な対処を行います。

soundfile側でarm64のバイナリを配布することが最も良いことだと思います。
しかし作業が進んでいる様子がなく0.15リリースまでに間に合わないような気がしますので先に対処を行います。

## 関連 Issue

- ref #770