### PR TITLE
整理: `.default_sampling_rate` 移植

### DIFF
--- a/test/test_synthesis_engine.py
+++ b/test/test_synthesis_engine.py
@@ -109,6 +109,7 @@ def decode_mock(
 
 
 class MockCore:
+    default_sampling_rate = 24000
     yukarin_s_forward = Mock(side_effect=yukarin_s_mock)
     yukarin_sa_forward = Mock(side_effect=yukarin_sa_mock)
     decode_forward = Mock(side_effect=decode_mock)

--- a/test/test_synthesis_engine_base.py
+++ b/test/test_synthesis_engine_base.py
@@ -169,6 +169,7 @@ def create_mock_query(accent_phrases):
 
 
 class MockCore:
+    default_sampling_rate = 24000
     yukarin_s_forward = Mock(side_effect=yukarin_s_mock)
     yukarin_sa_forward = Mock(side_effect=yukarin_sa_mock)
     decode_forward = Mock(side_effect=decode_mock)

--- a/voicevox_engine/dev/synthesis_engine/mock.py
+++ b/voicevox_engine/dev/synthesis_engine/mock.py
@@ -27,7 +27,10 @@ class MockSynthesisEngine(SynthesisEngineBase):
 
         self._speakers = speakers
         self._supported_devices = supported_devices
-        self.default_sampling_rate = 24000
+
+    @property
+    def default_sampling_rate(self) -> int:
+        return 24000
 
     @property
     def speakers(self) -> str:

--- a/voicevox_engine/synthesis_engine/core_wrapper.py
+++ b/voicevox_engine/synthesis_engine/core_wrapper.py
@@ -357,6 +357,8 @@ class CoreWrapper:
         load_all_models: bool = False,
     ) -> None:
 
+        self.default_sampling_rate = 24000
+
         self.core = load_core(core_dir, use_gpu)
 
         self.core.initialize.restype = c_bool

--- a/voicevox_engine/synthesis_engine/synthesis_engine.py
+++ b/voicevox_engine/synthesis_engine/synthesis_engine.py
@@ -234,7 +234,10 @@ class SynthesisEngine(SynthesisEngineBase):
         super().__init__()
         self.core = core
         self.mutex = threading.Lock()
-        self.default_sampling_rate = 24000
+
+    @property
+    def default_sampling_rate(self) -> int:
+        return self.core.default_sampling_rate
 
     @property
     def speakers(self) -> str:

--- a/voicevox_engine/synthesis_engine/synthesis_engine_base.py
+++ b/voicevox_engine/synthesis_engine/synthesis_engine_base.py
@@ -80,6 +80,11 @@ def full_context_label_moras_to_moras(
 
 
 class SynthesisEngineBase(metaclass=ABCMeta):
+    @property
+    @abstractmethod
+    def default_sampling_rate(self) -> int:
+        raise NotImplementedError
+
     # FIXME: jsonではなくModelを返すようにする
     @property
     @abstractmethod


### PR DESCRIPTION
## 内容
`.default_sampling_rate` の `SynthesisEngine` → `CoreWrapper` 移植によるリファクタリング。  

## 関連 Issue
resolve #808 