### PR TITLE
整理: 前後空白挿入の統合

### DIFF
--- a/test/test_synthesis_engine.py
+++ b/test/test_synthesis_engine.py
@@ -171,21 +171,19 @@ def _gen_mora(
 def test_calc_frame_per_phoneme():
     """Test `calc_frame_per_phoneme`."""
     # Inputs
-    query = _gen_query(
-        speedScale=2.0,
-        prePhonemeLength=2 * 0.01067,  # 0.01067 [sec/frame]
-        postPhonemeLength=6 * 0.01067,
-    )
+    query = _gen_query(speedScale=2.0)
     moras = [
+        _gen_mora(" ", None, None, " ", 2 * 0.01067, 0.0),  # 0.01067 [sec/frame]
         _gen_mora("コ", "k", 2 * 0.01067, "o", 4 * 0.01067, 0.0),
         _gen_mora("ン", None, None, "N", 4 * 0.01067, 0.0),
         _gen_mora("、", None, None, "pau", 2 * 0.01067, 0.0),
         _gen_mora("ヒ", "h", 2 * 0.01067, "i", 4 * 0.01067, 0.0),
         _gen_mora("ホ", "h", 4 * 0.01067, "O", 2 * 0.01067, 0.0),
+        _gen_mora(" ", None, None, " ", 6 * 0.01067, 0.0),
     ]
 
     # Expects
-    #                      Pre k  o  N pau h  i  h  O Pst
+    #                        Pre k  o  N pau h  i  h  O Pst
     true_frame_per_phoneme = [1, 1, 2, 2, 1, 1, 2, 2, 1, 3]
     true_frame_per_phoneme = numpy.array(true_frame_per_phoneme, dtype=numpy.int32)
 

--- a/test/test_synthesis_engine.py
+++ b/test/test_synthesis_engine.py
@@ -16,8 +16,8 @@ from voicevox_engine.synthesis_engine.synthesis_engine import (
     calc_frame_per_phoneme,
     calc_frame_phoneme,
     calc_frame_pitch,
-    change_silence,
     mora_phoneme_list,
+    pad_with_silence,
     pre_process,
     split_mora,
     to_flatten_moras,
@@ -169,8 +169,8 @@ def _gen_mora(
     )
 
 
-def test_change_silence():
-    """Test `change_silence`."""
+def test_pad_with_silence():
+    """Test `pad_with_silence`."""
     # Inputs
     query = _gen_query(prePhonemeLength=2 * 0.01067, postPhonemeLength=6 * 0.01067)
     moras = [
@@ -185,7 +185,7 @@ def test_change_silence():
     ]
 
     # Outputs
-    moras_with_silence = change_silence(moras, query)
+    moras_with_silence = pad_with_silence(moras, query)
 
     assert moras_with_silence == true_moras_with_silence
 
@@ -321,7 +321,7 @@ def test_feat_to_framescale():
     assert true_frame_per_phoneme.shape[0] == len(phoneme_data_list), "Prerequisites"
 
     # Outputs
-    flatten_moras = change_silence(flatten_moras, query)
+    flatten_moras = pad_with_silence(flatten_moras, query)
     frame_per_phoneme = calc_frame_per_phoneme(query, flatten_moras)
     f0 = calc_frame_pitch(query, flatten_moras, phoneme_data_list, frame_per_phoneme)
     frame_phoneme = calc_frame_phoneme(phoneme_data_list, frame_per_phoneme)

--- a/test/test_synthesis_engine.py
+++ b/test/test_synthesis_engine.py
@@ -179,9 +179,9 @@ def test_pad_with_silence():
 
     # Expects
     true_moras_with_silence = [
-        _gen_mora(" ", None, None, "sil", 2 * 0.01067, 0.0),
+        _gen_mora("　", None, None, "sil", 2 * 0.01067, 0.0),
         _gen_mora("ヒ", "h", 2 * 0.01067, "i", 4 * 0.01067, 100.0),
-        _gen_mora(" ", None, None, "sil", 6 * 0.01067, 0.0),
+        _gen_mora("　", None, None, "sil", 6 * 0.01067, 0.0),
     ]
 
     # Outputs
@@ -195,13 +195,13 @@ def test_calc_frame_per_phoneme():
     # Inputs
     query = _gen_query(speedScale=2.0)
     moras = [
-        _gen_mora(" ", None, None, " ", 2 * 0.01067, 0.0),  # 0.01067 [sec/frame]
+        _gen_mora("　", None, None, "　", 2 * 0.01067, 0.0),  # 0.01067 [sec/frame]
         _gen_mora("コ", "k", 2 * 0.01067, "o", 4 * 0.01067, 0.0),
         _gen_mora("ン", None, None, "N", 4 * 0.01067, 0.0),
         _gen_mora("、", None, None, "pau", 2 * 0.01067, 0.0),
         _gen_mora("ヒ", "h", 2 * 0.01067, "i", 4 * 0.01067, 0.0),
         _gen_mora("ホ", "h", 4 * 0.01067, "O", 2 * 0.01067, 0.0),
-        _gen_mora(" ", None, None, " ", 6 * 0.01067, 0.0),
+        _gen_mora("　", None, None, "　", 6 * 0.01067, 0.0),
     ]
 
     # Expects
@@ -220,13 +220,13 @@ def test_calc_frame_pitch():
     # Inputs
     query = _gen_query(pitchScale=2.0, intonationScale=0.5)
     moras = [
-        _gen_mora(" ", None, None, " ", 0.0, 0.0),
+        _gen_mora("　", None, None, "　", 0.0, 0.0),
         _gen_mora("コ", "k", 0.0, "o", 0.0, 50.0),
         _gen_mora("ン", None, None, "N", 0.0, 50.0),
         _gen_mora("、", None, None, "pau", 0.0, 0.0),
         _gen_mora("ヒ", "h", 0.0, "i", 0.0, 125.0),
         _gen_mora("ホ", "h", 0.0, "O", 0.0, 0.0),
-        _gen_mora(" ", None, None, " ", 0.0, 0.0),
+        _gen_mora("　", None, None, "　", 0.0, 0.0),
     ]
     phoneme_str = "pau k o N pau h i h O pau"
     phonemes = [OjtPhoneme(p, 0, 0) for p in phoneme_str.split()]

--- a/voicevox_engine/synthesis_engine/synthesis_engine.py
+++ b/voicevox_engine/synthesis_engine/synthesis_engine.py
@@ -128,9 +128,9 @@ def change_silence(moras: list[Mora], query: AudioQuery) -> list[Mora]:
     moras : List[Mora]
         前後無音が付加されたモーラ時系列
     """
-    silence_moras_head = [generate_silence_mora(query.prePhonemeLength)]
-    silence_moras_tail = [generate_silence_mora(query.postPhonemeLength)]
-    moras = silence_moras_head + moras + silence_moras_tail
+    pre_silence_moras = [generate_silence_mora(query.prePhonemeLength)]
+    post_silence_moras = [generate_silence_mora(query.postPhonemeLength)]
+    moras = pre_silence_moras + moras + post_silence_moras
     return moras
 
 

--- a/voicevox_engine/synthesis_engine/synthesis_engine.py
+++ b/voicevox_engine/synthesis_engine/synthesis_engine.py
@@ -110,7 +110,7 @@ def pre_process(
     return flatten_moras, phoneme_data_list
 
 
-def silence_mora(length: float) -> Mora:
+def generate_silence_mora(length: float) -> Mora:
     """無音モーラの生成"""
     return Mora(text=" ", vowel="sil", vowel_length=length, pitch=0.0)
 
@@ -128,8 +128,8 @@ def change_silence(moras: list[Mora], query: AudioQuery) -> list[Mora]:
     moras : List[Mora]
         前後無音が付加されたモーラ時系列
     """
-    silence_moras_head = [silence_mora(query.prePhonemeLength)]
-    silence_moras_tail = [silence_mora(query.postPhonemeLength)]
+    silence_moras_head = [generate_silence_mora(query.prePhonemeLength)]
+    silence_moras_tail = [generate_silence_mora(query.postPhonemeLength)]
     moras = silence_moras_head + moras + silence_moras_tail
     return moras
 

--- a/voicevox_engine/synthesis_engine/synthesis_engine.py
+++ b/voicevox_engine/synthesis_engine/synthesis_engine.py
@@ -89,9 +89,9 @@ def pre_process(
     Returns
     -------
     flatten_moras : List[Mora]
-        AccentPhraseモデルのリスト内に含まれるすべてのMoraをリスト化したものを返す
+        モーラ時系列（前後の無音含まない）
     phoneme_data_list : List[OjtPhoneme]
-        flatten_morasから取り出したすべてのPhonemeをOjtPhonemeに変換したものを返す
+        音素時系列（前後の無音含む）
     """
     flatten_moras = to_flatten_moras(accent_phrases)
 
@@ -479,7 +479,7 @@ class SynthesisEngine(SynthesisEngineBase):
         # モデルがロードされていない場合はロードする
         self.initialize_style_id_synthesis(style_id, skip_reinit=True)
         # phoneme
-        # AccentPhraseをすべてMoraおよびOjtPhonemeの形に分解し、処理可能な形にする
+        # 無音無しモーラ時系列 / 無音有り音素時系列
         flatten_moras, phoneme_data_list = pre_process(query.accent_phrases)
 
         frame_per_phoneme = calc_frame_per_phoneme(query, flatten_moras)

--- a/voicevox_engine/synthesis_engine/synthesis_engine.py
+++ b/voicevox_engine/synthesis_engine/synthesis_engine.py
@@ -89,9 +89,9 @@ def pre_process(
     Returns
     -------
     flatten_moras : List[Mora]
-        モーラ時系列（前後の無音含まない）
+        モーラ列（前後の無音含まない）
     phoneme_data_list : List[OjtPhoneme]
-        音素時系列（前後の無音含む）
+        音素列（前後の無音含む）
     """
     flatten_moras = to_flatten_moras(accent_phrases)
 
@@ -112,7 +112,7 @@ def pre_process(
 
 def generate_silence_mora(length: float) -> Mora:
     """無音モーラの生成"""
-    return Mora(text=" ", vowel="sil", vowel_length=length, pitch=0.0)
+    return Mora(text="　", vowel="sil", vowel_length=length, pitch=0.0)
 
 
 def pad_with_silence(moras: list[Mora], query: AudioQuery) -> list[Mora]:

--- a/voicevox_engine/synthesis_engine/synthesis_engine.py
+++ b/voicevox_engine/synthesis_engine/synthesis_engine.py
@@ -115,7 +115,7 @@ def generate_silence_mora(length: float) -> Mora:
     return Mora(text=" ", vowel="sil", vowel_length=length, pitch=0.0)
 
 
-def change_silence(moras: list[Mora], query: AudioQuery) -> list[Mora]:
+def pad_with_silence(moras: list[Mora], query: AudioQuery) -> list[Mora]:
     """モーラ列の先頭/最後尾へqueryに基づいた無音モーラを追加
     Parameters
     ----------
@@ -504,7 +504,7 @@ class SynthesisEngine(SynthesisEngineBase):
         # AccentPhraseをすべてMoraおよびOjtPhonemeの形に分解し、処理可能な形にする
         flatten_moras, phoneme_data_list = pre_process(query.accent_phrases)
 
-        flatten_moras = change_silence(flatten_moras, query)
+        flatten_moras = pad_with_silence(flatten_moras, query)
         frame_per_phoneme = calc_frame_per_phoneme(query, flatten_moras)
         f0 = calc_frame_pitch(
             query, flatten_moras, phoneme_data_list, frame_per_phoneme

--- a/voicevox_engine/synthesis_engine/synthesis_engine.py
+++ b/voicevox_engine/synthesis_engine/synthesis_engine.py
@@ -187,15 +187,15 @@ def calc_frame_pitch(
     phonemes : List[OjtPhoneme]
         音素列
     frame_per_phoneme: NDArray
-        音素（前後の無音含む）あたりのフレーム長。端数丸め。
+        音素あたりのフレーム長。端数丸め。
     Returns
     -------
     frame_f0 : NDArray[]
         フレームごとの基本周波数系列
     """
     # TODO: Better function name (c.f. VOICEVOX/voicevox_engine#790)
-    # モーラ（前後の無音含む）ごとの基本周波数
-    f0 = numpy.array([0] + [mora.pitch for mora in moras] + [0], dtype=numpy.float32)
+    # モーラごとの基本周波数
+    f0 = numpy.array([mora.pitch for mora in moras], dtype=numpy.float32)
 
     # 音高スケールによる補正
     f0 *= 2**query.pitchScale
@@ -499,14 +499,14 @@ class SynthesisEngine(SynthesisEngineBase):
         """
         # モデルがロードされていない場合はロードする
         self.initialize_style_id_synthesis(style_id, skip_reinit=True)
-        # phoneme
-        # 無音無しモーラ時系列 / 無音有り音素時系列
+
+        # モーラ時系列 / 音素時系列
         flatten_moras, phoneme_data_list = pre_process(query.accent_phrases)
 
+        flatten_moras = change_silence(flatten_moras, query)
+
         # 無音有り音素ごとのフレーム長
-        frame_per_phoneme = calc_frame_per_phoneme(
-            query, change_silence(flatten_moras, query)
-        )
+        frame_per_phoneme = calc_frame_per_phoneme(query, flatten_moras)
         f0 = calc_frame_pitch(
             query, flatten_moras, phoneme_data_list, frame_per_phoneme
         )

--- a/voicevox_engine/synthesis_engine/synthesis_engine.py
+++ b/voicevox_engine/synthesis_engine/synthesis_engine.py
@@ -111,6 +111,7 @@ def pre_process(
 
 
 def silence_mora(length: float) -> Mora:
+    """無音モーラの生成"""
     return Mora(text=" ", vowel="sil", vowel_length=length, pitch=0.0)
 
 
@@ -119,13 +120,13 @@ def change_silence(moras: list[Mora], query: AudioQuery) -> list[Mora]:
     Parameters
     ----------
     moras : List[Mora]
-        モーラ列
+        モーラ時系列
     query : AudioQuery
         音声合成クエリ
     Returns
     -------
     moras : List[Mora]
-        前後無音が付加されたモーラ列
+        前後無音が付加されたモーラ時系列
     """
     silence_moras_head = [silence_mora(query.prePhonemeLength)]
     silence_moras_tail = [silence_mora(query.postPhonemeLength)]
@@ -499,13 +500,11 @@ class SynthesisEngine(SynthesisEngineBase):
         """
         # モデルがロードされていない場合はロードする
         self.initialize_style_id_synthesis(style_id, skip_reinit=True)
-
-        # モーラ時系列 / 音素時系列
+        # phoneme
+        # AccentPhraseをすべてMoraおよびOjtPhonemeの形に分解し、処理可能な形にする
         flatten_moras, phoneme_data_list = pre_process(query.accent_phrases)
 
         flatten_moras = change_silence(flatten_moras, query)
-
-        # 無音有り音素ごとのフレーム長
         frame_per_phoneme = calc_frame_per_phoneme(query, flatten_moras)
         f0 = calc_frame_pitch(
             query, flatten_moras, phoneme_data_list, frame_per_phoneme


### PR DESCRIPTION
## 内容
`_synthesis_impl` における前後無音挿入の統合  

- `calc_frame_per_phoneme()` における無音音素の挿入
- `calc_frame_pitch()` における前後 f0=0 挿入

をモーラ時系列への無音モーラ付加により統合。  

## 関連 Issue
part of #801 