### PR TITLE
修正: AquesTalk風記法の旧式記述を置換

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ curl -s \
 
 ### 読み方を AquesTalk風記法で取得・修正するサンプルコード
 
-`/audio_query`のレスポンスにはエンジンが判断した読み方が AquesTalk ライクな記法([本家の記法](https://www.a-quest.com/archive/manual/siyo_onseikigou.pdf)とは一部異なります)で記録されています。
+`/audio_query`のレスポンスにはエンジンが判断した読み方が AquesTalk 風記法([本家の記法](https://www.a-quest.com/archive/manual/siyo_onseikigou.pdf)とは一部異なります)で記録されています。
 記法は次のルールに従います。
 
 - 全てのカナはカタカナで記述される

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ curl -s \
 
 `style_id` に指定する値は `/speakers` エンドポイントで得られます。
 
-### 読み方を AquesTalk 記法で取得・修正するサンプルコード
+### 読み方を AquesTalk風記法で取得・修正するサンプルコード
 
 `/audio_query`のレスポンスにはエンジンが判断した読み方が AquesTalk ライクな記法([本家の記法](https://www.a-quest.com/archive/manual/siyo_onseikigou.pdf)とは一部異なります)で記録されています。
 記法は次のルールに従います。

--- a/run.py
+++ b/run.py
@@ -327,7 +327,7 @@ def generate_app(
     ) -> list[AccentPhrase]:
         """
         テキストからアクセント句を得ます。
-        is_kanaが`true`のとき、テキストは次のようなAquesTalkライクな記法に従う読み仮名として処理されます。デフォルトは`false`です。
+        is_kanaが`true`のとき、テキストは次のAquesTalk風記法で解釈されます。デフォルトは`false`です。
         * 全てのカナはカタカナで記述される
         * アクセント句は`/`または`、`で区切る。`、`で区切った場合に限り無音区間が挿入される。
         * カナの手前に`_`を入れるとそのカナは無声化される
@@ -1155,7 +1155,7 @@ def generate_app(
         "/validate_kana",
         response_model=bool,
         tags=["その他"],
-        summary="テキストがAquesTalkライクな記法に従っているか判定する",
+        summary="テキストがAquesTalk風記法に従っているか判定する",
         responses={
             400: {
                 "description": "テキストが不正です",
@@ -1165,7 +1165,7 @@ def generate_app(
     )
     def validate_kana(text: str) -> bool:
         """
-        テキストがAquesTalkライクな記法に従っているかどうかを判定します。
+        テキストがAquesTalk風記法に従っているかどうかを判定します。
         従っていない場合はエラーが返ります。
 
         Parameters

--- a/voicevox_engine/kana_parser.py
+++ b/voicevox_engine/kana_parser.py
@@ -81,7 +81,7 @@ def _text_to_accent_phrase(phrase: str) -> AccentPhrase:
 
 def parse_kana(text: str) -> List[AccentPhrase]:
     """
-    AquesTalkライクな読み仮名をパースして音長・音高未指定のaccent phraseに変換
+    AquesTalk風記法テキストをパースして音長・音高未指定のaccent phraseに変換
     """
 
     parsed_results: List[AccentPhrase] = []

--- a/voicevox_engine/model.py
+++ b/voicevox_engine/model.py
@@ -59,7 +59,7 @@ class AudioQuery(BaseModel):
     postPhonemeLength: float = Field(title="音声の後の無音時間")
     outputSamplingRate: int = Field(title="音声データの出力サンプリングレート")
     outputStereo: bool = Field(title="音声データをステレオ出力するか否か")
-    kana: Optional[str] = Field(title="[読み取り専用]AquesTalkライクな読み仮名。音声合成クエリとしては無視される")
+    kana: Optional[str] = Field(title="[読み取り専用]AquesTalk風記法によるテキスト。音声合成クエリとしては無視される")
 
     def __hash__(self):
         items = [


### PR DESCRIPTION
## 内容
AquesTalk風記法の旧式記述を統一名称へ置換して修正

## 関連 Issue
resolve #720