### PR TITLE
整理: グローバル特徴量適用の関数化

### DIFF
--- a/test/test_synthesis_engine.py
+++ b/test/test_synthesis_engine.py
@@ -15,13 +15,13 @@ from voicevox_engine.synthesis_engine import SynthesisEngine
 from voicevox_engine.synthesis_engine.synthesis_engine import (
     apply_intonation,
     apply_pitch,
+    apply_silence,
     apply_speed,
     apply_volume,
     calc_frame_per_phoneme,
     calc_frame_phoneme,
     calc_frame_pitch,
     mora_phoneme_list,
-    pad_with_silence,
     pre_process,
     split_mora,
     to_flatten_moras,
@@ -174,8 +174,8 @@ def _gen_mora(
     )
 
 
-def test_pad_with_silence():
-    """Test `pad_with_silence`."""
+def test_apply_silence():
+    """Test `apply_silence`."""
     # Inputs
     query = _gen_query(prePhonemeLength=2 * 0.01067, postPhonemeLength=6 * 0.01067)
     moras = [
@@ -190,7 +190,7 @@ def test_pad_with_silence():
     ]
 
     # Outputs
-    moras_with_silence = pad_with_silence(moras, query)
+    moras_with_silence = apply_silence(moras, query)
 
     assert moras_with_silence == true_moras_with_silence
 
@@ -422,7 +422,7 @@ def test_feat_to_framescale():
     assert true_frame_per_phoneme.shape[0] == len(phoneme_data_list), "Prerequisites"
 
     # Outputs
-    flatten_moras = pad_with_silence(flatten_moras, query)
+    flatten_moras = apply_silence(flatten_moras, query)
     frame_per_phoneme = calc_frame_per_phoneme(query, flatten_moras)
     f0 = calc_frame_pitch(query, flatten_moras, phoneme_data_list, frame_per_phoneme)
     frame_phoneme = calc_frame_phoneme(phoneme_data_list, frame_per_phoneme)

--- a/test/test_synthesis_engine.py
+++ b/test/test_synthesis_engine.py
@@ -13,6 +13,9 @@ from voicevox_engine.synthesis_engine import SynthesisEngine
 
 # TODO: import from voicevox_engine.synthesis_engine.mora
 from voicevox_engine.synthesis_engine.synthesis_engine import (
+    apply_pitch,
+    apply_intonation,
+    apply_volume,
     calc_frame_per_phoneme,
     calc_frame_phoneme,
     calc_frame_pitch,
@@ -189,6 +192,75 @@ def test_pad_with_silence():
     moras_with_silence = pad_with_silence(moras, query)
 
     assert moras_with_silence == true_moras_with_silence
+
+
+def test_apply_pitch():
+    """Test `apply_pitch`."""
+    # Inputs
+    query = _gen_query(pitchScale=2.0)
+    input_moras = [
+        _gen_mora("コ", "k", 0.0, "o", 0.0, 50.0),
+        _gen_mora("ン", None, None, "N", 0.0, 50.0),
+        _gen_mora("、", None, None, "pau", 0.0, 0.0),
+        _gen_mora("ヒ", "h", 0.0, "i", 0.0, 125.0),
+        _gen_mora("ホ", "h", 0.0, "O", 0.0, 0.0),
+    ]
+
+    # Expects - x4 value scaled
+    true_moras = [
+        _gen_mora("コ", "k", 0.0, "o", 0.0, 200.0),
+        _gen_mora("ン", None, None, "N", 0.0, 200.0),
+        _gen_mora("、", None, None, "pau", 0.0, 0.0),
+        _gen_mora("ヒ", "h", 0.0, "i", 0.0, 500.0),
+        _gen_mora("ホ", "h", 0.0, "O", 0.0, 0.0),
+    ]
+
+    # Outputs
+    moras = apply_pitch(input_moras, query)
+
+    assert moras == true_moras
+
+
+def test_apply_intonation():
+    """Test `apply_intonation`."""
+    # Inputs
+    query = _gen_query(intonationScale=0.5)
+    input_moras = [
+        _gen_mora("コ", "k", 0.0, "o", 0.0, 200.0),
+        _gen_mora("ン", None, None, "N", 0.0, 200.0),
+        _gen_mora("、", None, None, "pau", 0.0, 0.0),
+        _gen_mora("ヒ", "h", 0.0, "i", 0.0, 500.0),
+        _gen_mora("ホ", "h", 0.0, "O", 0.0, 0.0),
+    ]
+
+    # Expects - mean=300 var x0.5 intonation scaling
+    true_moras = [
+        _gen_mora("コ", "k", 0.0, "o", 0.0, 250.0),
+        _gen_mora("ン", None, None, "N", 0.0, 250.0),
+        _gen_mora("、", None, None, "pau", 0.0, 0.0),
+        _gen_mora("ヒ", "h", 0.0, "i", 0.0, 400.0),
+        _gen_mora("ホ", "h", 0.0, "O", 0.0, 0.0),
+    ]
+
+    # Outputs
+    moras = apply_intonation(input_moras, query)
+
+    assert moras == true_moras
+
+
+def test_apply_volume():
+    """Test `apply_volume`."""
+    # Inputs
+    query = _gen_query(volumeScale=3.0)
+    input_wave = numpy.array([0.0, 1.0, 2.0, 0.0,])
+
+    # Expects - x3 scale
+    true_wave = numpy.array([0.0, 3.0, 6.0, 0.0,])
+
+    # Outputs
+    wave = apply_volume(input_wave, query)
+
+    assert numpy.allclose(wave, true_wave)
 
 
 def test_calc_frame_per_phoneme():

--- a/test/test_synthesis_engine.py
+++ b/test/test_synthesis_engine.py
@@ -13,13 +13,13 @@ from voicevox_engine.synthesis_engine import SynthesisEngine
 
 # TODO: import from voicevox_engine.synthesis_engine.mora
 from voicevox_engine.synthesis_engine.synthesis_engine import (
-    apply_intonation,
-    apply_pitch,
-    apply_sampling_rate,
-    apply_silence,
-    apply_speed,
-    apply_stereo,
-    apply_volume,
+    apply_intonation_scale,
+    apply_output_sampling_rate,
+    apply_output_stereo,
+    apply_pitch_scale,
+    apply_prepost_silence,
+    apply_speed_scale,
+    apply_volume_scale,
     calc_frame_per_phoneme,
     calc_frame_phoneme,
     calc_frame_pitch,
@@ -176,8 +176,8 @@ def _gen_mora(
     )
 
 
-def test_apply_silence():
-    """Test `apply_silence`."""
+def test_apply_prepost_silence():
+    """Test `apply_prepost_silence`."""
     # Inputs
     query = _gen_query(prePhonemeLength=2 * 0.01067, postPhonemeLength=6 * 0.01067)
     moras = [
@@ -192,13 +192,13 @@ def test_apply_silence():
     ]
 
     # Outputs
-    moras_with_silence = apply_silence(moras, query)
+    moras_with_silence = apply_prepost_silence(moras, query)
 
     assert moras_with_silence == true_moras_with_silence
 
 
-def test_apply_speed():
-    """Test `apply_speed`."""
+def test_apply_speed_scale():
+    """Test `apply_speed_scale`."""
     # Inputs
     query = _gen_query(speedScale=2.0)
     input_moras = [
@@ -219,13 +219,13 @@ def test_apply_speed():
     ]
 
     # Outputs
-    moras = apply_speed(input_moras, query)
+    moras = apply_speed_scale(input_moras, query)
 
     assert moras == true_moras
 
 
-def test_apply_pitch():
-    """Test `apply_pitch`."""
+def test_apply_pitch_scale():
+    """Test `apply_pitch_scale`."""
     # Inputs
     query = _gen_query(pitchScale=2.0)
     input_moras = [
@@ -246,13 +246,13 @@ def test_apply_pitch():
     ]
 
     # Outputs
-    moras = apply_pitch(input_moras, query)
+    moras = apply_pitch_scale(input_moras, query)
 
     assert moras == true_moras
 
 
-def test_apply_intonation():
-    """Test `apply_intonation`."""
+def test_apply_intonation_scale():
+    """Test `apply_intonation_scale`."""
     # Inputs
     query = _gen_query(intonationScale=0.5)
     input_moras = [
@@ -273,13 +273,13 @@ def test_apply_intonation():
     ]
 
     # Outputs
-    moras = apply_intonation(input_moras, query)
+    moras = apply_intonation_scale(input_moras, query)
 
     assert moras == true_moras
 
 
-def test_apply_volume():
-    """Test `apply_volume`."""
+def test_apply_volume_scale():
+    """Test `apply_volume_scale`."""
     # Inputs
     query = _gen_query(volumeScale=3.0)
     input_wave = numpy.array([0.0, 1.0, 2.0])
@@ -288,13 +288,13 @@ def test_apply_volume():
     true_wave = numpy.array([0.0, 3.0, 6.0])
 
     # Outputs
-    wave = apply_volume(input_wave, query)
+    wave = apply_volume_scale(input_wave, query)
 
     assert numpy.allclose(wave, true_wave)
 
 
-def test_apply_sampling_rate():
-    """Test `apply_sampling_rate`."""
+def test_apply_output_sampling_rate():
+    """Test `apply_output_sampling_rate`."""
     # Inputs
     query = _gen_query(outputSamplingRate=12000)
     input_wave = numpy.array([1.0 for _ in range(120)])
@@ -305,13 +305,13 @@ def test_apply_sampling_rate():
     assert true_wave.shape == (60,), "Prerequisites"
 
     # Outputs
-    wave = apply_sampling_rate(input_wave, input_sr_wave, query)
+    wave = apply_output_sampling_rate(input_wave, input_sr_wave, query)
 
     assert wave.shape[0] == true_wave.shape[0]
 
 
-def test_apply_stereo():
-    """Test `apply_stereo`."""
+def test_apply_output_stereo():
+    """Test `apply_output_stereo`."""
     # Inputs
     query = _gen_query(outputStereo=True)
     input_wave = numpy.array([1.0, 0.0, 2.0])
@@ -320,7 +320,7 @@ def test_apply_stereo():
     true_wave = numpy.array([[1.0, 1.0], [0.0, 0.0], [2.0, 2.0]])
 
     # Outputs
-    wave = apply_stereo(input_wave, query)
+    wave = apply_output_stereo(input_wave, query)
 
     assert numpy.array_equal(wave, true_wave)
 
@@ -456,7 +456,7 @@ def test_feat_to_framescale():
     assert true_frame_per_phoneme.shape[0] == len(phoneme_data_list), "Prerequisites"
 
     # Outputs
-    flatten_moras = apply_silence(flatten_moras, query)
+    flatten_moras = apply_prepost_silence(flatten_moras, query)
     frame_per_phoneme = calc_frame_per_phoneme(query, flatten_moras)
     f0 = calc_frame_pitch(query, flatten_moras, phoneme_data_list, frame_per_phoneme)
     frame_phoneme = calc_frame_phoneme(phoneme_data_list, frame_per_phoneme)

--- a/test/test_synthesis_engine.py
+++ b/test/test_synthesis_engine.py
@@ -15,6 +15,7 @@ from voicevox_engine.synthesis_engine import SynthesisEngine
 from voicevox_engine.synthesis_engine.synthesis_engine import (
     apply_intonation,
     apply_pitch,
+    apply_speed,
     apply_volume,
     calc_frame_per_phoneme,
     calc_frame_phoneme,
@@ -192,6 +193,33 @@ def test_pad_with_silence():
     moras_with_silence = pad_with_silence(moras, query)
 
     assert moras_with_silence == true_moras_with_silence
+
+
+def test_apply_speed():
+    """Test `apply_speed`."""
+    # Inputs
+    query = _gen_query(speedScale=2.0)
+    input_moras = [
+        _gen_mora("コ", "k", 2 * 0.01067, "o", 4 * 0.01067, 50.0),
+        _gen_mora("ン", None, None, "N", 4 * 0.01067, 50.0),
+        _gen_mora("、", None, None, "pau", 2 * 0.01067, 0.0),
+        _gen_mora("ヒ", "h", 2 * 0.01067, "i", 4 * 0.01067, 125.0),
+        _gen_mora("ホ", "h", 4 * 0.01067, "O", 2 * 0.01067, 0.0),
+    ]
+
+    # Expects - x2 fast
+    true_moras = [
+        _gen_mora("コ", "k", 1 * 0.01067, "o", 2 * 0.01067, 50.0),
+        _gen_mora("ン", None, None, "N", 2 * 0.01067, 50.0),
+        _gen_mora("、", None, None, "pau", 1 * 0.01067, 0.0),
+        _gen_mora("ヒ", "h", 1 * 0.01067, "i", 2 * 0.01067, 125.0),
+        _gen_mora("ホ", "h", 2 * 0.01067, "O", 1 * 0.01067, 0.0),
+    ]
+
+    # Outputs
+    moras = apply_speed(input_moras, query)
+
+    assert moras == true_moras
 
 
 def test_apply_pitch():

--- a/test/test_synthesis_engine.py
+++ b/test/test_synthesis_engine.py
@@ -13,8 +13,8 @@ from voicevox_engine.synthesis_engine import SynthesisEngine
 
 # TODO: import from voicevox_engine.synthesis_engine.mora
 from voicevox_engine.synthesis_engine.synthesis_engine import (
-    apply_pitch,
     apply_intonation,
+    apply_pitch,
     apply_volume,
     calc_frame_per_phoneme,
     calc_frame_phoneme,
@@ -252,10 +252,10 @@ def test_apply_volume():
     """Test `apply_volume`."""
     # Inputs
     query = _gen_query(volumeScale=3.0)
-    input_wave = numpy.array([0.0, 1.0, 2.0, 0.0,])
+    input_wave = numpy.array([0.0, 1.0, 2.0])
 
     # Expects - x3 scale
-    true_wave = numpy.array([0.0, 3.0, 6.0, 0.0,])
+    true_wave = numpy.array([0.0, 3.0, 6.0])
 
     # Outputs
     wave = apply_volume(input_wave, query)

--- a/test/test_synthesis_engine.py
+++ b/test/test_synthesis_engine.py
@@ -15,8 +15,10 @@ from voicevox_engine.synthesis_engine import SynthesisEngine
 from voicevox_engine.synthesis_engine.synthesis_engine import (
     apply_intonation,
     apply_pitch,
+    apply_sampling_rate,
     apply_silence,
     apply_speed,
+    apply_stereo,
     apply_volume,
     calc_frame_per_phoneme,
     calc_frame_phoneme,
@@ -289,6 +291,38 @@ def test_apply_volume():
     wave = apply_volume(input_wave, query)
 
     assert numpy.allclose(wave, true_wave)
+
+
+def test_apply_sampling_rate():
+    """Test `apply_sampling_rate`."""
+    # Inputs
+    query = _gen_query(outputSamplingRate=12000)
+    input_wave = numpy.array([1.0 for _ in range(120)])
+    input_sr_wave = 24000
+
+    # Expects - half sampling rate
+    true_wave = numpy.array([1.0 for _ in range(60)])
+    assert true_wave.shape == (60,), "Prerequisites"
+
+    # Outputs
+    wave = apply_sampling_rate(input_wave, input_sr_wave, query)
+
+    assert wave.shape[0] == true_wave.shape[0]
+
+
+def test_apply_stereo():
+    """Test `apply_stereo`."""
+    # Inputs
+    query = _gen_query(outputStereo=True)
+    input_wave = numpy.array([1.0, 0.0, 2.0])
+
+    # Expects - Stereo :: (Time, Channel)
+    true_wave = numpy.array([[1.0, 1.0], [0.0, 0.0], [2.0, 2.0]])
+
+    # Outputs
+    wave = apply_stereo(input_wave, query)
+
+    assert numpy.array_equal(wave, true_wave)
 
 
 def test_calc_frame_per_phoneme():

--- a/voicevox_engine/synthesis_engine/synthesis_engine.py
+++ b/voicevox_engine/synthesis_engine/synthesis_engine.py
@@ -259,11 +259,9 @@ def calc_frame_pitch(
     frame_f0 : NDArray[]
         フレームごとの基本周波数系列
     """
-    # Apply: グローバル特徴量による補正（音高、抑揚）
     moras = apply_pitch_scale(moras, query)
     moras = apply_intonation_scale(moras, query)
 
-    # Convert: Core入力形式への変換（スカラ系列）
     # TODO: Better function name (c.f. VOICEVOX/voicevox_engine#790)
     # モーラごとの基本周波数
     f0 = numpy.array([mora.pitch for mora in moras], dtype=numpy.float32)
@@ -640,7 +638,6 @@ class SynthesisEngine(SynthesisEngineBase):
             )
             sr_wave = self.default_sampling_rate
 
-        # Apply: グローバル特徴量による補正（音量・サンプリングレート・ステレオ）
         wave = apply_volume_scale(wave, query)
         wave = apply_output_sampling_rate(wave, sr_wave, query)
         wave = apply_output_stereo(wave, query)

--- a/voicevox_engine/synthesis_engine/synthesis_engine.py
+++ b/voicevox_engine/synthesis_engine/synthesis_engine.py
@@ -335,7 +335,7 @@ def apply_sampling_rate(wave: ndarray, sr_wave: int, query: AudioQuery) -> ndarr
     wave : ndarray
         出力サンプリングレートが適用された音声波形
     """
-    # サンプリングレート一致: スルー
+    # サンプリングレート一致のときはスルー
     if sr_wave == query.outputSamplingRate:
         return wave
 

--- a/voicevox_engine/synthesis_engine/synthesis_engine.py
+++ b/voicevox_engine/synthesis_engine/synthesis_engine.py
@@ -241,17 +241,17 @@ def calc_frame_pitch(
     moras = apply_pitch(moras, query)
     moras = apply_intonation(moras, query)
 
+    # Convert: Core入力形式への変換（スカラ系列）
     # TODO: Better function name (c.f. VOICEVOX/voicevox_engine#790)
     # モーラごとの基本周波数
     f0 = numpy.array([mora.pitch for mora in moras], dtype=numpy.float32)
 
-    # フレームごとのピッチ化
+    # Rescale: 時間スケールの変更（モーラ -> フレーム）
     # 母音インデックスに基づき "音素あたりのフレーム長" を "モーラあたりのフレーム長" に集約
     vowel_indexes = numpy.array(split_mora(phonemes)[2])
     frame_per_mora = [
         a.sum() for a in numpy.split(frame_per_phoneme, vowel_indexes[:-1] + 1)
     ]
-    # モーラの基本周波数を子音・母音に割当てフレーム化
     frame_f0 = numpy.repeat(f0, frame_per_mora)
     return frame_f0
 
@@ -289,7 +289,10 @@ def calc_frame_phoneme(phonemes: List[OjtPhoneme], frame_per_phoneme: numpy.ndar
         フレームごとの音素系列
     """
     # TODO: Better function name (c.f. VOICEVOX/voicevox_engine#790)
+    # Convert: Core入力形式への変換（onehotベクトル系列）
     onehot_phoneme = numpy.stack([p.onehot for p in phonemes])
+
+    # Rescale: 時間スケールの変更（音素 -> フレーム）
     frame_phoneme = numpy.repeat(onehot_phoneme, frame_per_phoneme, axis=0)
     return frame_phoneme
 
@@ -568,7 +571,7 @@ class SynthesisEngine(SynthesisEngineBase):
                 phoneme=phoneme,
                 style_id=numpy.array(style_id, dtype=numpy.int64).reshape(-1),
             )
- 
+
         # Apply: グローバル特徴量による補正（音量）
         wave = apply_volume(wave, query)
 

--- a/voicevox_engine/synthesis_engine/synthesis_engine.py
+++ b/voicevox_engine/synthesis_engine/synthesis_engine.py
@@ -116,8 +116,9 @@ def generate_silence_mora(length: float) -> Mora:
     return Mora(text="　", vowel="sil", vowel_length=length, pitch=0.0)
 
 
-def pad_with_silence(moras: list[Mora], query: AudioQuery) -> list[Mora]:
-    """モーラ列の先頭/最後尾へqueryに基づいた無音モーラを追加
+def apply_silence(moras: list[Mora], query: AudioQuery) -> list[Mora]:
+    """
+    前後無音（`prePhonemeLength` & `postPhonemeLength`）の適用
     Parameters
     ----------
     moras : List[Mora]
@@ -575,7 +576,7 @@ class SynthesisEngine(SynthesisEngineBase):
         # AccentPhraseをすべてMoraおよびOjtPhonemeの形に分解し、処理可能な形にする
         flatten_moras, phoneme_data_list = pre_process(query.accent_phrases)
 
-        flatten_moras = pad_with_silence(flatten_moras, query)
+        flatten_moras = apply_silence(flatten_moras, query)
         frame_per_phoneme = calc_frame_per_phoneme(query, flatten_moras)
         f0 = calc_frame_pitch(
             query, flatten_moras, phoneme_data_list, frame_per_phoneme


### PR DESCRIPTION
## 内容
グローバル特徴量適用の関数化によるリファクタリング  

`AudioQuery` を介してユーザーから与えられるグローバル特徴量は以下の7系統：  

- `speedScale`
- `pitchScale`
- `intonationScale`
- `volumeScale`
- (silence)
  - `prePhonemeLength`
  - `postPhonemeLength`
- `outputSamplingRate`
- `outputStereo`

それぞれが独立したユーザー機能であるため、これらの適用を関数として独立しテストを追加する。  

## 関連 Issue
step1a of #815 