### PR TITLE
[docs] スピーカー→話者

### DIFF
--- a/voicevox_engine/metas/Metas.py
+++ b/voicevox_engine/metas/Metas.py
@@ -40,7 +40,7 @@ class CoreSpeaker(BaseModel):
 
     name: str = Field(title="名前")
     speaker_uuid: str = Field(title="話者のUUID")
-    styles: List[SpeakerStyle] = Field(title="話者スタイルの一覧")
+    styles: List[SpeakerStyle] = Field(title="スタイルの一覧")
     version: str = Field("話者のバージョン")
 
 

--- a/voicevox_engine/metas/Metas.py
+++ b/voicevox_engine/metas/Metas.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel, Field
 
 class SpeakerStyle(BaseModel):
     """
-    スピーカーのスタイル情報
+    話者のスタイル情報
     """
 
     name: str = Field(title="スタイル名")
@@ -35,28 +35,28 @@ class SpeakerSupportedFeatures(BaseModel):
 
 class CoreSpeaker(BaseModel):
     """
-    コアに含まれるスピーカー情報
+    コアに含まれる話者情報
     """
 
     name: str = Field(title="名前")
-    speaker_uuid: str = Field(title="スピーカーのUUID")
-    styles: List[SpeakerStyle] = Field(title="スピーカースタイルの一覧")
-    version: str = Field("スピーカーのバージョン")
+    speaker_uuid: str = Field(title="話者のUUID")
+    styles: List[SpeakerStyle] = Field(title="話者スタイルの一覧")
+    version: str = Field("話者のバージョン")
 
 
 class EngineSpeaker(BaseModel):
     """
-    エンジンに含まれるスピーカー情報
+    エンジンに含まれる話者情報
     """
 
     supported_features: SpeakerSupportedFeatures = Field(
-        title="スピーカーの対応機能", default_factory=SpeakerSupportedFeatures
+        title="話者の対応機能", default_factory=SpeakerSupportedFeatures
     )
 
 
 class Speaker(CoreSpeaker, EngineSpeaker):
     """
-    スピーカー情報
+    話者情報
     """
 
     pass

--- a/voicevox_engine/preset/Preset.py
+++ b/voicevox_engine/preset/Preset.py
@@ -8,7 +8,7 @@ class Preset(BaseModel):
 
     id: int = Field(title="プリセットID")
     name: str = Field(title="プリセット名")
-    speaker_uuid: str = Field(title="スピーカーのUUID")
+    speaker_uuid: str = Field(title="話者のUUID")
     style_id: int = Field(title="スタイルID")
     speedScale: float = Field(title="全体の話速")
     pitchScale: float = Field(title="全体の音高")


### PR DESCRIPTION
## 内容

ドキュメントの一部で話者のことをスピーカーと呼んでいたので変更しました。
エディタやコアを見直してもスピーカーと呼んでいるところはこのAPI以外なさそうでした。


<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## その他

提案なのですが、ドメイン用語をまとめたドキュメントをどこかに置いてもいいかなと思いました。
とりあえず数個のドメイン用語を書いて`voicevox_project`の`docs`に配置するプルリクを送ろうかなと思ってます。
