### PR TITLE
整理: `pre_process` の細分化

### DIFF
--- a/test/test_synthesis_engine.py
+++ b/test/test_synthesis_engine.py
@@ -449,22 +449,32 @@ def test_calc_frame_phoneme():
 def test_feat_to_framescale():
     """Test Mora/Phonemefeature-to-framescaleFeature pipeline."""
     # Inputs
+    accent_phrases = [
+        AccentPhrase(
+            moras=[
+                _gen_mora("コ", "k", 2 * 0.01067, "o", 4 * 0.01067, 50.0),
+                _gen_mora("ン", None, None, "N", 4 * 0.01067, 50.0),
+            ],
+            accent=1,
+            pause_mora=_gen_mora("、", None, None, "pau", 2 * 0.01067, 0.0),
+        ),
+        AccentPhrase(
+            moras=[
+                _gen_mora("ヒ", "h", 2 * 0.01067, "i", 4 * 0.01067, 125.0),
+                _gen_mora("ホ", "h", 4 * 0.01067, "O", 2 * 0.01067, 0.0),
+            ],
+            accent=1,
+            pause_mora=None,
+        ),
+    ]
     query = _gen_query(
+        accent_phrases=accent_phrases,
         speedScale=2.0,
         pitchScale=2.0,
         intonationScale=0.5,
         prePhonemeLength=2 * 0.01067,
         postPhonemeLength=6 * 0.01067,
     )
-    flatten_moras = [
-        _gen_mora("コ", "k", 2 * 0.01067, "o", 4 * 0.01067, 50.0),
-        _gen_mora("ン", None, None, "N", 4 * 0.01067, 50.0),
-        _gen_mora("、", None, None, "pau", 2 * 0.01067, 0.0),
-        _gen_mora("ヒ", "h", 2 * 0.01067, "i", 4 * 0.01067, 125.0),
-        _gen_mora("ホ", "h", 4 * 0.01067, "O", 2 * 0.01067, 0.0),
-    ]
-    phoneme_str = "pau k o N pau h i h O pau"
-    phoneme_data_list = [OjtPhoneme(p) for p in phoneme_str.split()]
 
     # Expects
     # frame_per_phoneme
@@ -492,9 +502,8 @@ def test_feat_to_framescale():
     true3_f0 = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
     true_f0 = numpy.array(true1_f0 + true2_f0 + true3_f0, dtype=numpy.float32)
 
-    assert true_frame_per_phoneme.shape[0] == len(phoneme_data_list), "Prerequisites"
-
     # Outputs
+    flatten_moras, phoneme_data_list = pre_process(query.accent_phrases)
     flatten_moras = apply_prepost_silence(flatten_moras, query)
     flatten_moras = apply_speed_scale(flatten_moras, query)
     flatten_moras = apply_pitch_scale(flatten_moras, query)

--- a/test/test_synthesis_engine.py
+++ b/test/test_synthesis_engine.py
@@ -28,6 +28,7 @@ from voicevox_engine.synthesis_engine.synthesis_engine import (
     pre_process,
     split_mora,
     to_flatten_moras,
+    to_flatten_phonemes,
     unvoiced_mora_phoneme_list,
 )
 
@@ -178,6 +179,24 @@ def _gen_mora(
         vowel_length=vowel_length,
         pitch=pitch,
     )
+
+
+def test_to_flatten_phonemes():
+    """Test `to_flatten_phonemes`."""
+    # Inputs
+    moras = [
+        _gen_mora("　", None, None, "sil", 2 * 0.01067, 0.0),
+        _gen_mora("ヒ", "h", 2 * 0.01067, "i", 4 * 0.01067, 100.0),
+        _gen_mora("　", None, None, "sil", 6 * 0.01067, 0.0),
+    ]
+
+    # Expects
+    true_phonemes = ["pau", "h", "i", "pau"]
+
+    # Outputs
+    phonemes = list(map(lambda p: p.phoneme, to_flatten_phonemes(moras)))
+
+    assert true_phonemes == phonemes
 
 
 def test_apply_prepost_silence():

--- a/test/test_synthesis_engine.py
+++ b/test/test_synthesis_engine.py
@@ -503,11 +503,14 @@ def test_feat_to_framescale():
     true_f0 = numpy.array(true1_f0 + true2_f0 + true3_f0, dtype=numpy.float32)
 
     # Outputs
-    flatten_moras, phoneme_data_list = pre_process(query.accent_phrases)
+    flatten_moras = to_flatten_moras(query.accent_phrases)
     flatten_moras = apply_prepost_silence(flatten_moras, query)
     flatten_moras = apply_speed_scale(flatten_moras, query)
     flatten_moras = apply_pitch_scale(flatten_moras, query)
     flatten_moras = apply_intonation_scale(flatten_moras, query)
+
+    phoneme_data_list = to_flatten_phonemes(flatten_moras)
+
     frame_per_phoneme = calc_frame_per_phoneme(flatten_moras)
     f0 = calc_frame_pitch(flatten_moras)
     frame_phoneme = calc_frame_phoneme(phoneme_data_list, frame_per_phoneme)

--- a/voicevox_engine/synthesis_engine/synthesis_engine.py
+++ b/voicevox_engine/synthesis_engine/synthesis_engine.py
@@ -613,14 +613,14 @@ class SynthesisEngine(SynthesisEngineBase):
         """
         # モデルがロードされていない場合はロードする
         self.initialize_style_id_synthesis(style_id, skip_reinit=True)
-        # phoneme
-        # AccentPhraseをすべてMoraおよびOjtPhonemeの形に分解し、処理可能な形にする
-        flatten_moras, phoneme_data_list = pre_process(query.accent_phrases)
 
+        flatten_moras = to_flatten_moras(query.accent_phrases)
         flatten_moras = apply_prepost_silence(flatten_moras, query)
         flatten_moras = apply_speed_scale(flatten_moras, query)
         flatten_moras = apply_pitch_scale(flatten_moras, query)
         flatten_moras = apply_intonation_scale(flatten_moras, query)
+
+        phoneme_data_list = to_flatten_phonemes(flatten_moras)
 
         frame_per_phoneme = calc_frame_per_phoneme(flatten_moras)
         f0 = calc_frame_pitch(flatten_moras)

--- a/voicevox_engine/synthesis_engine/synthesis_engine.py
+++ b/voicevox_engine/synthesis_engine/synthesis_engine.py
@@ -1,7 +1,6 @@
 import math
 import threading
-from itertools import chain
-from typing import List, Optional, Tuple
+from typing import List, Optional
 
 import numpy
 from numpy import ndarray
@@ -17,30 +16,44 @@ mora_phoneme_list = ["a", "i", "u", "e", "o", "N"] + unvoiced_mora_phoneme_list
 
 
 # TODO: move mora utility to mora module
-def to_flatten_moras(accent_phrases: List[AccentPhrase]) -> List[Mora]:
+def to_flatten_moras(accent_phrases: list[AccentPhrase]) -> list[Mora]:
     """
-    accent_phrasesに含まれるMora(とpause_moraがあればそれも)を
-    すべて一つのリストに結合する
+    アクセント句系列に含まれるモーラの抽出
     Parameters
     ----------
-    accent_phrases : List[AccentPhrase]
-        AccentPhraseのリスト
+    accent_phrases : list[AccentPhrase]
+        アクセント句系列
     Returns
     -------
-    moras : List[Mora]
-        結合されたMoraのリストを返す
+    moras : list[Mora]
+        モーラ系列。ポーズモーラを含む。
     """
-    return list(
-        chain.from_iterable(
-            accent_phrase.moras
-            + (
-                [accent_phrase.pause_mora]
-                if accent_phrase.pause_mora is not None
-                else []
-            )
-            for accent_phrase in accent_phrases
-        )
-    )
+    moras: list[Mora] = []
+    for accent_phrase in accent_phrases:
+        moras += accent_phrase.moras
+        if accent_phrase.pause_mora:
+            moras += [accent_phrase.pause_mora]
+    return moras
+
+
+def to_flatten_phonemes(moras: list[Mora]) -> list[OjtPhoneme]:
+    """
+    モーラ系列に含まれる音素の抽出
+    Parameters
+    ----------
+    moras : list[Mora]
+        モーラ系列
+    Returns
+    -------
+    phonemes : list[OjtPhoneme]
+        音素系列
+    """
+    phonemes: list[OjtPhoneme] = []
+    for mora in moras:
+        if mora.consonant:
+            phonemes += [OjtPhoneme(mora.consonant)]
+        phonemes += [(OjtPhoneme(mora.vowel))]
+    return phonemes
 
 
 def split_mora(phoneme_list: List[OjtPhoneme]):
@@ -80,8 +93,8 @@ def split_mora(phoneme_list: List[OjtPhoneme]):
 
 
 def pre_process(
-    accent_phrases: List[AccentPhrase],
-) -> Tuple[List[Mora], List[OjtPhoneme]]:
+    accent_phrases: list[AccentPhrase],
+) -> tuple[list[Mora], list[OjtPhoneme]]:
     """
     AccentPhraseモデルのリストを整形し、処理に必要なデータの原型を作り出す
     Parameters
@@ -92,21 +105,16 @@ def pre_process(
     -------
     flatten_moras : List[Mora]
         モーラ列（前後の無音含まない）
-    phoneme_data_list : List[OjtPhoneme]
+    phonemes : List[OjtPhoneme]
         音素列（前後の無音含む）
     """
     flatten_moras = to_flatten_moras(accent_phrases)
+    phonemes = to_flatten_phonemes(flatten_moras)
 
-    phoneme_each_mora = [
-        ([mora.consonant] if mora.consonant is not None else []) + [mora.vowel]
-        for mora in flatten_moras
-    ]
-    phoneme_str_list = list(chain.from_iterable(phoneme_each_mora))
-    phoneme_str_list = ["pau"] + phoneme_str_list + ["pau"]
+    # 前後無音の追加
+    phonemes = [OjtPhoneme("pau")] + phonemes + [OjtPhoneme("pau")]
 
-    phoneme_data_list = list(map(OjtPhoneme, phoneme_str_list))
-
-    return flatten_moras, phoneme_data_list
+    return flatten_moras, phonemes
 
 
 def generate_silence_mora(length: float) -> Mora:


### PR DESCRIPTION
## 内容
`pre_process()` の細分化と置き換えによるリファクタリング  

synthesis における [`pre_process()`](https://github.com/VOICEVOX/voicevox_engine/blob/5d7562c51364e4672462f5110c4c87e1a8eaf145/voicevox_engine/synthesis_engine/synthesis_engine.py#L82) は以下の3つの役割を果たしている：  

A. アクセント句系列からモーラ系列を抽出
B. アクセント句系列から音素系列を抽出
C.  音素系列への前後無音追加

A は `to_flatten_moras()` として関数化されている一方、B は関数化されていない。  
また `pre_process()` をコールする関数の1つである `_synthesis_impl()` の場合、 C は `apply_prepost_silence()` で代替可能である。   

よって以下のリファクタリングをおこなった：

- Aの実装簡略化
- Bの関数化 (`to_flatten_phonemes`) とそれを用いた `pre_process()` の簡略化
- `_synthesis_impl()` での A・B 関数直接コールによる `pre_process()` の代替

本PRはリファクタリングであり、機能は不変でなければならない。  
これを保証するために、`test_feat_to_framescale()` が `pre_process()` を含むよう拡張した。  
上記3点のリファクタリング前後で拡張したテストがパスすることを確認済みである。  

## 関連 Issue
related to #815 step4