### PR TITLE
整理: 合成エンジン生成のコメント追加

### DIFF
--- a/voicevox_engine/tts_pipeline/make_tts_engines.py
+++ b/voicevox_engine/tts_pipeline/make_tts_engines.py
@@ -64,7 +64,8 @@ def make_synthesis_engines(
             voicelib_dirs = [root_dir]
         if runtime_dirs is None:
             runtime_dirs = [root_dir]
-    # パスをフルパスへ解決する
+
+    # `~`をホームディレクトリのパスに置き換える
     voicelib_dirs = [p.expanduser() for p in voicelib_dirs]
     runtime_dirs = [p.expanduser() for p in runtime_dirs]
 
@@ -101,8 +102,8 @@ def make_synthesis_engines(
                     )
                 else:
                     synthesis_engines[core_version] = SynthesisEngine(core=core)
-            # コア候補の場合エラーを抑制する
             except Exception:
+                # コアでなかった場合のエラーを抑制する
                 if not suppress_error:
                     raise
 
@@ -111,7 +112,7 @@ def make_synthesis_engines(
             load_core_library(core_dir)
 
         # ユーザーディレクトリ下のコアをロードし登録する
-        # コア候補パスを列挙する
+        # コア候補を列挙する
         user_voicelib_dirs = []
         core_libraries_dir = get_save_dir() / "core_libraries"
         core_libraries_dir.mkdir(exist_ok=True)
@@ -120,7 +121,7 @@ def make_synthesis_engines(
             if not path.is_dir():
                 continue
             user_voicelib_dirs.append(path)
-        # コア候補パスからコアをロードし登録する。候補がコアで無い場合でもエラーは抑制される。
+        # コア候補をロードし登録する。候補がコアで無かった場合のエラーを抑制する。
         for core_dir in user_voicelib_dirs:
             load_core_library(core_dir, suppress_error=True)
 

--- a/voicevox_engine/tts_pipeline/make_tts_engines.py
+++ b/voicevox_engine/tts_pipeline/make_tts_engines.py
@@ -83,8 +83,8 @@ def make_synthesis_engines(
             ----------
             core_dir : Path
                 直下にコア（共有ライブラリ）が存在するディレクトリ、あるいはその候補
-            is_candidate: bool
-                `core_dir` がコア候補であることを示し、エラーを抑制する
+            suppress_error: bool
+                エラーを抑制する。`core_dir` がコア候補であることを想定。
             """
             # 指定されたコアをロードし登録する
             try:


### PR DESCRIPTION
## 内容
概要: `make_synthesis_engines.py` へのコメント追加によるリファクタリング  

`make_synthesis_engines.py` はコアロードを司るモジュールである。  
様々な条件を受け入れる複雑な処理をおこなう一方、開発者向けのコメントがほぼ存在しない。  

よってコメント追加によるリファクタリングを提案します。  

## 関連 Issue
無し  

## Reviewer 向け情報
### 変更内容
コード変更無し。  
コメント追加のみ。  
### 依存 Issues
以下の issues / PRs に依存、これらが解決の後、reviewとマージ可能

- [x] #867