### PR TITLE
追加: 音声ライブラリ自動読み込み docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,7 +472,7 @@ DYLD_LIBRARY_PATH="/path/to/onnx" python run.py --voicelib_dir="/path/to/voicevo
 
 ##### 音声ライブラリを自動読み込みする
 
-音声ライブラリを特定のフォルダ下へ配置すると自動読み込みできます（製品版VOICEVOX・コンパイル済みエンジン・`run.py` 共通）。  
+音声ライブラリを特定のフォルダ下へ配置すると自動読み込みできます。  
 次のフォルダの下に音声ライブラリフォルダを配置してください：  
 
 - 製品版: `<user_data_dir>/voicevox-engine/core_libraries/`

--- a/README.md
+++ b/README.md
@@ -470,13 +470,18 @@ Mac では、`--runtime_dir`引数の代わりに`DYLD_LIBRARY_PATH`の指定が
 DYLD_LIBRARY_PATH="/path/to/onnx" python run.py --voicelib_dir="/path/to/voicevox_core"
 ```
 
-##### 音声ライブラリを自動読み込みする
+##### ユーザーディレクトリに配置する
 
-音声ライブラリを特定のフォルダ下へ配置すると自動読み込みできます。  
-次のフォルダの下に音声ライブラリフォルダを配置してください：  
+以下のディレクトリにある音声ライブラリは自動で読み込まれます。
 
-- 製品版: `<user_data_dir>/voicevox-engine/core_libraries/`
-- 開発版: `<user_data_dir>/voicevox-engine-dev/core_libraries/`
+- ビルド版: `<user_data_dir>/voicevox-engine/core_libraries/`
+- Python 版: `<user_data_dir>/voicevox-engine-dev/core_libraries/`
+
+`<user_data_dir>`は OS によって異なります。
+
+- Windows: `C:\Users\<username>\AppData\Local\`
+- macOS: `/Users/<username>/Library/Application\ Support/`
+- Linux: `/home/<username>/.local/share/`
 
 ### ビルド
 

--- a/README.md
+++ b/README.md
@@ -475,12 +475,8 @@ DYLD_LIBRARY_PATH="/path/to/onnx" python run.py --voicelib_dir="/path/to/voicevo
 音声ライブラリを特定のフォルダ下へ配置すると自動読み込みできます（製品版VOICEVOX・コンパイル済みエンジン・`run.py` 共通）。  
 次のフォルダの下に音声ライブラリフォルダを配置してください：  
 
-- 製品版
-  - Windows: `<user_data_dir>/voicevox-engine/core_libraries/`
-  - Linux/MacOS: `<user_data_dir>/VOICEVOX/core_libraries/`
-- 開発版:
-  - Windows: `<user_data_dir>/voicevox-engine-dev/core_libraries/`
-  - Linux/MacOS: `<user_data_dir>/VOICEVOX/core_libraries/`
+- 製品版: `<user_data_dir>/voicevox-engine/core_libraries/`
+- 開発版: `<user_data_dir>/voicevox-engine-dev/core_libraries/`
 
 ### ビルド
 

--- a/README.md
+++ b/README.md
@@ -470,6 +470,18 @@ Mac では、`--runtime_dir`引数の代わりに`DYLD_LIBRARY_PATH`の指定が
 DYLD_LIBRARY_PATH="/path/to/onnx" python run.py --voicelib_dir="/path/to/voicevox_core"
 ```
 
+##### 音声ライブラリを自動読み込みする
+
+音声ライブラリを特定のフォルダ下へ配置すると自動読み込みできます（製品版VOICEVOX・コンパイル済みエンジン・`run.py` 共通）。  
+次のフォルダの下に音声ライブラリフォルダを配置してください：  
+
+- 製品版
+  - Windows: `<user_data_dir>/voicevox-engine/core_libraries/`
+  - Linux/MacOS: `<user_data_dir>/VOICEVOX/core_libraries/`
+- 開発版:
+  - Windows: `<user_data_dir>/voicevox-engine-dev/core_libraries/`
+  - Linux/MacOS: `<user_data_dir>/VOICEVOX/core_libraries/`
+
 ### ビルド
 
 この方法でビルドしたものは、リリースで公開されているものとは異なります。


### PR DESCRIPTION
## 内容
追加: 「ユーザーディレクトリに過去のコアライブラリを配置」（音声ライブラリ自動読み込み） ドキュメントの追加

## 関連 Issue
resolve #459

## 論点
### ① パス表記法
ユーザデータディレクトリ（例: `C:\Users\<username>\AppData\Local\voicevox-engine`）の良い表記法が思いつかない。  
現在は `<user_data_dir>` と表記しているが、エンドユーザーには少なくとも伝わらない。  
エンジニア向けドキュメントではあるが、どうするのが良いか。  

### ② Linux/MacOS未検証
当方に Linux/MacOS デスクトップ環境が無いため、動作未確認。  

## スクリーンショット・動画など
動作検証: Windows / VOICEVOX製品版 v0.14.10 / 追加Core v0.13.3  

![image](https://github.com/VOICEVOX/voicevox_engine/assets/19833110/ba6ac214-1502-4651-9f5a-bbdaa83f6739)
