### PR TITLE
整理: `SynthesisEngine` → `TTSEngine` 改名

### DIFF
--- a/build_util/make_docs.py
+++ b/build_util/make_docs.py
@@ -1,7 +1,7 @@
 import json
 
 from voicevox_engine.dev.core import mock as core
-from voicevox_engine.dev.synthesis_engine.mock import MockSynthesisEngine
+from voicevox_engine.dev.synthesis_engine.mock import MockTTSEngine
 from voicevox_engine.preset import PresetManager
 from voicevox_engine.setting import USER_SETTING_PATH, SettingLoader
 from voicevox_engine.utility import engine_root
@@ -10,7 +10,7 @@ if __name__ == "__main__":
     import run
 
     app = run.generate_app(
-        synthesis_engines={"mock": MockSynthesisEngine(speakers=core.metas())},
+        synthesis_engines={"mock": MockTTSEngine(speakers=core.metas())},
         latest_core_version="mock",
         setting_loader=SettingLoader(USER_SETTING_PATH),
         preset_manager=PresetManager(  # FIXME: impl MockPresetManager

--- a/run.py
+++ b/run.py
@@ -65,7 +65,7 @@ from voicevox_engine.setting import (
     Setting,
     SettingLoader,
 )
-from voicevox_engine.tts_pipeline import SynthesisEngineBase, make_synthesis_engines
+from voicevox_engine.tts_pipeline import TTSEngineBase, make_synthesis_engines
 from voicevox_engine.tts_pipeline.kana_parser import create_kana, parse_kana
 from voicevox_engine.user_dict import (
     apply_word,
@@ -131,7 +131,7 @@ def set_output_log_utf8() -> None:
 
 
 def generate_app(
-    synthesis_engines: Dict[str, SynthesisEngineBase],
+    synthesis_engines: Dict[str, TTSEngineBase],
     latest_core_version: str,
     setting_loader: SettingLoader,
     preset_manager: PresetManager,
@@ -227,7 +227,7 @@ def generate_app(
     def apply_user_dict():
         update_dict()
 
-    def get_engine(core_version: Optional[str]) -> SynthesisEngineBase:
+    def get_engine(core_version: Optional[str]) -> TTSEngineBase:
         if core_version is None:
             return synthesis_engines[latest_core_version]
         if core_version in synthesis_engines:

--- a/test/test_mock_synthesis_engine.py
+++ b/test/test_mock_synthesis_engine.py
@@ -1,11 +1,11 @@
 from unittest import TestCase
 
-from voicevox_engine.dev.synthesis_engine import MockSynthesisEngine
+from voicevox_engine.dev.synthesis_engine import MockTTSEngine
 from voicevox_engine.model import AccentPhrase, AudioQuery, Mora
 from voicevox_engine.tts_pipeline.kana_parser import create_kana
 
 
-class TestMockSynthesisEngine(TestCase):
+class TestMockTTSEngine(TestCase):
     def setUp(self):
         super().setUp()
 
@@ -102,7 +102,7 @@ class TestMockSynthesisEngine(TestCase):
                 pause_mora=None,
             ),
         ]
-        self.engine = MockSynthesisEngine(speakers="", supported_devices="")
+        self.engine = MockTTSEngine(speakers="", supported_devices="")
 
     def test_replace_phoneme_length(self):
         self.assertEqual(

--- a/test/test_synthesis_engine.py
+++ b/test/test_synthesis_engine.py
@@ -8,7 +8,7 @@ from unittest.mock import Mock
 import numpy
 
 from voicevox_engine.model import AccentPhrase, AudioQuery, Mora
-from voicevox_engine.tts_pipeline import SynthesisEngine
+from voicevox_engine.tts_pipeline import TTSEngine
 from voicevox_engine.tts_pipeline.acoustic_feature_extractor import OjtPhoneme
 
 # TODO: import from voicevox_engine.synthesis_engine.mora
@@ -506,7 +506,7 @@ def test_query_to_decoder_feature():
     assert numpy.array_equal(f0, true_f0)
 
 
-class TestSynthesisEngine(TestCase):
+class TestTTSEngine(TestCase):
     def setUp(self):
         super().setUp()
         self.str_list_hello_hiho = (
@@ -543,7 +543,7 @@ class TestSynthesisEngine(TestCase):
         self.yukarin_s_mock = core.yukarin_s_forward
         self.yukarin_sa_mock = core.yukarin_sa_forward
         self.decode_mock = core.decode_forward
-        self.synthesis_engine = SynthesisEngine(core=core)
+        self.synthesis_engine = TTSEngine(core=core)
 
     def test_to_flatten_moras(self):
         flatten_moras = to_flatten_moras(self.accent_phrases_hello_hiho)
@@ -790,7 +790,7 @@ class TestSynthesisEngine(TestCase):
         for i in range(len(phoneme_length_list)):
             phoneme_length_list[i] /= audio_query.speedScale
 
-        # Outputs: MockCore入りSynthesisEngine の `.synthesis` 出力および core.decode_forward 引数
+        # Outputs: MockCore入りTTSEngine の `.synthesis` 出力および core.decode_forward 引数
         result = self.synthesis_engine.synthesis(query=audio_query, style_id=1)
         decode_args = self.decode_mock.call_args[1]
         list_length = decode_args["length"]

--- a/test/test_synthesis_engine_base.py
+++ b/test/test_synthesis_engine_base.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock
 import numpy
 
 from voicevox_engine.model import AccentPhrase, AudioQuery, Mora
-from voicevox_engine.tts_pipeline import SynthesisEngine
+from voicevox_engine.tts_pipeline import TTSEngine
 
 
 def yukarin_s_mock(length: int, phoneme_list: numpy.ndarray, style_id: numpy.ndarray):
@@ -184,10 +184,10 @@ class MockCore:
         return True
 
 
-class TestSynthesisEngineBase(TestCase):
+class TestTTSEngineBase(TestCase):
     def setUp(self):
         super().setUp()
-        self.synthesis_engine = SynthesisEngine(
+        self.synthesis_engine = TTSEngine(
             core=MockCore(),
         )
         self.synthesis_engine._synthesis_impl = Mock()

--- a/voicevox_engine/dev/core/mock.py
+++ b/voicevox_engine/dev/core/mock.py
@@ -32,7 +32,7 @@ def yukarin_sa_forward(length: int, **kwargs: Dict[str, Any]) -> np.ndarray:
 def decode_forward(length: int, **kwargs: Dict[str, Any]) -> np.ndarray:
     """
     合成音声の波形データをNumPy配列で返します。ただし、常に固定の文言を読み上げます（DUMMY_TEXT）
-    参照→SynthesisEngine のdocstring [Mock]
+    参照→TTSEngine のdocstring [Mock]
 
     Parameters
     ----------

--- a/voicevox_engine/dev/synthesis_engine/__init__.py
+++ b/voicevox_engine/dev/synthesis_engine/__init__.py
@@ -1,3 +1,3 @@
-from .mock import MockSynthesisEngine
+from .mock import MockTTSEngine
 
-__all__ = ["MockSynthesisEngine"]
+__all__ = ["MockTTSEngine"]

--- a/voicevox_engine/dev/synthesis_engine/mock.py
+++ b/voicevox_engine/dev/synthesis_engine/mock.py
@@ -6,13 +6,13 @@ from pyopenjtalk import tts
 from soxr import resample
 
 from ...model import AccentPhrase, AudioQuery
-from ...tts_pipeline import SynthesisEngineBase
+from ...tts_pipeline import TTSEngineBase
 from ...tts_pipeline.tts_engine import to_flatten_moras
 
 
-class MockSynthesisEngine(SynthesisEngineBase):
+class MockTTSEngine(TTSEngineBase):
     """
-    SynthesisEngine [Mock]
+    TTSEngine [Mock]
     """
 
     def __init__(
@@ -110,7 +110,7 @@ class MockSynthesisEngine(SynthesisEngineBase):
     def forward(self, text: str, **kwargs: Dict[str, Any]) -> np.ndarray:
         """
         forward tts via pyopenjtalk.tts()
-        参照→SynthesisEngine のdocstring [Mock]
+        参照→TTSEngine のdocstring [Mock]
 
         Parameters
         ----------

--- a/voicevox_engine/metas/MetasStore.py
+++ b/voicevox_engine/metas/MetasStore.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Dict, List, Tuple
 from voicevox_engine.metas.Metas import CoreSpeaker, EngineSpeaker, Speaker, StyleInfo
 
 if TYPE_CHECKING:
-    from voicevox_engine.tts_pipeline.tts_engine_base import SynthesisEngineBase
+    from voicevox_engine.tts_pipeline.tts_engine_base import TTSEngineBase
 
 
 class MetasStore:
@@ -29,13 +29,13 @@ class MetasStore:
         }
 
     # FIXME: engineではなくList[CoreSpeaker]を渡す形にすることで
-    # SynthesisEngineBaseによる循環importを修正する
-    def load_combined_metas(self, engine: "SynthesisEngineBase") -> List[Speaker]:
+    # TTSEngineBaseによる循環importを修正する
+    def load_combined_metas(self, engine: "TTSEngineBase") -> List[Speaker]:
         """
         コアに含まれる話者メタ情報とエンジンに含まれる話者メタ情報を統合
         Parameters
         ----------
-        engine : SynthesisEngineBase
+        engine : TTSEngineBase
             コアに含まれる話者メタ情報をもったエンジン
         Returns
         -------

--- a/voicevox_engine/morphing.py
+++ b/voicevox_engine/morphing.py
@@ -10,7 +10,7 @@ from soxr import resample
 from .metas.Metas import Speaker, SpeakerSupportPermittedSynthesisMorphing, StyleInfo
 from .metas.MetasStore import construct_lookup
 from .model import AudioQuery, MorphableTargetInfo, StyleIdNotFoundError
-from .tts_pipeline import SynthesisEngine
+from .tts_pipeline import TTSEngine
 
 
 # FIXME: ndarray type hint, https://github.com/JeremyCCHsu/Python-Wrapper-for-World-Vocoder/blob/2b64f86197573497c685c785c6e0e743f407b63e/pyworld/pyworld.pyx#L398  # noqa
@@ -128,7 +128,7 @@ def is_synthesis_morphing_permitted(
 
 
 def synthesis_morphing_parameter(
-    engine: SynthesisEngine,
+    engine: TTSEngine,
     query: AudioQuery,
     base_speaker: int,
     target_speaker: int,

--- a/voicevox_engine/tts_pipeline/__init__.py
+++ b/voicevox_engine/tts_pipeline/__init__.py
@@ -1,12 +1,12 @@
 from ..core_wrapper import CoreWrapper, load_runtime_lib
 from .make_tts_engines import make_synthesis_engines
-from .tts_engine import SynthesisEngine
-from .tts_engine_base import SynthesisEngineBase
+from .tts_engine import TTSEngine
+from .tts_engine_base import TTSEngineBase
 
 __all__ = [
     "CoreWrapper",
     "load_runtime_lib",
     "make_synthesis_engines",
-    "SynthesisEngine",
-    "SynthesisEngineBase",
+    "TTSEngine",
+    "TTSEngineBase",
 ]

--- a/voicevox_engine/tts_pipeline/make_tts_engines.py
+++ b/voicevox_engine/tts_pipeline/make_tts_engines.py
@@ -5,7 +5,7 @@ from typing import Dict, List, Optional
 
 from ..core_wrapper import CoreWrapper, load_runtime_lib
 from ..utility import engine_root, get_save_dir
-from .tts_engine import SynthesisEngine, SynthesisEngineBase
+from .tts_engine import TTSEngine, TTSEngineBase
 
 
 def make_synthesis_engines(
@@ -16,7 +16,7 @@ def make_synthesis_engines(
     cpu_num_threads: Optional[int] = None,
     enable_mock: bool = True,
     load_all_models: bool = False,
-) -> Dict[str, SynthesisEngineBase]:
+) -> Dict[str, TTSEngineBase]:
     """
     音声ライブラリをロードして、音声合成エンジンを生成
 
@@ -88,7 +88,7 @@ def make_synthesis_engines(
                         file=sys.stderr,
                     )
                 else:
-                    synthesis_engines[core_version] = SynthesisEngine(core=core)
+                    synthesis_engines[core_version] = TTSEngine(core=core)
             except Exception:
                 if not suppress_error:
                     raise
@@ -113,11 +113,11 @@ def make_synthesis_engines(
         # モック追加
         from ..dev.core import metas as mock_metas
         from ..dev.core import supported_devices as mock_supported_devices
-        from ..dev.synthesis_engine import MockSynthesisEngine
+        from ..dev.synthesis_engine import MockTTSEngine
 
         if "0.0.0" not in synthesis_engines:
             print("Info: Loading mock.")
-            synthesis_engines["0.0.0"] = MockSynthesisEngine(
+            synthesis_engines["0.0.0"] = MockTTSEngine(
                 speakers=mock_metas(), supported_devices=mock_supported_devices()
             )
 

--- a/voicevox_engine/tts_pipeline/tts_engine.py
+++ b/voicevox_engine/tts_pipeline/tts_engine.py
@@ -9,7 +9,7 @@ from soxr import resample
 from ..core_wrapper import CoreWrapper, OldCoreError
 from ..model import AccentPhrase, AudioQuery, Mora
 from .acoustic_feature_extractor import OjtPhoneme
-from .tts_engine_base import SynthesisEngineBase
+from .tts_engine_base import TTSEngineBase
 
 unvoiced_mora_phoneme_list = ["A", "I", "U", "E", "O", "cl", "pau"]
 mora_phoneme_list = ["a", "i", "u", "e", "o", "N"] + unvoiced_mora_phoneme_list
@@ -397,7 +397,7 @@ def raw_wave_to_output_wave(query: AudioQuery, wave: ndarray, sr_wave: int) -> n
     return wave
 
 
-class SynthesisEngine(SynthesisEngineBase):
+class TTSEngine(TTSEngineBase):
     """音声合成器（core）の管理/実行/プロキシと音声合成フロー"""
 
     def __init__(self, core: CoreWrapper):

--- a/voicevox_engine/tts_pipeline/tts_engine_base.py
+++ b/voicevox_engine/tts_pipeline/tts_engine_base.py
@@ -172,7 +172,7 @@ def test_to_accent_phrases(text: str) -> list[AccentPhrase]:
     return utterance_to_accent_phrases(utterance)
 
 
-class SynthesisEngineBase(metaclass=ABCMeta):
+class TTSEngineBase(metaclass=ABCMeta):
     @property
     @abstractmethod
     def default_sampling_rate(self) -> int:


### PR DESCRIPTION
## 内容
`SynthesisEngine` → `TTSEngine` 改名によるリファクタリング  

## 関連 Issue
ref #822

## Reviewer 向け情報

### 変更内容
- `SynthesisEngineBase` → `TTSEngineBase`
- `SynthesisEngine` → `TTSEngine`
- `MockSynthesisEngine` → `MockTTSEngine`

### 依存 Issues
以下の issues / PRs に依存、これらが解決の後、reviewとマージ可能

- #867