### PR TITLE
整理: `_synthesis_impl` 前処理/後処理の関数化

### DIFF
--- a/test/test_synthesis_engine.py
+++ b/test/test_synthesis_engine.py
@@ -26,6 +26,7 @@ from voicevox_engine.tts_pipeline.tts_engine import (
     calc_frame_pitch,
     mora_phoneme_list,
     pre_process,
+    query_to_decoder_feature,
     split_mora,
     to_flatten_moras,
     to_flatten_phonemes,
@@ -446,8 +447,8 @@ def test_calc_frame_phoneme():
     assert numpy.array_equal(frame_phoneme, true_frame_phoneme)
 
 
-def test_feat_to_framescale():
-    """Test Mora/Phonemefeature-to-framescaleFeature pipeline."""
+def test_query_to_decoder_feature():
+    """Test `query_to_decoder_feature`."""
     # Inputs
     accent_phrases = [
         AccentPhrase(
@@ -485,9 +486,9 @@ def test_feat_to_framescale():
     # phoneme
     #                     Pr  k   o   o  N  N pau  h   i   i   h   h  O Pt Pt Pt
     frame_phoneme_idxs = [0, 23, 30, 30, 4, 4, 0, 19, 21, 21, 19, 19, 5, 0, 0, 0]
-    true_frame_phoneme = numpy.zeros([n_frame, TRUE_NUM_PHONEME], dtype=numpy.float32)
+    true_phoneme = numpy.zeros([n_frame, TRUE_NUM_PHONEME], dtype=numpy.float32)
     for frame_idx, phoneme_idx in enumerate(frame_phoneme_idxs):
-        true_frame_phoneme[frame_idx, phoneme_idx] = 1.0
+        true_phoneme[frame_idx, phoneme_idx] = 1.0
     # Pitch
     #          Pre   ko      N    pau   hi    hO   Pst
     true_f0 = [0.0, 200.0, 200.0, 0.0, 500.0, 0.0, 0.0]  # mean 300
@@ -503,19 +504,9 @@ def test_feat_to_framescale():
     true_f0 = numpy.array(true1_f0 + true2_f0 + true3_f0, dtype=numpy.float32)
 
     # Outputs
-    flatten_moras = to_flatten_moras(query.accent_phrases)
-    flatten_moras = apply_prepost_silence(flatten_moras, query)
-    flatten_moras = apply_speed_scale(flatten_moras, query)
-    flatten_moras = apply_pitch_scale(flatten_moras, query)
-    flatten_moras = apply_intonation_scale(flatten_moras, query)
+    phoneme, f0 = query_to_decoder_feature(query)
 
-    phoneme_data_list = to_flatten_phonemes(flatten_moras)
-
-    frame_per_phoneme = calc_frame_per_phoneme(flatten_moras)
-    f0 = calc_frame_pitch(flatten_moras)
-    frame_phoneme = calc_frame_phoneme(phoneme_data_list, frame_per_phoneme)
-
-    assert numpy.array_equal(frame_phoneme, true_frame_phoneme)
+    assert numpy.array_equal(phoneme, true_phoneme)
     assert numpy.array_equal(f0, true_f0)
 
 

--- a/voicevox_engine/tts_pipeline/tts_engine.py
+++ b/voicevox_engine/tts_pipeline/tts_engine.py
@@ -374,6 +374,7 @@ def query_to_decoder_feature(query: AudioQuery) -> tuple[ndarray, ndarray]:
         フレームごとの基本周波数、shape=(Frame,)
     """
     flatten_moras = to_flatten_moras(query.accent_phrases)
+
     flatten_moras = apply_prepost_silence(flatten_moras, query)
     flatten_moras = apply_speed_scale(flatten_moras, query)
     flatten_moras = apply_pitch_scale(flatten_moras, query)


### PR DESCRIPTION
## 内容
`_synthesis_impl` 前処理/後処理の関数化によるリファクタリング  

重複を排除して整理された前処理/後処理をテスト可能な関数として切り出した。  

## 関連 Issue
step4 of #815 

## Reviewer 向け情報
### 依存 Issues
以下の issues / PRs に依存、これらが解決の後、reviewとマージ可能

- [x] #867