### PR TITLE
廃止: `MetasStore` の不使用関数

### DIFF
--- a/voicevox_engine/metas/MetasStore.py
+++ b/voicevox_engine/metas/MetasStore.py
@@ -22,7 +22,6 @@ class MetasStore:
         engine_speakers_path : Path
             エンジンに含まれる話者メタ情報ディレクトリのパス。
         """
-        self._engine_speakers_path = engine_speakers_path
         # エンジンに含まれる各話者のメタ情報
         self._loaded_metas: Dict[str, EngineSpeaker] = {
             folder.name: EngineSpeaker(

--- a/voicevox_engine/metas/MetasStore.py
+++ b/voicevox_engine/metas/MetasStore.py
@@ -86,10 +86,6 @@ class MetasStore:
         return self.combine_metas(core_metas)
 
     @property
-    def engine_speakers_path(self) -> Path:
-        return self._engine_speakers_path
-
-    @property
     def loaded_metas(self) -> Dict[str, EngineSpeaker]:
         return self._loaded_metas
 

--- a/voicevox_engine/metas/MetasStore.py
+++ b/voicevox_engine/metas/MetasStore.py
@@ -30,27 +30,6 @@ class MetasStore:
             for folder in engine_speakers_path.iterdir()
         }
 
-    def combine_metas(self, core_metas: List[CoreSpeaker]) -> List[Speaker]:
-        """
-        コアに含まれる話者メタ情報に、エンジンに含まれる話者メタ情報を統合して返す
-        Parameters
-        ----------
-        core_metas : List[CoreSpeaker]
-            コアに含まれる話者メタ情報
-        Returns
-        -------
-        ret : List[Speaker]
-            エンジンとコアに含まれる話者メタ情報
-        """
-        # 話者単位でエンジン・コアに含まれるメタ情報を統合
-        return [
-            Speaker(
-                **self.self._loaded_metas[speaker_meta.speaker_uuid].dict(),
-                **speaker_meta.dict(),
-            )
-            for speaker_meta in core_metas
-        ]
-
     # FIXME: engineではなくList[CoreSpeaker]を渡す形にすることで
     # SynthesisEngineBaseによる循環importを修正する
     def load_combined_metas(self, engine: "SynthesisEngineBase") -> List[Speaker]:
@@ -68,7 +47,13 @@ class MetasStore:
         # コアに含まれる話者メタ情報の収集
         core_metas = [CoreSpeaker(**speaker) for speaker in json.loads(engine.speakers)]
         # エンジンに含まれる話者メタ情報との統合
-        return self.combine_metas(core_metas)
+        return [
+            Speaker(
+                **self.self._loaded_metas[speaker_meta.speaker_uuid].dict(),
+                **speaker_meta.dict(),
+            )
+            for speaker_meta in core_metas
+        ]
 
 
 def construct_lookup(speakers: List[Speaker]) -> Dict[int, Tuple[Speaker, StyleInfo]]:

--- a/voicevox_engine/metas/MetasStore.py
+++ b/voicevox_engine/metas/MetasStore.py
@@ -30,20 +30,6 @@ class MetasStore:
             for folder in engine_speakers_path.iterdir()
         }
 
-    def speaker_engine_metas(self, speaker_uuid: str) -> EngineSpeaker:
-        """
-        エンジンに含まれる指定話者のメタ情報を取得
-        Parameters
-        ----------
-        speaker_uuid : str
-            話者UUID
-        Returns
-        -------
-        ret : EngineSpeaker
-            エンジンに含まれる指定話者のメタ情報
-        """
-        return self._loaded_metas[speaker_uuid]
-
     def combine_metas(self, core_metas: List[CoreSpeaker]) -> List[Speaker]:
         """
         コアに含まれる話者メタ情報に、エンジンに含まれる話者メタ情報を統合して返す
@@ -59,7 +45,7 @@ class MetasStore:
         # 話者単位でエンジン・コアに含まれるメタ情報を統合
         return [
             Speaker(
-                **self.speaker_engine_metas(speaker_meta.speaker_uuid).dict(),
+                **self.self._loaded_metas[speaker_meta.speaker_uuid].dict(),
                 **speaker_meta.dict(),
             )
             for speaker_meta in core_metas

--- a/voicevox_engine/metas/MetasStore.py
+++ b/voicevox_engine/metas/MetasStore.py
@@ -42,7 +42,7 @@ class MetasStore:
         ret : EngineSpeaker
             エンジンに含まれる指定話者のメタ情報
         """
-        return self.loaded_metas[speaker_uuid]
+        return self._loaded_metas[speaker_uuid]
 
     def combine_metas(self, core_metas: List[CoreSpeaker]) -> List[Speaker]:
         """
@@ -83,10 +83,6 @@ class MetasStore:
         core_metas = [CoreSpeaker(**speaker) for speaker in json.loads(engine.speakers)]
         # エンジンに含まれる話者メタ情報との統合
         return self.combine_metas(core_metas)
-
-    @property
-    def loaded_metas(self) -> Dict[str, EngineSpeaker]:
-        return self._loaded_metas
 
 
 def construct_lookup(speakers: List[Speaker]) -> Dict[int, Tuple[Speaker, StyleInfo]]:


### PR DESCRIPTION
## 内容
`MetasStore` 不使用関数の廃止  

`MetasStore` はエンジンが含むメタ情報を保持し、それらをコアが含むメタ情報と統合する機能をもつ。  
このクラスは以下の5つのメソッド・propertyを有する：  

- `speaker_engine_metas()`
- `combine_metas()`
- `load_combined_metas()`
- `engine_speakers_path`
- `loaded_metas`

しかし現在の VOICEVOX ENGINE では `load_combined_metas()` のみが実質 public として機能しており、他は不使用 or private method として運用されている。  
現状メタ情報はエンジン+コアのセットで扱われており、また将来的に元のメタ情報がコア側へ寄せられると考えられる（c.f. #847）。  
よってエンジンmetasとコアmetasを別扱いする上記実質 private 関数が存在する意義は薄い。  

その結果、現在の `MetasStore` は粒度が小さい関数が並列しており、コードの見通しに課題がある。  

このような背景から、`MetasStore` 不使用関数の廃止を提案します。  

## 関連 Issue
無し

## Reviewer 向け情報
### 変更内容
4/5の関数を廃止したため、diffが機能していません。  
よって 1 commit 単位でレビュー可能なよう commit log を調整してあります。   
順に追っていただければ比較的容易にレビューできるかと思います。  
少し変則的でお手数おかけします、よろしくお願いします。  