### PR TITLE
hotfix/build_utilディレクトリ内のスクリプトのDockerfile内でのコピーを正しい形に

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -227,7 +227,8 @@ COPY --from=download-onnxruntime-env /opt/onnxruntime /opt/onnxruntime
 # Add local files
 ADD ./voicevox_engine /opt/voicevox_engine/voicevox_engine
 ADD ./docs /opt/voicevox_engine/docs
-ADD ./run.py ./build_util/generate_licenses.py ./presets.yaml ./default.csv ./engine_manifest.json /opt/voicevox_engine/
+ADD ./run.py ./presets.yaml ./default.csv ./engine_manifest.json /opt/voicevox_engine/
+ADD ./build_util/generate_licenses.py /opt/voicevox_engine/build_util
 ADD ./speaker_info /opt/voicevox_engine/speaker_info
 ADD ./ui_template /opt/voicevox_engine/ui_template
 ADD ./engine_manifest_assets /opt/voicevox_engine/engine_manifest_assets


### PR DESCRIPTION
## 内容

Docker Buildが落ちていてレビュー漏れがあったことに気づきました。 
https://github.com/VOICEVOX/voicevox_engine/actions/runs/7224324841/job/19685363884

https://github.com/VOICEVOX/voicevox_engine/blob/ec1f70e52b1df5628317311fced841f4e9d8877c/Dockerfile#L230

ここで`build_util/generate_licenses.py`ファイルを`/opt/voicevox_engine/`の下にコピーしているので、後の`gosu user /opt/python/bin/python3 build_util/generate_licenses.py`がエラーを吐いている気がします。

ということで修正してみました。

## 関連 Issue

- https://github.com/VOICEVOX/voicevox_engine/pull/874


## その他
