### PR TITLE
[hotfix] Dockerfileのディレクトリ以下へのコピーのスラッシュ忘れ

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -228,7 +228,7 @@ COPY --from=download-onnxruntime-env /opt/onnxruntime /opt/onnxruntime
 ADD ./voicevox_engine /opt/voicevox_engine/voicevox_engine
 ADD ./docs /opt/voicevox_engine/docs
 ADD ./run.py ./presets.yaml ./default.csv ./engine_manifest.json /opt/voicevox_engine/
-ADD ./build_util/generate_licenses.py /opt/voicevox_engine/build_util
+ADD ./build_util/generate_licenses.py /opt/voicevox_engine/build_util/
 ADD ./speaker_info /opt/voicevox_engine/speaker_info
 ADD ./ui_template /opt/voicevox_engine/ui_template
 ADD ./engine_manifest_assets /opt/voicevox_engine/engine_manifest_assets


### PR DESCRIPTION
## 内容

- https://github.com/VOICEVOX/voicevox_engine/pull/878

って修正したつもりだったのですが、まだエラーがありました。

https://github.com/VOICEVOX/voicevox_engine/actions/runs/7224472734/job/19685829538

ディレクトリ以下にファイルをコピーしたいけど、末尾に`/`を書いていなかったのでディレクトリ指定になっていない気がしたので修正してみました。

## 関連 Issue

- https://github.com/VOICEVOX/voicevox_engine/pull/874
- https://github.com/VOICEVOX/voicevox_engine/pull/878

