### PR TITLE
整理: フルコンテキストラベル関連コメント/docstring/型ヒント

### DIFF
--- a/voicevox_engine/tts_pipeline/full_context_label.py
+++ b/voicevox_engine/tts_pipeline/full_context_label.py
@@ -196,7 +196,7 @@ class AccentPhrase:
             # 区切りとなるcontextが出現するまでモーラごとの音素系列に一時保存する
             mora_phonemes.append(phoneme)
 
-            # 確定したモーラごとの音素系列を処理する
+            # 一時的な音素系列を確定させて処理する
             # context a2 の定義: "position of the current mora identity in the current accent phrase (forward)    1 ~ 49"  # noqa: B950
             if (
                 next_phoneme is None
@@ -314,7 +314,7 @@ class BreathGroup:
             # 区切りとなるcontextが出現するまでアクセント句ごとの音素系列に一時保存する
             accent_phonemes.append(phoneme)
 
-            # 確定したアクセント句ごとの音素系列を処理する
+            # 一時的な音素系列を確定させて処理する
             # context i3 の定義: "position of the current breath group identity by breath group (forward)"  # noqa: B950
             # context f5 の定義: "position of the current accent phrase identity in the current breath group by the accent phrase (forward)"  # noqa: B950
             if (
@@ -404,7 +404,7 @@ class Utterance:
             if not phoneme.is_pause():
                 group_phonemes.append(phoneme)
 
-            # 確定したBreathGroupごとの音素系列を処理する
+            # 一時的な音素系列を確定させて処理する
             else:
                 # ポーズ音素を保存する
                 pauses.append(phoneme)

--- a/voicevox_engine/tts_pipeline/full_context_label.py
+++ b/voicevox_engine/tts_pipeline/full_context_label.py
@@ -180,7 +180,7 @@ class AccentPhrase:
 
     @classmethod
     def from_phonemes(cls, phonemes: list[Phoneme]) -> Self:
-        """音素系列をcontextで区切り AccentPhrase インスタンスを生成する"""
+        """音素系列をcontextで区切りAccentPhraseインスタンスを生成する"""
 
         # NOTE:「モーラごとの音素系列」は音素系列をcontextで区切り生成される。
 
@@ -303,7 +303,7 @@ class BreathGroup:
 
     @classmethod
     def from_phonemes(cls, phonemes: list[Phoneme]) -> Self:
-        """音素系列をcontextで区切り BreathGroup インスタンスを生成する"""
+        """音素系列をcontextで区切りBreathGroupインスタンスを生成する"""
 
         # NOTE:「アクセント句ごとの音素系列」は音素系列をcontextで区切り生成される。
 
@@ -391,7 +391,7 @@ class Utterance:
 
     @classmethod
     def from_phonemes(cls, phonemes: list[Phoneme]) -> Self:
-        """音素系列をポーズで区切り Utterance インスタンスを生成する"""
+        """音素系列をポーズで区切りUtteranceインスタンスを生成する"""
 
         # NOTE:「BreathGroupごとの音素系列」は音素系列をポーズで区切り生成される。
 
@@ -409,13 +409,13 @@ class Utterance:
                 # ポーズ音素を保存する
                 pauses.append(phoneme)
                 if len(group_phonemes) > 0:
-                    # 音素系列から BreathGroup を生成して保存する
+                    # 音素系列からBreathGroupを生成して保存する
                     breath_group = BreathGroup.from_phonemes(group_phonemes)
                     breath_groups.append(breath_group)
                     # 次に向けてリセット
                     group_phonemes = []
 
-        # Utterance インスタンスを生成する
+        # Utteranceインスタンスを生成する
         utterance = cls(breath_groups=breath_groups, pauses=pauses)
 
         return utterance

--- a/voicevox_engine/tts_pipeline/full_context_label.py
+++ b/voicevox_engine/tts_pipeline/full_context_label.py
@@ -193,7 +193,7 @@ class AccentPhrase:
             if int(phoneme.contexts["a2"]) == 49:
                 break
 
-            # 区切りとなるcontextが出現するまでモーラごとの音素系列に一時保存する
+            # 区切りまで音素系列を一時保存する
             mora_phonemes.append(phoneme)
 
             # 一時的な音素系列を確定させて処理する
@@ -311,7 +311,7 @@ class BreathGroup:
         accent_phonemes: list[Phoneme] = []  # アクセント句ごとの音素系列を一時保存するコンテナ
 
         for phoneme, next_phoneme in zip(phonemes, phonemes[1:] + [None]):
-            # 区切りとなるcontextが出現するまでアクセント句ごとの音素系列に一時保存する
+            # 区切りまで音素系列を一時保存する
             accent_phonemes.append(phoneme)
 
             # 一時的な音素系列を確定させて処理する
@@ -400,7 +400,7 @@ class Utterance:
         group_phonemes: list[Phoneme] = []  # BreathGroupごとの音素系列を一時保存するコンテナ
 
         for phoneme in phonemes:
-            # ポーズが出現するまでBreathGroupごとの音素系列に一時保存する
+            # ポーズが出現するまで音素系列を一時保存する
             if not phoneme.is_pause():
                 group_phonemes.append(phoneme)
 

--- a/voicevox_engine/tts_pipeline/full_context_label.py
+++ b/voicevox_engine/tts_pipeline/full_context_label.py
@@ -197,7 +197,7 @@ class AccentPhrase:
             mora_phonemes.append(phoneme)
 
             # 一時的な音素系列を確定させて処理する
-            # context a2 の定義: "position of the current mora identity in the current accent phrase (forward)    1 ~ 49"  # noqa: B950
+            # a2はアクセント句内でのモーラ番号(1~49)
             if (
                 next_phoneme is None
                 or phoneme.contexts["a2"] != next_phoneme.contexts["a2"]
@@ -216,13 +216,13 @@ class AccentPhrase:
                 mora_phonemes = []
 
         # アクセント位置を決定する
-        # context f2 の定義: "accent type in the current accent phrase    1 ~ 49"
+        # f2はアクセント句のアクセント位置(1~49)
         accent = int(moras[0].vowel.contexts["f2"])
         # f2 の値がアクセント句内のモーラ数を超える場合はクリップ（ワークアラウンド、VOICEVOX/voicevox_engine#55 を参照）
         accent = accent if accent <= len(moras) else len(moras)
 
         # 疑問文か否か判定する（末尾モーラ母音のcontextに基づく）
-        # context f3 の定義: "whether the current accent phrase interrogative or not (0: not interrogative, 1: interrogative)"  # noqa: B950
+        # f3はアクセント句が疑問文かどうか（1で疑問文）
         is_interrogative = moras[-1].vowel.contexts["f3"] == "1"
 
         # AccentPhrase インスタンスを生成する
@@ -315,8 +315,8 @@ class BreathGroup:
             accent_phonemes.append(phoneme)
 
             # 一時的な音素系列を確定させて処理する
-            # context i3 の定義: "position of the current breath group identity by breath group (forward)"  # noqa: B950
-            # context f5 の定義: "position of the current accent phrase identity in the current breath group by the accent phrase (forward)"  # noqa: B950
+            # i3はBreathGroupの番号
+            # f5はBreathGroup内でのアクセント句の番号
             if (
                 next_phoneme is None
                 or phoneme.contexts["i3"] != next_phoneme.contexts["i3"]

--- a/voicevox_engine/tts_pipeline/full_context_label.py
+++ b/voicevox_engine/tts_pipeline/full_context_label.py
@@ -212,7 +212,7 @@ class AccentPhrase:
                 # 子音と母音からモーラを生成して保存する
                 mora = Mora(consonant=consonant, vowel=vowel)
                 moras.append(mora)
-                # モーラごとの音素系列コンテナを初期化する
+                # 次に向けてリセット
                 mora_phonemes = []
 
         # アクセント位置を決定する
@@ -325,7 +325,7 @@ class BreathGroup:
                 # アクセント句を生成して保存する
                 accent_phrase = AccentPhrase.from_phonemes(accent_phonemes)
                 accent_phrases.append(accent_phrase)
-                # アクセント句ごとの音素系列コンテナを初期化する
+                # 次に向けてリセット
                 accent_phonemes = []
 
         # BreathGroup インスタンスを生成する
@@ -412,7 +412,7 @@ class Utterance:
                     # 音素系列から BreathGroup を生成して保存する
                     breath_group = BreathGroup.from_phonemes(group_phonemes)
                     breath_groups.append(breath_group)
-                    # BreathGroupごとの音素系列コンテナを初期化する
+                    # 次に向けてリセット
                     group_phonemes = []
 
         # Utterance インスタンスを生成する

--- a/voicevox_engine/tts_pipeline/full_context_label.py
+++ b/voicevox_engine/tts_pipeline/full_context_label.py
@@ -184,7 +184,7 @@ class AccentPhrase:
 
         # NOTE:「モーラごとの音素系列」は単一モーラを構成する音素系列である。音素系列をcontextで区切り生成される。
 
-        moras: list[Mora] = []  # 音素サブ行列から生成されたモーラ系列
+        moras: list[Mora] = []  # モーラごとの音素系列から生成されたモーラ系列
         mora_phonemes: list[Phoneme] = []  # モーラごとの音素系列を一時保存するコンテナ
 
         for phoneme, next_phoneme in zip(phonemes, phonemes[1:] + [None]):
@@ -212,7 +212,7 @@ class AccentPhrase:
                 # 子音と母音からモーラを生成して保存する
                 mora = Mora(consonant=consonant, vowel=vowel)
                 moras.append(mora)
-                # 音素サブ行列コンテナを初期化する
+                # モーラごとの音素系列コンテナを初期化する
                 mora_phonemes = []
 
         # アクセント位置を決定する
@@ -307,7 +307,7 @@ class BreathGroup:
 
         # NOTE:「アクセント句ごとの音素系列」は単一アクセント句を構成する音素系列である。音素系列をcontextで区切り生成される。
 
-        accent_phrases: list[AccentPhrase] = []  # 音素サブ行列から生成されたアクセント句系列
+        accent_phrases: list[AccentPhrase] = []  # アクセント句ごとの音素系列から生成されたアクセント句系列
         accent_phonemes: list[Phoneme] = []  # アクセント句ごとの音素系列を一時保存するコンテナ
 
         for phoneme, next_phoneme in zip(phonemes, phonemes[1:] + [None]):
@@ -325,7 +325,7 @@ class BreathGroup:
                 # アクセント句ごとの音素系列からアクセント句を生成して保存する
                 accent_phrase = AccentPhrase.from_phonemes(accent_phonemes)
                 accent_phrases.append(accent_phrase)
-                # 音素サブ行列コンテナを初期化する
+                # アクセント句ごとの音素系列コンテナを初期化する
                 accent_phonemes = []
 
         # BreathGroup インスタンスを生成する
@@ -396,7 +396,7 @@ class Utterance:
         # NOTE:「BreathGroupごとの音素系列」は単一 BreathGroup を構成する音素系列である。音素系列をポーズで区切り生成される。
 
         pauses: list[Phoneme] = []  # ポーズ音素のリスト
-        breath_groups: list[BreathGroup] = []  # 音素サブ行列から生成された BreathGroup のリスト
+        breath_groups: list[BreathGroup] = []  # BreathGroupごとの音素系列から生成された BreathGroup のリスト
         group_phonemes: list[Phoneme] = []  # BreathGroupごとの音素系列を一時保存するコンテナ
 
         for phoneme in phonemes:
@@ -412,7 +412,7 @@ class Utterance:
                     # BreathGroupごとの音素系列から BreathGroup を生成して保存する
                     breath_group = BreathGroup.from_phonemes(group_phonemes)
                     breath_groups.append(breath_group)
-                    # 音素サブ行列コンテナを初期化する
+                    # BreathGroupごとの音素系列コンテナを初期化する
                     group_phonemes = []
 
         # Utterance インスタンスを生成する

--- a/voicevox_engine/tts_pipeline/full_context_label.py
+++ b/voicevox_engine/tts_pipeline/full_context_label.py
@@ -193,7 +193,7 @@ class AccentPhrase:
             if int(phoneme.contexts["a2"]) == 49:
                 break
 
-            # 区切りとなるcontextが出現するまでモーラごとの音素系列の一員として一時保存する
+            # 区切りとなるcontextが出現するまでモーラごとの音素系列に一時保存する
             mora_phonemes.append(phoneme)
 
             # 確定したモーラごとの音素系列を処理する
@@ -311,7 +311,7 @@ class BreathGroup:
         accent_phonemes: list[Phoneme] = []  # アクセント句ごとの音素系列を一時保存するコンテナ
 
         for phoneme, next_phoneme in zip(phonemes, phonemes[1:] + [None]):
-            # 区切りとなるcontextが出現するまでアクセント句ごとの音素系列の一員として一時保存する
+            # 区切りとなるcontextが出現するまでアクセント句ごとの音素系列に一時保存する
             accent_phonemes.append(phoneme)
 
             # 確定したアクセント句ごとの音素系列を処理する
@@ -400,7 +400,7 @@ class Utterance:
         group_phonemes: list[Phoneme] = []  # BreathGroupごとの音素系列を一時保存するコンテナ
 
         for phoneme in phonemes:
-            # ポーズが出現するまでBreathGroupごとの音素系列の一員として一時保存する
+            # ポーズが出現するまでBreathGroupごとの音素系列に一時保存する
             if not phoneme.is_pause():
                 group_phonemes.append(phoneme)
 

--- a/voicevox_engine/tts_pipeline/full_context_label.py
+++ b/voicevox_engine/tts_pipeline/full_context_label.py
@@ -322,7 +322,7 @@ class BreathGroup:
                 or phoneme.contexts["i3"] != next_phoneme.contexts["i3"]
                 or phoneme.contexts["f5"] != next_phoneme.contexts["f5"]
             ):
-                # アクセント句ごとの音素系列からアクセント句を生成して保存する
+                # アクセント句を生成して保存する
                 accent_phrase = AccentPhrase.from_phonemes(accent_phonemes)
                 accent_phrases.append(accent_phrase)
                 # アクセント句ごとの音素系列コンテナを初期化する
@@ -409,7 +409,7 @@ class Utterance:
                 # ポーズ音素を保存する
                 pauses.append(phoneme)
                 if len(group_phonemes) > 0:
-                    # BreathGroupごとの音素系列から BreathGroup を生成して保存する
+                    # 音素系列から BreathGroup を生成して保存する
                     breath_group = BreathGroup.from_phonemes(group_phonemes)
                     breath_groups.append(breath_group)
                     # BreathGroupごとの音素系列コンテナを初期化する

--- a/voicevox_engine/tts_pipeline/full_context_label.py
+++ b/voicevox_engine/tts_pipeline/full_context_label.py
@@ -182,9 +182,9 @@ class AccentPhrase:
     def from_phonemes(cls, phonemes: list[Phoneme]) -> Self:
         """音素系列をcontextで区切り AccentPhrase インスタンスを生成する"""
 
-        # NOTE:「モーラごとの音素系列」は単一モーラを構成する音素系列である。音素系列をcontextで区切り生成される。
+        # NOTE:「モーラごとの音素系列」は音素系列をcontextで区切り生成される。
 
-        moras: list[Mora] = []  # モーラごとの音素系列から生成されたモーラ系列
+        moras: list[Mora] = []  # モーラ系列
         mora_phonemes: list[Phoneme] = []  # モーラごとの音素系列を一時保存するコンテナ
 
         for phoneme, next_phoneme in zip(phonemes, phonemes[1:] + [None]):
@@ -305,9 +305,9 @@ class BreathGroup:
     def from_phonemes(cls, phonemes: list[Phoneme]) -> Self:
         """音素系列をcontextで区切り BreathGroup インスタンスを生成する"""
 
-        # NOTE:「アクセント句ごとの音素系列」は単一アクセント句を構成する音素系列である。音素系列をcontextで区切り生成される。
+        # NOTE:「アクセント句ごとの音素系列」は音素系列をcontextで区切り生成される。
 
-        accent_phrases: list[AccentPhrase] = []  # アクセント句ごとの音素系列から生成されたアクセント句系列
+        accent_phrases: list[AccentPhrase] = []  # アクセント句系列
         accent_phonemes: list[Phoneme] = []  # アクセント句ごとの音素系列を一時保存するコンテナ
 
         for phoneme, next_phoneme in zip(phonemes, phonemes[1:] + [None]):
@@ -393,10 +393,10 @@ class Utterance:
     def from_phonemes(cls, phonemes: list[Phoneme]) -> Self:
         """音素系列をポーズで区切り Utterance インスタンスを生成する"""
 
-        # NOTE:「BreathGroupごとの音素系列」は単一 BreathGroup を構成する音素系列である。音素系列をポーズで区切り生成される。
+        # NOTE:「BreathGroupごとの音素系列」は音素系列をポーズで区切り生成される。
 
         pauses: list[Phoneme] = []  # ポーズ音素のリスト
-        breath_groups: list[BreathGroup] = []  # BreathGroupごとの音素系列から生成された BreathGroup のリスト
+        breath_groups: list[BreathGroup] = []  # BreathGroup のリスト
         group_phonemes: list[Phoneme] = []  # BreathGroupごとの音素系列を一時保存するコンテナ
 
         for phoneme in phonemes:

--- a/voicevox_engine/tts_pipeline/full_context_label.py
+++ b/voicevox_engine/tts_pipeline/full_context_label.py
@@ -81,11 +81,11 @@ class Phoneme:
     @property
     def phoneme(self):
         """
-        音素クラスの中で、発声に必要な要素を返す
+        音素クラスの中で、発声に必要なcontextを返す
         Returns
         -------
         phoneme : str
-            発声に必要な要素を返す
+            発声に必要なcontextを返す
         """
         return self.contexts["p3"]
 
@@ -180,24 +180,24 @@ class AccentPhrase:
 
     @classmethod
     def from_phonemes(cls, phonemes: list[Phoneme]) -> Self:
-        """音素系列をコンテキスト値で区切り AccentPhrase インスタンスを生成する"""
+        """音素系列をcontextで区切り AccentPhrase インスタンスを生成する"""
 
-        # NOTE:「音素サブ系列」は単一モーラを構成する音素系列である。音素系列をコンテキスト値で区切り生成される。
+        # NOTE:「音素サブ系列」は単一モーラを構成する音素系列である。音素系列をcontextで区切り生成される。
 
         moras: list[Mora] = []  # 音素サブ行列から生成されたモーラ系列
         mora_phonemes: list[Phoneme] = []  # 音素サブ系列を一時保存するコンテナ
 
         for phoneme, next_phoneme in zip(phonemes, phonemes[1:] + [None]):
             # モーラ抽出を打ち切る（ワークアラウンド、VOICEVOX/voicevox_engine#57）
-            # (py)openjtalk コンテキスト a2 属性（モーラ番号）の最大値が 49 であるため、49番目以降のモーラでは音素のモーラ番号を区切りに使えない
+            # context a2（モーラ番号）の最大値が 49 であるため、49番目以降のモーラでは音素のモーラ番号を区切りに使えない
             if int(phoneme.contexts["a2"]) == 49:
                 break
 
-            # 区切りとなるコンテキスト値が出現するまで音素サブ系列の一員として一時保存する
+            # 区切りとなるcontextが出現するまで音素サブ系列の一員として一時保存する
             mora_phonemes.append(phoneme)
 
             # 確定した音素サブ系列を処理する
-            # コンテキスト a2 属性の定義: "position of the current mora identity in the current accent phrase (forward)    1 ~ 49"  # noqa: B950
+            # context a2 の定義: "position of the current mora identity in the current accent phrase (forward)    1 ~ 49"  # noqa: B950
             if (
                 next_phoneme is None
                 or phoneme.contexts["a2"] != next_phoneme.contexts["a2"]
@@ -216,13 +216,13 @@ class AccentPhrase:
                 mora_phonemes = []
 
         # アクセント位置を決定する
-        # コンテキスト f2 属性の定義: "accent type in the current accent phrase    1 ~ 49"
+        # context f2 の定義: "accent type in the current accent phrase    1 ~ 49"
         accent = int(moras[0].vowel.contexts["f2"])
         # f2 の値がアクセント句内のモーラ数を超える場合はクリップ（ワークアラウンド、VOICEVOX/voicevox_engine#55 を参照）
         accent = accent if accent <= len(moras) else len(moras)
 
-        # 疑問文か否か判定する（末尾モーラ母音のコンテキスト値に基づく）
-        # コンテキスト f3 属性の定義: "whether the current accent phrase interrogative or not (0: not interrogative, 1: interrogative)"  # noqa: B950
+        # 疑問文か否か判定する（末尾モーラ母音のcontextに基づく）
+        # context f3 の定義: "whether the current accent phrase interrogative or not (0: not interrogative, 1: interrogative)"  # noqa: B950
         is_interrogative = moras[-1].vowel.contexts["f3"] == "1"
 
         # AccentPhrase インスタンスを生成する
@@ -303,20 +303,20 @@ class BreathGroup:
 
     @classmethod
     def from_phonemes(cls, phonemes: list[Phoneme]) -> Self:
-        """音素系列をコンテキスト値で区切り BreathGroup インスタンスを生成する"""
+        """音素系列をcontextで区切り BreathGroup インスタンスを生成する"""
 
-        # NOTE:「音素サブ系列」は単一アクセント句を構成する音素系列である。音素系列をコンテキスト値で区切り生成される。
+        # NOTE:「音素サブ系列」は単一アクセント句を構成する音素系列である。音素系列をcontextで区切り生成される。
 
         accent_phrases: list[AccentPhrase] = []  # 音素サブ行列から生成されたアクセント句系列
         accent_phonemes: list[Phoneme] = []  # 音素サブ系列を一時保存するコンテナ
 
         for phoneme, next_phoneme in zip(phonemes, phonemes[1:] + [None]):
-            # 区切りとなるコンテキスト値が出現するまで音素サブ系列の一員として一時保存する
+            # 区切りとなるcontextが出現するまで音素サブ系列の一員として一時保存する
             accent_phonemes.append(phoneme)
 
             # 確定した音素サブ系列を処理する
-            # コンテキスト i3 属性の定義: "position of the current breath group identity by breath group (forward)"  # noqa: B950
-            # コンテキスト f5 属性の定義: "position of the current accent phrase identity in the current breath group by the accent phrase (forward)"  # noqa: B950
+            # context i3 の定義: "position of the current breath group identity by breath group (forward)"  # noqa: B950
+            # context f5 の定義: "position of the current accent phrase identity in the current breath group by the accent phrase (forward)"  # noqa: B950
             if (
                 next_phoneme is None
                 or phoneme.contexts["i3"] != next_phoneme.contexts["i3"]


### PR DESCRIPTION
## 内容
概要: フルコンテキストラベル関連のコメント/docstring/型ヒントをリファクタリング

`full_context_label.py` は OpenJTalk / フルコンテキストラベル（以下 label）を扱うモジュールである。  
ここで定義されるクラス（例: `BreathGroup`, `Utterance`）は label 仕様を解釈する複雑な操作をおこなっている。  
その複雑さに比べるとコメント量が少なく、仕様と実装の関係をコメントで明示すれば可読性向上が期待できる。  

このような背景から、`full_context_label.py` へのコメント追加によるリファクタリングを提案します。  

また同時に以下のリファクタリングを提案します：  

- コーディング規約④ (#799) に基づく docstring の単純化
- deprecated な型ヒントのアップデート

## 関連 Issue
無し
