### PR TITLE
整理: Ojtドメイン変換切り出しと集約

### DIFF
--- a/voicevox_engine/tts_pipeline/tts_engine_base.py
+++ b/voicevox_engine/tts_pipeline/tts_engine_base.py
@@ -159,6 +159,19 @@ def utterance_to_accent_phrases(utterance: Utterance) -> list[AccentPhrase]:
     ]
 
 
+def test_to_accent_phrases(text: str) -> list[AccentPhrase]:
+    """日本語テキストからアクセント句系列を生成"""
+    if len(text.strip()) == 0:
+        return []
+
+    # 音素とアクセントの推定
+    utterance = extract_full_context_label(text)
+    if len(utterance.breath_groups) == 0:
+        return []
+
+    return utterance_to_accent_phrases(utterance)
+
+
 class SynthesisEngineBase(metaclass=ABCMeta):
     @property
     @abstractmethod
@@ -288,17 +301,12 @@ class SynthesisEngineBase(metaclass=ABCMeta):
         accent_phrases : List[AccentPhrase]
             アクセント句系列
         """
-        if len(text.strip()) == 0:
-            return []
-
         # 音素とアクセントの推定
-        utterance = extract_full_context_label(text)
-        if len(utterance.breath_groups) == 0:
-            return []
+        accent_phrases = test_to_accent_phrases(text)
 
-        # Utterance -> List[AccentPharase] のキャスト & 音素長・モーラ音高の推定と更新
+        # 音素長・モーラ音高の推定と更新
         accent_phrases = self.replace_mora_data(
-            accent_phrases=utterance_to_accent_phrases(utterance),
+            accent_phrases=accent_phrases,
             style_id=style_id,
         )
         return accent_phrases


### PR DESCRIPTION
## 内容
OpenJTalk-ENGINE 間ドメイン変換の関数切り出しと集約によるリファクタリング

- OpenJTalk-ENGINE 間ドメイン変換の関数切り出し
- OpenJTalkドメイン関数の集約（`test_to_accent_phrases` 関数化）  

によるリファクタリングをおこなった。  
上位のテストが存在するため、新規unittestは導入せず（`Utterance` インスタンスの用意/メンテが著しく高コスト）  

## 関連 Issue
part 1 of #881

## Reviewer 向け情報
コード移動 & 関数化のため、diff が機能していません。  
1 commit 1 関数化に整理してあるため、commit log がレビューの参考になれば幸いです。  