### PR TITLE
整理: OpenJTalk 系の不使用メソッド削除

### DIFF
--- a/test/test_full_context_label.py
+++ b/test/test_full_context_label.py
@@ -266,20 +266,6 @@ class TestAccentPhrase(TestBasePhonemes):
             self.accent_phrase_hiho.labels, self.test_case_hello_hiho[11:19]
         )
 
-    def test_merge(self):
-        # 「こんにちはヒホです」
-        # 読点を無くしたものと同等
-        merged_accent_phrase = self.accent_phrase_hello.merge(self.accent_phrase_hiho)
-        self.assertEqual(merged_accent_phrase.accent, 5)
-        self.assertEqual(
-            " ".join([phoneme.phoneme for phoneme in merged_accent_phrase.phonemes]),
-            "k o N n i ch i w a h i h o d e s U",
-        )
-        self.assertEqual(
-            merged_accent_phrase.labels,
-            self.test_case_hello_hiho[1:10] + self.test_case_hello_hiho[11:19],
-        )
-
 
 class TestBreathGroup(TestBasePhonemes):
     def setUp(self) -> None:

--- a/voicevox_engine/tts_pipeline/full_context_label.py
+++ b/voicevox_engine/tts_pipeline/full_context_label.py
@@ -267,26 +267,6 @@ class AccentPhrase:
         """
         return [p.label for p in self.phonemes]
 
-    def merge(self, accent_phrase: "AccentPhrase"):
-        """
-        AccentPhraseを合成する
-        (このクラスが保持するmorasの後ろに、引数として渡されたAccentPhraseのmorasを合成する)
-        Parameters
-        ----------
-        accent_phrase : AccentPhrase
-            合成したいAccentPhraseを渡す
-
-        Returns
-        -------
-        accent_phrase : AccentPhrase
-            合成されたAccentPhraseを返す
-        """
-        return AccentPhrase(
-            moras=self.moras + accent_phrase.moras,
-            accent=self.accent,
-            is_interrogative=accent_phrase.is_interrogative,
-        )
-
 
 @dataclass
 class BreathGroup:


### PR DESCRIPTION
## 内容
OpenJTalk 系の不使用メソッド削除によるリファクタリング

`AccentPhrase.merge()` メソッドはアクセント句同士を結合する機能を提供するが、現在利用されていない。  

OpenJTalk 系モジュール単純化のため、このメソッドの廃止を提案します。  

## 関連 Issue
無し