### PR TITLE
整理: OpenJTalk `Phoneme` → `Label` リネーム

### DIFF
--- a/test/test_full_context_label.py
+++ b/test/test_full_context_label.py
@@ -6,7 +6,7 @@ from voicevox_engine.tts_pipeline.full_context_label import (
     AccentPhrase,
     BreathGroup,
     Mora,
-    Phoneme,
+    Label,
     Utterance,
 )
 
@@ -123,7 +123,7 @@ class TestBasePhonemes(TestCase):
             + "@xx+xx&xx-xx|xx+xx/J:xx_xx/K:2+2-9",
         ]
         self.phonemes_hello_hiho = [
-            Phoneme.from_label(label) for label in self.test_case_hello_hiho
+            Label.from_feature(feature) for feature in self.test_case_hello_hiho
         ]
 
 
@@ -254,10 +254,10 @@ class TestAccentPhrase(TestBasePhonemes):
         super().setUp()
         # TODO: ValueErrorを吐く作為的ではない自然な例の模索
         # 存在しないなら放置でよい
-        self.accent_phrase_hello = AccentPhrase.from_phonemes(
+        self.accent_phrase_hello = AccentPhrase.from_labels(
             self.phonemes_hello_hiho[1:10]
         )
-        self.accent_phrase_hiho = AccentPhrase.from_phonemes(
+        self.accent_phrase_hiho = AccentPhrase.from_labels(
             self.phonemes_hello_hiho[11:19]
         )
 
@@ -298,10 +298,10 @@ class TestAccentPhrase(TestBasePhonemes):
 class TestBreathGroup(TestBasePhonemes):
     def setUp(self) -> None:
         super().setUp()
-        self.breath_group_hello = BreathGroup.from_phonemes(
+        self.breath_group_hello = BreathGroup.from_labels(
             self.phonemes_hello_hiho[1:10]
         )
-        self.breath_group_hiho = BreathGroup.from_phonemes(
+        self.breath_group_hiho = BreathGroup.from_labels(
             self.phonemes_hello_hiho[11:19]
         )
 
@@ -337,7 +337,7 @@ class TestBreathGroup(TestBasePhonemes):
 class TestUtterance(TestBasePhonemes):
     def setUp(self) -> None:
         super().setUp()
-        self.utterance_hello_hiho = Utterance.from_phonemes(self.phonemes_hello_hiho)
+        self.utterance_hello_hiho = Utterance.from_labels(self.phonemes_hello_hiho)
 
     def test_phonemes(self):
         self.assertEqual(
@@ -346,7 +346,7 @@ class TestUtterance(TestBasePhonemes):
             ),
             "sil k o N n i ch i w a pau h i h o d e s U sil",
         )
-        changed_utterance = Utterance.from_phonemes(self.utterance_hello_hiho.phonemes)
+        changed_utterance = Utterance.from_labels(self.utterance_hello_hiho.phonemes)
         self.assertEqual(len(changed_utterance.breath_groups), 2)
         accent_phrases = list(
             chain.from_iterable(

--- a/test/test_full_context_label.py
+++ b/test/test_full_context_label.py
@@ -5,8 +5,8 @@ from unittest import TestCase
 from voicevox_engine.tts_pipeline.full_context_label import (
     AccentPhrase,
     BreathGroup,
-    Mora,
     Label,
+    Mora,
     Utterance,
 )
 

--- a/voicevox_engine/tts_pipeline/full_context_label.py
+++ b/voicevox_engine/tts_pipeline/full_context_label.py
@@ -285,23 +285,23 @@ class Utterance:
 
         pauses: list[Label] = []  # ポーズラベルのリスト
         breath_groups: list[BreathGroup] = []  # BreathGroup のリスト
-        group_lavels: list[Label] = []  # BreathGroupごとのラベル系列を一時保存するコンテナ
+        group_labels: list[Label] = []  # BreathGroupごとのラベル系列を一時保存するコンテナ
 
         for label in labels:
             # ポーズが出現するまでラベル系列を一時保存する
             if not label.is_pause():
-                group_lavels.append(label)
+                group_labels.append(label)
 
             # 一時的なラベル系列を確定させて処理する
             else:
                 # ポーズラベルを保存する
                 pauses.append(label)
-                if len(group_lavels) > 0:
+                if len(group_labels) > 0:
                     # ラベル系列からBreathGroupを生成して保存する
-                    breath_group = BreathGroup.from_labels(group_lavels)
+                    breath_group = BreathGroup.from_labels(group_labels)
                     breath_groups.append(breath_group)
                     # 次に向けてリセット
-                    group_lavels = []
+                    group_labels = []
 
         # Utteranceインスタンスを生成する
         utterance = cls(breath_groups=breath_groups, pauses=pauses)

--- a/voicevox_engine/tts_pipeline/full_context_label.py
+++ b/voicevox_engine/tts_pipeline/full_context_label.py
@@ -50,7 +50,7 @@ class Label:
         return self.contexts["f1"] == "xx"
 
     def __repr__(self):
-        return f"<Phoneme phoneme='{self.phoneme}'>"
+        return f"<Label phoneme='{self.phoneme}'>"
 
 
 @dataclass
@@ -61,9 +61,9 @@ class Mora:
 
     Attributes
     ----------
-    consonant : Phoneme | None
+    consonant : Label | None
         子音
-    vowel : Phoneme
+    vowel : Label
         母音
     """
 
@@ -72,7 +72,7 @@ class Mora:
 
     def set_context(self, key: str, value: str):
         """
-        Moraクラス内に含まれるPhonemeのcontextのうち、指定されたキーの値を変更する
+        Moraクラス内に含まれるLabelのcontextのうち、指定されたキーの値を変更する
         consonantが存在する場合は、vowelと同じようにcontextを変更する
         Parameters
         ----------
@@ -164,7 +164,7 @@ class AccentPhrase:
 
     def set_context(self, key: str, value: str):
         """
-        AccentPhraseに間接的に含まれる全てのPhonemeのcontextの、指定されたキーの値を変更する
+        AccentPhraseに間接的に含まれる全てのLabelのcontextの、指定されたキーの値を変更する
         Parameters
         ----------
         key : str
@@ -181,8 +181,8 @@ class AccentPhrase:
         音素群を返す
         Returns
         -------
-        phonemes : list[Phoneme]
-            AccentPhraseに間接的に含まれる全てのPhonemeを返す
+        labels : list[Label]
+            AccentPhraseに間接的に含まれる全てのLabelを返す
         """
         return list(chain.from_iterable(m.phonemes for m in self.moras))
 
@@ -234,7 +234,7 @@ class BreathGroup:
 
     def set_context(self, key: str, value: str):
         """
-        BreathGroupに間接的に含まれる全てのPhonemeのcontextの、指定されたキーの値を変更する
+        BreathGroupに間接的に含まれる全てのLabelのcontextの、指定されたキーの値を変更する
         Parameters
         ----------
         key : str
@@ -251,8 +251,8 @@ class BreathGroup:
         音素群を返す
         Returns
         -------
-        phonemes : list[Phoneme]
-            BreathGroupに間接的に含まれる全てのPhonemeを返す
+        labels : list[Label]
+            BreathGroupに間接的に含まれる全てのLabelを返す
         """
         return list(
             chain.from_iterable(
@@ -270,7 +270,7 @@ class Utterance:
     ----------
     breath_groups : list[BreathGroup]
         発声の区切りのリスト
-    pauses : list[Phoneme]
+    pauses : list[Label]
         無音のリスト
     """
 
@@ -310,7 +310,7 @@ class Utterance:
 
     def set_context(self, key: str, value: str):
         """
-        Utteranceに間接的に含まれる全てのPhonemeのcontextの、指定されたキーの値を変更する
+        Utteranceに間接的に含まれる全てのLabelのcontextの、指定されたキーの値を変更する
         Parameters
         ----------
         key : str
@@ -327,8 +327,8 @@ class Utterance:
         音素群を返す
         Returns
         -------
-        phonemes : list[Phoneme]
-            Utteranceクラスに直接的・間接的に含まれる、全てのPhonemeを返す
+        labels : list[Label]
+            Utteranceクラスに直接的・間接的に含まれる、全てのLabelを返す
         """
         accent_phrases = list(
             chain.from_iterable(
@@ -392,15 +392,15 @@ class Utterance:
             ),
         )
 
-        phonemes: list[Label] = []
+        labels: list[Label] = []
         for i in range(len(self.pauses)):
             if self.pauses[i] is not None:
-                phonemes += [self.pauses[i]]
+                labels += [self.pauses[i]]
 
             if i < len(self.pauses) - 1:
-                phonemes += self.breath_groups[i].phonemes
+                labels += self.breath_groups[i].phonemes
 
-        return phonemes
+        return labels
 
 
 def extract_full_context_label(text: str):

--- a/voicevox_engine/tts_pipeline/full_context_label.py
+++ b/voicevox_engine/tts_pipeline/full_context_label.py
@@ -131,10 +131,7 @@ class AccentPhrase:
 
             # 一時的なラベル系列を確定させて処理する
             # a2はアクセント句内でのモーラ番号(1~49)
-            if (
-                next_label is None
-                or label.contexts["a2"] != next_label.contexts["a2"]
-            ):
+            if next_label is None or label.contexts["a2"] != next_label.contexts["a2"]:
                 # モーラごとのラベル系列長に基づいて子音と母音を得る
                 if len(mora_labels) == 1:
                     consonant, vowel = None, mora_labels[0]

--- a/voicevox_engine/tts_pipeline/full_context_label.py
+++ b/voicevox_engine/tts_pipeline/full_context_label.py
@@ -87,7 +87,9 @@ class Mora:
 
     @property
     def phonemes(self):
-        """このモーラを構成するラベルリスト。母音ラベルのみの場合は [母音ラベル,]、子音ラベルもある場合は [子音ラベル, 母音ラベル]"""
+        """このモーラを構成するラベルリスト。母音ラベルのみの場合は [母音ラベル,]、子音ラベルもある場合は [子音ラベル, 母音ラベル]。
+        NOTE: `.labels` に名称変更予定
+        """
         if self.consonant is not None:
             return [self.consonant, self.vowel]
         else:
@@ -178,7 +180,8 @@ class AccentPhrase:
     @property
     def phonemes(self):
         """
-        音素群を返す
+        内包する全てのラベルを返す
+        NOTE: `.labels` に名称変更予定
         Returns
         -------
         labels : list[Label]
@@ -248,7 +251,8 @@ class BreathGroup:
     @property
     def phonemes(self):
         """
-        音素群を返す
+        内包する全てのラベルを返す
+        NOTE: `.labels` に名称変更予定
         Returns
         -------
         labels : list[Label]
@@ -324,7 +328,8 @@ class Utterance:
     @property
     def phonemes(self):
         """
-        音素群を返す
+        内包する全てのラベルを返す
+        NOTE: `.labels` に名称変更予定
         Returns
         -------
         labels : list[Label]


### PR DESCRIPTION
## 内容
OpenJTalk `Phoneme` クラスを `Label` にリネームしてリファクタリング

## 関連 Issue
step 3 of #881

## Reviewer 向け情報
<del>既存の `.label` / `.labels` アクセッサには触れていません。  
これらの属性は別PR (#891) にて切り出し・改名される予定です。  
PR merge 順序による一時的な混乱（#891 より先にこちらを merge すると一時的に2種類の `label` 語が登場）を避ける場合、#891 の review・merge を先にお願いします。</del>  