### PR TITLE
整理: `.test_synthesis` 重複テストの削除

### DIFF
--- a/test/test_synthesis_engine.py
+++ b/test/test_synthesis_engine.py
@@ -846,21 +846,6 @@ class TestTTSEngine(TestCase):
                 f0[i][0] = (f0[i][0] - mean_f0) * audio_query.intonationScale + mean_f0
         phoneme = numpy.array(phoneme, dtype=numpy.float32)
 
-        assert_f0_count = 0
-
-        # Outputs: decode_forward `f0` 引数
-        decode_f0 = decode_args["f0"]
-
-        # Test: フレームごとの音高系列
-        # 乱数の影響で数値の位置がずれが生じるので、大半(4/5)があっていればよしとする
-        # また、上の部分のint(round(phoneme_length * (24000 / 256)))の影響で
-        # 本来のf0/phonemeとテスト生成したf0/phonemeの長さが変わることがあり、
-        # テスト生成したものが若干長くなることがあるので、本来のものの長さを基準にassertする
-        for i in range(len(decode_f0)):
-            # 乱数の影響等で数値にずれが生じるので、10の-5乗までの近似値であれば許容する
-            assert_f0_count += math.isclose(f0[i][0], decode_f0[i][0], rel_tol=10e-5)
-        self.assertTrue(assert_f0_count >= int(len(decode_f0) / 5) * 4)
-
         assert_phoneme_count = 0
 
         # Outputs: decode_forward `phoneme` 引数

--- a/test/test_synthesis_engine.py
+++ b/test/test_synthesis_engine.py
@@ -846,20 +846,6 @@ class TestTTSEngine(TestCase):
                 f0[i][0] = (f0[i][0] - mean_f0) * audio_query.intonationScale + mean_f0
         phoneme = numpy.array(phoneme, dtype=numpy.float32)
 
-        assert_phoneme_count = 0
-
-        # Outputs: decode_forward `phoneme` 引数
-        decode_phoneme = decode_args["phoneme"]
-
-        # Test: フレームごとの音素系列
-        for i in range(len(decode_phoneme)):
-            assert_true_count = 0
-            for j in range(len(decode_phoneme[i])):
-                assert_true_count += bool(phoneme[i][j] == decode_phoneme[i][j])
-            assert_phoneme_count += assert_true_count == num_phoneme
-
-        self.assertTrue(assert_phoneme_count >= int(len(decode_phoneme) / 5) * 4)
-
         # Test: スタイルID
         self.assertEqual(decode_args["style_id"], 1)
 

--- a/test/test_synthesis_engine.py
+++ b/test/test_synthesis_engine.py
@@ -808,13 +808,6 @@ class TestTTSEngine(TestCase):
         # Outputs: MockCore入りTTSEngine の `.synthesis` 出力および core.decode_forward 引数
         result = self.synthesis_engine.synthesis(query=audio_query, style_id=1)
         decode_args = self.decode_mock.call_args[1]
-        list_length = decode_args["length"]
-
-        # Test: フレーム長
-        self.assertEqual(
-            list_length,
-            int(sum([round(p * 24000 / 256) for p in phoneme_length_list])),
-        )
 
         # Expects: Apply/Convert/Rescale
         num_phoneme = 45
@@ -886,7 +879,7 @@ class TestTTSEngine(TestCase):
         self.assertEqual(decode_args["style_id"], 1)
 
         # Expects: waveform (by mock)
-        true_result = decode_mock(list_length, num_phoneme, f0, phoneme, 1)
+        true_result = decode_mock(decode_args["length"], num_phoneme, f0, phoneme, 1)
         # Expects: 音量スケール適用
         true_result *= audio_query.volumeScale
 

--- a/test/test_synthesis_engine.py
+++ b/test/test_synthesis_engine.py
@@ -846,9 +846,6 @@ class TestTTSEngine(TestCase):
                 f0[i][0] = (f0[i][0] - mean_f0) * audio_query.intonationScale + mean_f0
         phoneme = numpy.array(phoneme, dtype=numpy.float32)
 
-        # Test: スタイルID
-        self.assertEqual(decode_args["style_id"], 1)
-
         # Expects: waveform (by mock)
         true_result = decode_mock(decode_args["length"], num_phoneme, f0, phoneme, 1)
         # Expects: 音量スケール適用

--- a/test/test_synthesis_engine.py
+++ b/test/test_synthesis_engine.py
@@ -851,10 +851,6 @@ class TestTTSEngine(TestCase):
         # Expects: 音量スケール適用
         true_result *= audio_query.volumeScale
 
-        # TODO: resampyの部分は値の検証しようがないので、パスする
-        if audio_query.outputSamplingRate != 24000:
-            return
-
         # Test:
         assert_result_count = 0
         for i in range(len(true_result)):
@@ -900,12 +896,6 @@ class TestTTSEngine(TestCase):
         audio_query.volumeScale = 1.0
         audio_query.prePhonemeLength = 0.5
         audio_query.postPhonemeLength = 0.5
-        self.synthesis_test_base(audio_query)
-
-        # output sampling rateのテスト
-        audio_query.prePhonemeLength = 0.1
-        audio_query.postPhonemeLength = 0.1
-        audio_query.outputSamplingRate = 48000
         self.synthesis_test_base(audio_query)
 
         # output stereoのテスト


### PR DESCRIPTION
## 内容
`test_synthesis_engine.py` 重複テストの削除によるリファクタリング

## 関連 Issue
step1 of #899

## Reviewer 向け情報
### 変更内容
1 commit につき 1つのテストを削除しています。  
見通しが悪い場合は commit log を参照ください。  

### `.synthesis` テストと `._synthesis_impl` テストの違い
`.test_synthesis()` は `.synthesis()` をテストしており、 `._synthesis_impl()` のテストではない。  
これらの間には次の関係がある：  

```
`.synthesis()` = 疑問形処理 + `_synthesis_impl()`
```

そして切り出された preprocess 関数（`query_to_decoder_feature()`）は疑問形処理を（現時点では）含んでいない。  
つまり `.test_synthesis()` を preprocessテストと postprocess テストでは理論的には置き換えられない（疑問形処理のテストが無い）。  

しかし現状として `.test_synthesis()` は疑問形を ***含まない*** AudioQueryでテストがなされており、疑問形処理が実質的にテストされていない。  
ゆえに本 PR はテスト劣化がない（リファクタリングとして成立する）。  
疑問形のテストは今後の課題（参考: #897）と考えている。  