### PR TITLE
整理: 疑問形 upspeak の単純化

### DIFF
--- a/voicevox_engine/tts_pipeline/tts_engine_base.py
+++ b/voicevox_engine/tts_pipeline/tts_engine_base.py
@@ -45,16 +45,9 @@ def adjust_interrogative_accent_phrases(
     accent_phrases : List[AccentPhrase]
         必要に応じて疑問形補正されたアクセント句系列
     """
-    # NOTE: リファクタリング時に適切な場所へ移動させること
-    return [
-        AccentPhrase(
-            moras=adjust_interrogative_moras(accent_phrase),
-            accent=accent_phrase.accent,
-            pause_mora=accent_phrase.pause_mora,
-            is_interrogative=accent_phrase.is_interrogative,
-        )
-        for accent_phrase in accent_phrases
-    ]
+    for accent_phrase in accent_phrases:
+        accent_phrase.moras = adjust_interrogative_moras(accent_phrase)
+    return accent_phrases
 
 
 def adjust_interrogative_moras(accent_phrase: AccentPhrase) -> List[Mora]:

--- a/voicevox_engine/tts_pipeline/tts_engine_base.py
+++ b/voicevox_engine/tts_pipeline/tts_engine_base.py
@@ -45,7 +45,9 @@ def apply_interrogative_upspeak(
     for accent_phrase in accent_phrases:
         moras = copy.deepcopy(accent_phrase.moras)
         # 疑問形補正条件: 疑問形フラグON & 終端有声母音
-        if accent_phrase.is_interrogative and not (len(moras) == 0 or moras[-1].pitch == 0):
+        if accent_phrase.is_interrogative and not (
+            len(moras) == 0 or moras[-1].pitch == 0
+        ):
             last_mora = moras[-1]
             interrogative_mora = Mora(
                 text=openjtalk_mora2text[last_mora.vowel],
@@ -291,7 +293,9 @@ class TTSEngineBase(metaclass=ABCMeta):
         """
         # モーフィング時などに同一参照のqueryで複数回呼ばれる可能性があるので、元の引数のqueryに破壊的変更を行わない
         query = copy.deepcopy(query)
-        query.accent_phrases = apply_interrogative_upspeak(query.accent_phrases, enable_interrogative_upspeak)
+        query.accent_phrases = apply_interrogative_upspeak(
+            query.accent_phrases, enable_interrogative_upspeak
+        )
         return self._synthesis_impl(query, style_id)
 
     @abstractmethod

--- a/voicevox_engine/tts_pipeline/tts_engine_base.py
+++ b/voicevox_engine/tts_pipeline/tts_engine_base.py
@@ -44,9 +44,11 @@ def apply_interrogative_upspeak(
 
     for accent_phrase in accent_phrases:
         moras = accent_phrase.moras
+        if len(moras) == 0:
+            continue
         # 疑問形補正条件: 疑問形フラグON & 終端有声母音
         if accent_phrase.is_interrogative and not (
-            len(moras) == 0 or moras[-1].pitch == 0
+            moras[-1].pitch == 0
         ):
             last_mora = copy.deepcopy(moras[-1])
             interrogative_mora = Mora(
@@ -57,8 +59,7 @@ def apply_interrogative_upspeak(
                 vowel_length=UPSPEAK_LENGTH,
                 pitch=min(last_mora.pitch + UPSPEAK_PITCH_ADD, UPSPEAK_PITCH_MAX),
             )
-            moras.append(interrogative_mora)
-        accent_phrase.moras = moras
+            accent_phrase.moras += [interrogative_mora]
     return accent_phrases
 
 

--- a/voicevox_engine/tts_pipeline/tts_engine_base.py
+++ b/voicevox_engine/tts_pipeline/tts_engine_base.py
@@ -47,9 +47,7 @@ def apply_interrogative_upspeak(
         if len(moras) == 0:
             continue
         # 疑問形補正条件: 疑問形フラグON & 終端有声母音
-        if accent_phrase.is_interrogative and not (
-            moras[-1].pitch == 0
-        ):
+        if accent_phrase.is_interrogative and not (moras[-1].pitch == 0):
             last_mora = copy.deepcopy(moras[-1])
             interrogative_mora = Mora(
                 text=openjtalk_mora2text[last_mora.vowel],

--- a/voicevox_engine/tts_pipeline/tts_engine_base.py
+++ b/voicevox_engine/tts_pipeline/tts_engine_base.py
@@ -43,12 +43,12 @@ def apply_interrogative_upspeak(
         return accent_phrases
 
     for accent_phrase in accent_phrases:
-        moras = copy.deepcopy(accent_phrase.moras)
+        moras = accent_phrase.moras
         # 疑問形補正条件: 疑問形フラグON & 終端有声母音
         if accent_phrase.is_interrogative and not (
             len(moras) == 0 or moras[-1].pitch == 0
         ):
-            last_mora = moras[-1]
+            last_mora = copy.deepcopy(moras[-1])
             interrogative_mora = Mora(
                 text=openjtalk_mora2text[last_mora.vowel],
                 consonant=None,

--- a/voicevox_engine/tts_pipeline/tts_engine_base.py
+++ b/voicevox_engine/tts_pipeline/tts_engine_base.py
@@ -46,10 +46,10 @@ def apply_interrogative_upspeak(
         moras = accent_phrase.moras
         if len(moras) == 0:
             continue
-        # 疑問形補正条件: 疑問形フラグON & 終端有声母音
-        if accent_phrase.is_interrogative and not (moras[-1].pitch == 0):
+        # 疑問形補正条件: 疑問形アクセント句 & 末尾有声モーラ
+        if accent_phrase.is_interrogative and moras[-1].pitch > 0:
             last_mora = copy.deepcopy(moras[-1])
-            interrogative_mora = Mora(
+            upspeak_mora = Mora(
                 text=openjtalk_mora2text[last_mora.vowel],
                 consonant=None,
                 consonant_length=None,
@@ -57,7 +57,7 @@ def apply_interrogative_upspeak(
                 vowel_length=UPSPEAK_LENGTH,
                 pitch=min(last_mora.pitch + UPSPEAK_PITCH_ADD, UPSPEAK_PITCH_MAX),
             )
-            accent_phrase.moras += [interrogative_mora]
+            accent_phrase.moras += [upspeak_mora]
     return accent_phrases
 
 

--- a/voicevox_engine/tts_pipeline/tts_engine_base.py
+++ b/voicevox_engine/tts_pipeline/tts_engine_base.py
@@ -39,6 +39,7 @@ def apply_interrogative_upspeak(
     accent_phrases: list[AccentPhrase], enable_interrogative_upspeak: bool
 ) -> list[AccentPhrase]:
     """必要に応じて各アクセント句の末尾へ疑問形モーラ（同一母音・継続長 0.15秒・音高↑）を付与する"""
+    # NOTE: 将来的にAudioQueryインスタンスを引数にする予定
     if not enable_interrogative_upspeak:
         return accent_phrases
 

--- a/voicevox_engine/tts_pipeline/tts_engine_base.py
+++ b/voicevox_engine/tts_pipeline/tts_engine_base.py
@@ -35,10 +35,13 @@ def mora_to_text(mora: str) -> str:
         return mora
 
 
-def adjust_interrogative_accent_phrases(
-    accent_phrases: list[AccentPhrase]
+def apply_interrogative_upspeak(
+    accent_phrases: list[AccentPhrase], enable_interrogative_upspeak: bool
 ) -> list[AccentPhrase]:
     """必要に応じて各アクセント句の末尾へ疑問形モーラ（同一母音・継続長 0.15秒・音高↑）を付与する"""
+    if not enable_interrogative_upspeak:
+        return accent_phrases
+
     for accent_phrase in accent_phrases:
         moras = copy.deepcopy(accent_phrase.moras)
         # 疑問形補正条件: 疑問形フラグON & 終端有声母音
@@ -288,10 +291,7 @@ class TTSEngineBase(metaclass=ABCMeta):
         """
         # モーフィング時などに同一参照のqueryで複数回呼ばれる可能性があるので、元の引数のqueryに破壊的変更を行わない
         query = copy.deepcopy(query)
-        if enable_interrogative_upspeak:
-            query.accent_phrases = adjust_interrogative_accent_phrases(
-                query.accent_phrases
-            )
+        query.accent_phrases = apply_interrogative_upspeak(query.accent_phrases, enable_interrogative_upspeak)
         return self._synthesis_impl(query, style_id)
 
     @abstractmethod

--- a/voicevox_engine/tts_pipeline/tts_engine_base.py
+++ b/voicevox_engine/tts_pipeline/tts_engine_base.py
@@ -46,30 +46,13 @@ def adjust_interrogative_accent_phrases(
         必要に応じて疑問形補正されたアクセント句系列
     """
     for accent_phrase in accent_phrases:
-        accent_phrase.moras = adjust_interrogative_moras(accent_phrase)
+        moras = copy.deepcopy(accent_phrase.moras)
+        # 疑問形補正条件: 疑問形フラグON & 終端有声母音
+        if accent_phrase.is_interrogative and not (len(moras) == 0 or moras[-1].pitch == 0):
+            interrogative_mora = make_interrogative_mora(moras[-1])
+            moras.append(interrogative_mora)
+        accent_phrase.moras = moras
     return accent_phrases
-
-
-def adjust_interrogative_moras(accent_phrase: AccentPhrase) -> List[Mora]:
-    """
-    アクセント句に含まれるモーラ系列の必要に応じた疑問形補正
-    Parameters
-    ----------
-    accent_phrase : AccentPhrase
-        アクセント句
-    Returns
-    -------
-    moras : List[Mora]
-        補正済みモーラ系列
-    """
-    moras = copy.deepcopy(accent_phrase.moras)
-    # 疑問形補正条件: 疑問形フラグON & 終端有声母音
-    if accent_phrase.is_interrogative and not (len(moras) == 0 or moras[-1].pitch == 0):
-        interrogative_mora = make_interrogative_mora(moras[-1])
-        moras.append(interrogative_mora)
-        return moras
-    else:
-        return moras
 
 
 def make_interrogative_mora(last_mora: Mora) -> Mora:


### PR DESCRIPTION
## 内容
概要: 疑問形 upspeak 処理の単純化によるリファクタリング  

ネストの解消・処理の簡素化によってリファクタリングをおこなった。  

## 関連 Issue
part of #897

## Reviewer 向け情報
3つの関数ネストを削除したため、diff が機能していません。  
commit ごとに 1 つの関数を削除したため、レビュー時には commit log を参照していただければ幸いです。  