### PR TITLE
整理: `replace_phoneme_length()` の見通し改善

### DIFF
--- a/voicevox_engine/tts_pipeline/tts_engine.py
+++ b/voicevox_engine/tts_pipeline/tts_engine.py
@@ -375,7 +375,7 @@ class TTSEngine(TTSEngineBase):
                 style_id=numpy.array(style_id, dtype=numpy.int64).reshape(-1),
             )
 
-        # 推定結果でモーラ内の音素長属性を置換する
+        # 生成結果でモーラ内の音素長属性を置換する
         vowel_indexes = [
             i for i, p in enumerate(phonemes) if p.phoneme in mora_phoneme_list
         ]

--- a/voicevox_engine/tts_pipeline/tts_engine.py
+++ b/voicevox_engine/tts_pipeline/tts_engine.py
@@ -393,12 +393,7 @@ class TTSEngine(TTSEngineBase):
         phoneme_ids = numpy.array([p.phoneme_id for p in phonemes], dtype=numpy.int64)
 
         # コアを用いて音素長を生成する
-        with self.mutex:
-            phoneme_lengths = self.core.yukarin_s_forward(
-                length=len(phoneme_ids),
-                phoneme_list=phoneme_ids,
-                style_id=numpy.array(style_id, dtype=numpy.int64).reshape(-1),
-            )
+        phoneme_lengths = self.core.safe_yukarin_s_forward(phoneme_ids, style_id)
 
         # 生成結果でモーラ内の音素長属性を置換する
         vowel_indexes = [

--- a/voicevox_engine/tts_pipeline/tts_engine.py
+++ b/voicevox_engine/tts_pipeline/tts_engine.py
@@ -367,7 +367,7 @@ class TTSEngine(TTSEngineBase):
         # 音素クラスから音素IDスカラへ表現を変換する
         phoneme_ids = numpy.array([p.phoneme_id for p in phonemes], dtype=numpy.int64)
 
-        # コアを用いて音素長を推定する
+        # コアを用いて音素長を生成する
         with self.mutex:
             phoneme_lengths = self.core.yukarin_s_forward(
                 length=len(phoneme_ids),

--- a/voicevox_engine/tts_pipeline/tts_engine.py
+++ b/voicevox_engine/tts_pipeline/tts_engine.py
@@ -351,51 +351,40 @@ class TTSEngine(TTSEngineBase):
             return True  # コアが古い場合はどうしようもないのでTrueを返す
 
     def replace_phoneme_length(
-        self, accent_phrases: List[AccentPhrase], style_id: int
-    ) -> List[AccentPhrase]:
-        """
-        accent_phrasesの母音・子音の長さを設定する
-        Parameters
-        ----------
-        accent_phrases : List[AccentPhrase]
-            アクセント句モデルのリスト
-        style_id : int
-            スタイルID
-        Returns
-        -------
-        accent_phrases : List[AccentPhrase]
-            母音・子音の長さが設定されたアクセント句モデルのリスト
-        """
+        self, accent_phrases: list[AccentPhrase], style_id: int
+    ) -> list[AccentPhrase]:
+        """アクセント句系列に含まれるモーラの音素長属性をスタイルに合わせて更新する"""
         # モデルがロードされていない場合はロードする
         self.initialize_style_id_synthesis(style_id, skip_reinit=True)
-        # phoneme
-        # AccentPhraseをすべてMoraおよびOjtPhonemeの形に分解し、処理可能な形にする
-        flatten_moras, phoneme_data_list = pre_process(accent_phrases)
-        # OjtPhonemeの形に分解されたもの(phoneme_data_list)から、vowel(母音)の位置を抜き出す
-        _, _, vowel_indexes_data = split_mora(phoneme_data_list)
 
-        # yukarin_s
-        # OjtPhonemeのリストからOjtPhonemeのPhoneme ID(OpenJTalkにおける音素のID)のリストを作る
-        phoneme_list_s = numpy.array(
-            [p.phoneme_id for p in phoneme_data_list], dtype=numpy.int64
-        )
-        # Phoneme IDのリスト(phoneme_list_s)をyukarin_s_forwardにかけ、推論器によって適切な音素の長さを割り当てる
+        # モーラ系列を抽出する
+        moras = to_flatten_moras(accent_phrases)
+
+        # 音素系列を抽出し前後無音を付加する
+        phonemes = to_flatten_phonemes(moras)
+        phonemes = [OjtPhoneme("pau")] + phonemes + [OjtPhoneme("pau")]
+
+        # 音素クラスから音素IDスカラへ表現を変換する
+        phonemes = numpy.array([p.phoneme_id for p in phonemes], dtype=numpy.int64)
+
+        # コアを用いて音素長を推定する
         with self.mutex:
-            phoneme_length = self.core.yukarin_s_forward(
-                length=len(phoneme_list_s),
-                phoneme_list=phoneme_list_s,
+            phoneme_lengths = self.core.yukarin_s_forward(
+                length=len(phonemes),
+                phoneme_list=phonemes,
                 style_id=numpy.array(style_id, dtype=numpy.int64).reshape(-1),
             )
 
-        # yukarin_s_forwarderの結果をaccent_phrasesに反映する
-        # flatten_moras変数に展開された値を変更することでコード量を削減しつつaccent_phrases内のデータを書き換えている
-        for i, mora in enumerate(flatten_moras):
-            mora.consonant_length = (
-                phoneme_length[vowel_indexes_data[i + 1] - 1]
-                if mora.consonant is not None
-                else None
-            )
-            mora.vowel_length = phoneme_length[vowel_indexes_data[i + 1]]
+        # 推定結果でモーラ内の音素長属性を置換する
+        vowel_indexes = [
+            i for i, p in enumerate(phonemes) if p.phoneme in mora_phoneme_list
+        ]
+        for i, mora in enumerate(moras):
+            if mora.consonant is None:
+                mora.consonant_length = None
+            else:
+                mora.consonant_length = phoneme_lengths[vowel_indexes[i + 1] - 1]
+            mora.vowel_length = phoneme_lengths[vowel_indexes[i + 1]]
 
         return accent_phrases
 

--- a/voicevox_engine/tts_pipeline/tts_engine.py
+++ b/voicevox_engine/tts_pipeline/tts_engine.py
@@ -365,13 +365,13 @@ class TTSEngine(TTSEngineBase):
         phonemes = [OjtPhoneme("pau")] + phonemes + [OjtPhoneme("pau")]
 
         # 音素クラスから音素IDスカラへ表現を変換する
-        phonemes = numpy.array([p.phoneme_id for p in phonemes], dtype=numpy.int64)
+        phoneme_ids = numpy.array([p.phoneme_id for p in phonemes], dtype=numpy.int64)
 
         # コアを用いて音素長を推定する
         with self.mutex:
             phoneme_lengths = self.core.yukarin_s_forward(
-                length=len(phonemes),
-                phoneme_list=phonemes,
+                length=len(phoneme_ids),
+                phoneme_list=phoneme_ids,
                 style_id=numpy.array(style_id, dtype=numpy.int64).reshape(-1),
             )
 


### PR DESCRIPTION
## 内容
`replace_phoneme_length()` の関数ネスト廃止等によるリファクタリング  

昨今のリファクタリングにより、 `tts_engine.py` の各関数が簡素化した。  
その結果、現在の `replace_phoneme_length()` 内で call されている関数をバラしても（ネストを廃止しても）簡潔なコードが得られるようになった。  
またネストの廃止により処理の配置が最適化でき、実行高速化や見通し改善が可能になっている。  

よって本 PR では、`replace_phoneme_length()` の関数ネスト廃止等によるリファクタリングを提案します。  

## Reviewer 向け情報
### 変更内容
バラされた（ネストが廃止された）関数は以下の2つ：  

- `pre_process()`
- `split_mora()`:（副次効果: 不要コード実行の削減による高速化）

その他、変数名の簡潔化やコード表現簡潔化によるリファクタリングを本 PR は含む。  

## 関連 Issue
part of #792  