### PR TITLE
修正: `_synthesis_impl()` の直接コール

### DIFF
--- a/voicevox_engine/cancellable_engine.py
+++ b/voicevox_engine/cancellable_engine.py
@@ -240,6 +240,7 @@ def start_synthesis_subprocess(
                 # バージョンが見つからないエラー
                 sub_proc_con.send("")
                 continue
+            # FIXME: enable_interrogative_upspeakフラグをWebAPIから受け渡してくる
             wave = _engine.synthesis(query, style_id, False)
             with NamedTemporaryFile(delete=False) as f:
                 soundfile.write(

--- a/voicevox_engine/cancellable_engine.py
+++ b/voicevox_engine/cancellable_engine.py
@@ -240,7 +240,7 @@ def start_synthesis_subprocess(
                 # バージョンが見つからないエラー
                 sub_proc_con.send("")
                 continue
-            wave = _engine._synthesis_impl(query, style_id)
+            wave = _engine.synthesis(query, style_id, False)
             with NamedTemporaryFile(delete=False) as f:
                 soundfile.write(
                     file=f, data=wave, samplerate=query.outputSamplingRate, format="WAV"


### PR DESCRIPTION
## 内容
`_synthesis_impl()` の直接コールを `synthesis()` 呼び出しへ修正  

`_synthesis_impl()` 直接コールは（潜在バグとして）疑問文 upspeak をスキップしていた。  
後方互換性のために修正後でも `enable_interrogative_upspeak` 引数を `False` とした。  

## 関連 Issue
resolve #908

