### PR TITLE
廃止: フルコンテキストラベル系 `set_context()`

### DIFF
--- a/test/test_full_context_label.py
+++ b/test/test_full_context_label.py
@@ -1,4 +1,3 @@
-from copy import deepcopy
 from unittest import TestCase
 
 from voicevox_engine.tts_pipeline.full_context_label import (
@@ -253,13 +252,6 @@ class TestMora(TestBasePhonemes):
         self.assert_labels(self.mora_hiho_3, 15, 17)
         self.assert_labels(self.mora_hiho_4, 17, 19)
 
-    def test_set_context(self):
-        # 値を書き換えるので、他のテストに影響を出さないためにdeepcopyする
-        mora_hello_1 = deepcopy(self.mora_hello_1)
-        # phonemeにあたる"p3"を書き換える
-        mora_hello_1.set_context("p3", "a")
-        self.assertEqual(jointed_phonemes(mora_hello_1), "aa")
-
 
 class TestAccentPhrase(TestBasePhonemes):
     def setUp(self) -> None:
@@ -276,12 +268,6 @@ class TestAccentPhrase(TestBasePhonemes):
     def test_accent(self):
         self.assertEqual(self.accent_phrase_hello.accent, 5)
         self.assertEqual(self.accent_phrase_hiho.accent, 1)
-
-    def test_set_context(self):
-        accent_phrase_hello = deepcopy(self.accent_phrase_hello)
-        # phonemeにあたる"p3"を書き換える
-        accent_phrase_hello.set_context("p3", "a")
-        self.assertEqual(jointed_phonemes(accent_phrase_hello), "aaaaaaaaa")
 
     def test_phonemes(self):
         outputs_hello = space_jointed_phonemes(self.accent_phrase_hello)
@@ -307,13 +293,6 @@ class TestBreathGroup(TestBasePhonemes):
         self.breath_group_hiho = BreathGroup.from_labels(
             self.phonemes_hello_hiho[11:19]
         )
-
-    def test_set_context(self):
-        # 値を書き換えるので、他のテストに影響を出さないためにdeepcopyする
-        breath_group_hello = deepcopy(self.breath_group_hello)
-        # phonemeにあたる"p3"を書き換える
-        breath_group_hello.set_context("p3", "a")
-        self.assertEqual(jointed_phonemes(breath_group_hello), "aaaaaaaaa")
 
     def test_phonemes(self):
         outputs_hello = space_jointed_phonemes(self.breath_group_hello)

--- a/voicevox_engine/tts_pipeline/full_context_label.py
+++ b/voicevox_engine/tts_pipeline/full_context_label.py
@@ -74,21 +74,6 @@ class Mora:
     consonant: Label | None
     vowel: Label
 
-    def set_context(self, key: str, value: str):
-        """
-        Moraクラス内に含まれるLabelのcontextのうち、指定されたキーの値を変更する
-        consonantが存在する場合は、vowelと同じようにcontextを変更する
-        Parameters
-        ----------
-        key : str
-            変更したいcontextのキー
-        value : str
-            変更したいcontextの値
-        """
-        self.vowel.contexts[key] = value
-        if self.consonant is not None:
-            self.consonant.contexts[key] = value
-
     @property
     def phonemes(self):
         """このモーラを構成するラベルリスト。母音ラベルのみの場合は [母音ラベル,]、子音ラベルもある場合は [子音ラベル, 母音ラベル]。
@@ -168,19 +153,6 @@ class AccentPhrase:
 
         return accent_phrase
 
-    def set_context(self, key: str, value: str):
-        """
-        AccentPhraseに間接的に含まれる全てのLabelのcontextの、指定されたキーの値を変更する
-        Parameters
-        ----------
-        key : str
-            変更したいcontextのキー
-        value : str
-            変更したいcontextの値
-        """
-        for mora in self.moras:
-            mora.set_context(key, value)
-
     @property
     def phonemes(self):
         """
@@ -238,19 +210,6 @@ class BreathGroup:
         breath_group = cls(accent_phrases=accent_phrases)
 
         return breath_group
-
-    def set_context(self, key: str, value: str):
-        """
-        BreathGroupに間接的に含まれる全てのLabelのcontextの、指定されたキーの値を変更する
-        Parameters
-        ----------
-        key : str
-            変更したいcontextのキー
-        value : str
-            変更したいcontextの値
-        """
-        for accent_phrase in self.accent_phrases:
-            accent_phrase.set_context(key, value)
 
     @property
     def phonemes(self):
@@ -315,19 +274,6 @@ class Utterance:
         utterance = cls(breath_groups=breath_groups, pauses=pauses)
 
         return utterance
-
-    def set_context(self, key: str, value: str):
-        """
-        Utteranceに間接的に含まれる全てのLabelのcontextの、指定されたキーの値を変更する
-        Parameters
-        ----------
-        key : str
-            変更したいcontextのキー
-        value : str
-            変更したいcontextの値
-        """
-        for breath_group in self.breath_groups:
-            breath_group.set_context(key, value)
 
     @property
     def phonemes(self):


### PR DESCRIPTION
## 内容
フルコンテキストラベル系 `set_context()` の廃止  

#905 によりフルコンテキストラベル系の `set_context()` 関数は利用箇所がなくなった。  
また #892 での議論により、今後これら関数が用いられないことが明らかになった。  

このような背景から、フルコンテキストラベル系 `set_context()` の廃止を提案します。  

## 関連 Issue
ref #892