### PR TITLE
整理: `.phonemes` -> `.labels` リネーム

### DIFF
--- a/test/test_full_context_label.py
+++ b/test/test_full_context_label.py
@@ -34,7 +34,7 @@ OjtContainer = Mora | AccentPhrase | BreathGroup | Utterance
 
 def features(ojt_container: OjtContainer):
     """コンテナインスタンスに直接的・間接的に含まれる全ての feature を返す"""
-    return [contexts_to_feature(p.contexts) for p in ojt_container.phonemes]
+    return [contexts_to_feature(p.contexts) for p in ojt_container.labels]
 
 
 class TestBasePhonemes(TestCase):
@@ -132,16 +132,12 @@ class TestBasePhonemes(TestCase):
 
 def jointed_phonemes(ojt_container: OjtContainer) -> str:
     """コンテナインスタンスに直接的・間接的に含まれる全ラベルの音素文字を結合してを返す"""
-    return "".join([label.phoneme for label in ojt_container.phonemes])
-    # NOTE: `.phonemes` は `.labels` にリネーム予定
-    # return "".join([label.phoneme for label in ojt_container.labels])
+    return "".join([label.phoneme for label in ojt_container.labels])
 
 
 def space_jointed_phonemes(ojt_container: OjtContainer) -> str:
     """コンテナインスタンスに直接的・間接的に含まれる全ラベルの音素文字を ` ` 挟みながら結合してを返す"""
-    return " ".join([label.phoneme for label in ojt_container.phonemes])
-    # NOTE: `.phonemes` は `.labels` にリネーム予定
-    # return " ".join([label.phoneme for label in ojt_container.labels])
+    return " ".join([label.phoneme for label in ojt_container.labels])
 
 
 class TestPhoneme(TestBasePhonemes):

--- a/voicevox_engine/tts_pipeline/full_context_label.py
+++ b/voicevox_engine/tts_pipeline/full_context_label.py
@@ -90,10 +90,8 @@ class Mora:
             self.consonant.contexts[key] = value
 
     @property
-    def phonemes(self):
-        """このモーラを構成するラベルリスト。母音ラベルのみの場合は [母音ラベル,]、子音ラベルもある場合は [子音ラベル, 母音ラベル]。
-        NOTE: `.labels` に名称変更予定
-        """
+    def labels(self) -> list[Label]:
+        """このモーラを構成するラベルリスト。母音ラベルのみの場合は [母音ラベル,]、子音ラベルもある場合は [子音ラベル, 母音ラベル]。"""
         if self.consonant is not None:
             return [self.consonant, self.vowel]
         else:
@@ -182,16 +180,9 @@ class AccentPhrase:
             mora.set_context(key, value)
 
     @property
-    def phonemes(self):
-        """
-        内包する全てのラベルを返す
-        NOTE: `.labels` に名称変更予定
-        Returns
-        -------
-        labels : list[Label]
-            AccentPhraseに間接的に含まれる全てのLabelを返す
-        """
-        return list(chain.from_iterable(m.phonemes for m in self.moras))
+    def labels(self) -> list[Label]:
+        """内包する全てのラベルを返す"""
+        return list(chain.from_iterable(m.labels for m in self.moras))
 
 
 @dataclass
@@ -253,18 +244,11 @@ class BreathGroup:
             accent_phrase.set_context(key, value)
 
     @property
-    def phonemes(self):
-        """
-        内包する全てのラベルを返す
-        NOTE: `.labels` に名称変更予定
-        Returns
-        -------
-        labels : list[Label]
-            BreathGroupに間接的に含まれる全てのLabelを返す
-        """
+    def labels(self) -> list[Label]:
+        """内包する全てのラベルを返す"""
         return list(
             chain.from_iterable(
-                accent_phrase.phonemes for accent_phrase in self.accent_phrases
+                accent_phrase.labels for accent_phrase in self.accent_phrases
             )
         )
 
@@ -330,22 +314,15 @@ class Utterance:
             breath_group.set_context(key, value)
 
     @property
-    def phonemes(self):
-        """
-        内包する全てのラベルを返す
-        NOTE: `.labels` に名称変更予定
-        Returns
-        -------
-        labels : list[Label]
-            Utteranceクラスに直接的・間接的に含まれる、全てのLabelを返す
-        """
+    def labels(self) -> list[Label]:
+        """内包する全てのラベルを返す"""
         labels: list[Label] = []
         for i in range(len(self.pauses)):
             if self.pauses[i] is not None:
                 labels += [self.pauses[i]]
 
             if i < len(self.pauses) - 1:
-                labels += self.breath_groups[i].phonemes
+                labels += self.breath_groups[i].labels
 
         return labels
 
@@ -402,7 +379,7 @@ def full_context_label_moras_to_moras(full_context_moras: list[Mora]) -> list[Vv
     """
     return [
         VvMora(
-            text=mora_to_text("".join([p.phoneme for p in mora.phonemes])),
+            text=mora_to_text("".join([p.phoneme for p in mora.labels])),
             consonant=(mora.consonant.phoneme if mora.consonant is not None else None),
             consonant_length=0 if mora.consonant is not None else None,
             vowel=mora.vowel.phoneme,


### PR DESCRIPTION
## 内容
フルコンテキストラベル系の `.phonemes` -> `.labels` リネームによるリファクタリング  

一連のフルコンテキストラベル系リファクタリングによって、`Phoneme` クラスは `Label` クラスへリネームされた。  
これを反映し、getter メソッド名も改称する。  

## 関連 Issue
ref #893