### PR TITLE
整理: フルコンテキストラベル系クラスのリネーム

### DIFF
--- a/test/test_full_context_label.py
+++ b/test/test_full_context_label.py
@@ -2,11 +2,11 @@ from copy import deepcopy
 from unittest import TestCase
 
 from voicevox_engine.tts_pipeline.full_context_label import (
-    AccentPhrase,
-    BreathGroup,
+    AccentPhraseLabel,
+    BreathGroupLabel,
     Label,
-    Mora,
-    Utterance,
+    MoraLabel,
+    UtteranceLabel,
 )
 
 
@@ -29,7 +29,7 @@ def contexts_to_feature(contexts: dict[str, str]) -> str:
 
 
 # OpenJTalk コンテナクラス
-OjtContainer = Mora | AccentPhrase | BreathGroup | Utterance
+OjtContainer = MoraLabel | AccentPhraseLabel | BreathGroupLabel | UtteranceLabel
 
 
 def features(ojt_container: OjtContainer):
@@ -192,41 +192,41 @@ class TestMora(TestBasePhonemes):
     def setUp(self) -> None:
         super().setUp()
         # contexts["a2"] == "1" ko
-        self.mora_hello_1 = Mora(
+        self.mora_hello_1 = MoraLabel(
             consonant=self.phonemes_hello_hiho[1], vowel=self.phonemes_hello_hiho[2]
         )
         # contexts["a2"] == "2" N
-        self.mora_hello_2 = Mora(consonant=None, vowel=self.phonemes_hello_hiho[3])
+        self.mora_hello_2 = MoraLabel(consonant=None, vowel=self.phonemes_hello_hiho[3])
         # contexts["a2"] == "3" ni
-        self.mora_hello_3 = Mora(
+        self.mora_hello_3 = MoraLabel(
             consonant=self.phonemes_hello_hiho[4], vowel=self.phonemes_hello_hiho[5]
         )
         # contexts["a2"] == "4" chi
-        self.mora_hello_4 = Mora(
+        self.mora_hello_4 = MoraLabel(
             consonant=self.phonemes_hello_hiho[6], vowel=self.phonemes_hello_hiho[7]
         )
         # contexts["a2"] == "5" wa
-        self.mora_hello_5 = Mora(
+        self.mora_hello_5 = MoraLabel(
             consonant=self.phonemes_hello_hiho[8], vowel=self.phonemes_hello_hiho[9]
         )
         # contexts["a2"] == "1" hi
-        self.mora_hiho_1 = Mora(
+        self.mora_hiho_1 = MoraLabel(
             consonant=self.phonemes_hello_hiho[11], vowel=self.phonemes_hello_hiho[12]
         )
         # contexts["a2"] == "2" ho
-        self.mora_hiho_2 = Mora(
+        self.mora_hiho_2 = MoraLabel(
             consonant=self.phonemes_hello_hiho[13], vowel=self.phonemes_hello_hiho[14]
         )
         # contexts["a2"] == "3" de
-        self.mora_hiho_3 = Mora(
+        self.mora_hiho_3 = MoraLabel(
             consonant=self.phonemes_hello_hiho[15], vowel=self.phonemes_hello_hiho[16]
         )
         # contexts["a2"] == "1" sU
-        self.mora_hiho_4 = Mora(
+        self.mora_hiho_4 = MoraLabel(
             consonant=self.phonemes_hello_hiho[17], vowel=self.phonemes_hello_hiho[18]
         )
 
-    def assert_labels(self, mora: Mora, label_start: int, label_end: int) -> None:
+    def assert_labels(self, mora: MoraLabel, label_start: int, label_end: int) -> None:
         self.assertEqual(
             features(mora), self.test_case_hello_hiho[label_start:label_end]
         )
@@ -266,10 +266,10 @@ class TestAccentPhrase(TestBasePhonemes):
         super().setUp()
         # TODO: ValueErrorを吐く作為的ではない自然な例の模索
         # 存在しないなら放置でよい
-        self.accent_phrase_hello = AccentPhrase.from_labels(
+        self.accent_phrase_hello = AccentPhraseLabel.from_labels(
             self.phonemes_hello_hiho[1:10]
         )
-        self.accent_phrase_hiho = AccentPhrase.from_labels(
+        self.accent_phrase_hiho = AccentPhraseLabel.from_labels(
             self.phonemes_hello_hiho[11:19]
         )
 
@@ -301,10 +301,10 @@ class TestAccentPhrase(TestBasePhonemes):
 class TestBreathGroup(TestBasePhonemes):
     def setUp(self) -> None:
         super().setUp()
-        self.breath_group_hello = BreathGroup.from_labels(
+        self.breath_group_hello = BreathGroupLabel.from_labels(
             self.phonemes_hello_hiho[1:10]
         )
-        self.breath_group_hiho = BreathGroup.from_labels(
+        self.breath_group_hiho = BreathGroupLabel.from_labels(
             self.phonemes_hello_hiho[11:19]
         )
 
@@ -333,7 +333,7 @@ class TestBreathGroup(TestBasePhonemes):
 class TestUtterance(TestBasePhonemes):
     def setUp(self) -> None:
         super().setUp()
-        self.utterance_hello_hiho = Utterance.from_labels(self.phonemes_hello_hiho)
+        self.utterance_hello_hiho = UtteranceLabel.from_labels(self.phonemes_hello_hiho)
 
     def test_phonemes(self):
         outputs_hello_hiho = space_jointed_phonemes(self.utterance_hello_hiho)

--- a/voicevox_engine/tts_pipeline/full_context_label.py
+++ b/voicevox_engine/tts_pipeline/full_context_label.py
@@ -5,7 +5,7 @@ from typing import Self
 
 import pyopenjtalk
 
-from ..model import Mora, AccentPhrase
+from ..model import AccentPhrase, Mora
 from .mora_list import openjtalk_mora2text
 
 
@@ -13,7 +13,7 @@ from .mora_list import openjtalk_mora2text
 class Label:
     """OpenJTalkラベル"""
 
-    contexts: dict[str, str] # ラベルの属性
+    contexts: dict[str, str]  # ラベルの属性
 
     @classmethod
     def from_feature(cls, feature: str):
@@ -53,8 +53,8 @@ class Label:
 class MoraLabel:
     """モーララベル。モーラは1音素(母音や促音「っ」、撥音「ん」など)か、2音素(母音と子音の組み合わせ)で成り立つ。"""
 
-    consonant: Label | None # 子音
-    vowel: Label # 母音
+    consonant: Label | None  # 子音
+    vowel: Label  # 母音
 
     def set_context(self, key: str, value: str):
         """
@@ -86,9 +86,9 @@ class MoraLabel:
 class AccentPhraseLabel:
     """アクセント句ラベル"""
 
-    moras: list[MoraLabel] # モーラ系列
-    accent: int # アクセント位置
-    is_interrogative: bool # 疑問文か否か
+    moras: list[MoraLabel]  # モーラ系列
+    accent: int  # アクセント位置
+    is_interrogative: bool  # 疑問文か否か
 
     @classmethod
     def from_labels(cls, labels: list[Label]) -> Self:
@@ -171,7 +171,7 @@ class AccentPhraseLabel:
 class BreathGroupLabel:
     """発声区切りラベル"""
 
-    accent_phrases: list[AccentPhraseLabel] # アクセント句のリスト
+    accent_phrases: list[AccentPhraseLabel]  # アクセント句のリスト
 
     @classmethod
     def from_labels(cls, labels: list[Label]) -> Self:
@@ -239,8 +239,8 @@ class BreathGroupLabel:
 class UtteranceLabel:
     """発声ラベル"""
 
-    breath_groups: list[BreathGroupLabel] # 発声の区切りのリスト
-    pauses: list[Label] # 無音のリスト
+    breath_groups: list[BreathGroupLabel]  # 発声の区切りのリスト
+    pauses: list[Label]  # 無音のリスト
 
     @classmethod
     def from_labels(cls, labels: list[Label]) -> Self:
@@ -309,7 +309,7 @@ class UtteranceLabel:
 
 def _extract_utterance_label(text: str) -> UtteranceLabel:
     """日本語文からUtteranceLabelを抽出する"""
-    features: list[str] = pyopenjtalk.extract_fullcontext(text) #type: ignore
+    features: list[str] = pyopenjtalk.extract_fullcontext(text)  # type: ignore
     labels = [Label.from_feature(feature) for feature in features]
     utterance = UtteranceLabel.from_labels(labels)
     return utterance

--- a/voicevox_engine/tts_pipeline/full_context_label.py
+++ b/voicevox_engine/tts_pipeline/full_context_label.py
@@ -11,16 +11,9 @@ from .mora_list import openjtalk_mora2text
 
 @dataclass
 class Label:
-    """
-    OpenJTalk Label
+    """OpenJTalkラベル"""
 
-    Attributes
-    ----------
-    contexts: dict[str, str]
-        ラベルの属性
-    """
-
-    contexts: dict[str, str]
+    contexts: dict[str, str] # ラベルの属性
 
     @classmethod
     def from_feature(cls, feature: str):
@@ -58,24 +51,14 @@ class Label:
 
 @dataclass
 class MoraLabel:
-    """
-    モーラクラス
-    モーラは1音素(母音や促音「っ」、撥音「ん」など)か、2音素(母音と子音の組み合わせ)で成り立つ
+    """モーララベル。モーラは1音素(母音や促音「っ」、撥音「ん」など)か、2音素(母音と子音の組み合わせ)で成り立つ。"""
 
-    Attributes
-    ----------
-    consonant : Label | None
-        子音
-    vowel : Label
-        母音
-    """
-
-    consonant: Label | None
-    vowel: Label
+    consonant: Label | None # 子音
+    vowel: Label # 母音
 
     def set_context(self, key: str, value: str):
         """
-        Moraクラス内に含まれるLabelのcontextのうち、指定されたキーの値を変更する
+        MoraLabelクラス内に含まれるLabelのcontextのうち、指定されたキーの値を変更する
         consonantが存在する場合は、vowelと同じようにcontextを変更する
         Parameters
         ----------
@@ -101,24 +84,15 @@ class MoraLabel:
 
 @dataclass
 class AccentPhraseLabel:
-    """
-    アクセント句クラス
-    同じアクセントのMoraを複数保持する
-    Attributes
-    ----------
-    moras : list[Mora]
-        音韻のリスト
-    accent : int
-        アクセント
-    """
+    """アクセント句ラベル"""
 
-    moras: list[MoraLabel]
-    accent: int
-    is_interrogative: bool
+    moras: list[MoraLabel] # モーラ系列
+    accent: int # アクセント位置
+    is_interrogative: bool # 疑問文か否か
 
     @classmethod
     def from_labels(cls, labels: list[Label]) -> Self:
-        """ラベル系列をcontextで区切りAccentPhraseインスタンスを生成する"""
+        """ラベル系列をcontextで区切りアクセント句ラベルを生成する"""
 
         # NOTE:「モーラごとのラベル系列」はラベル系列をcontextで区切り生成される。
 
@@ -160,7 +134,7 @@ class AccentPhraseLabel:
         # f3はアクセント句が疑問文かどうか（1で疑問文）
         is_interrogative = moras[-1].vowel.contexts["f3"] == "1"
 
-        # AccentPhrase インスタンスを生成する
+        # アクセント句ラベルを生成する
         accent_phrase = cls(
             moras=moras, accent=accent, is_interrogative=is_interrogative
         )
@@ -169,7 +143,7 @@ class AccentPhraseLabel:
 
     def set_context(self, key: str, value: str):
         """
-        AccentPhraseに間接的に含まれる全てのLabelのcontextの、指定されたキーの値を変更する
+        アクセント句ラベルに間接的に含まれる全てのLabelのcontextの、指定されたキーの値を変更する
         Parameters
         ----------
         key : str
@@ -188,27 +162,20 @@ class AccentPhraseLabel:
         Returns
         -------
         labels : list[Label]
-            AccentPhraseに間接的に含まれる全てのLabelを返す
+            アクセント句ラベルに間接的に含まれる全てのLabelを返す
         """
         return list(chain.from_iterable(m.phonemes for m in self.moras))
 
 
 @dataclass
 class BreathGroupLabel:
-    """
-    発声の区切りクラス
-    アクセントの異なるアクセント句を複数保持する
-    Attributes
-    ----------
-    accent_phrases : list[AccentPhrase]
-        アクセント句のリスト
-    """
+    """発声区切りラベル"""
 
-    accent_phrases: list[AccentPhraseLabel]
+    accent_phrases: list[AccentPhraseLabel] # アクセント句のリスト
 
     @classmethod
     def from_labels(cls, labels: list[Label]) -> Self:
-        """ラベル系列をcontextで区切りBreathGroupインスタンスを生成する"""
+        """ラベル系列をcontextで区切りBreathGroupLabelインスタンスを生成する"""
 
         # NOTE:「アクセント句ごとのラベル系列」はラベル系列をcontextで区切り生成される。
 
@@ -220,8 +187,8 @@ class BreathGroupLabel:
             accent_labels.append(label)
 
             # 一時的なラベル系列を確定させて処理する
-            # i3はBreathGroupの番号
-            # f5はBreathGroup内でのアクセント句の番号
+            # i3はBreathGroupLabelの番号
+            # f5はBreathGroupLabel内でのアクセント句の番号
             if (
                 next_label is None
                 or label.contexts["i3"] != next_label.contexts["i3"]
@@ -233,14 +200,14 @@ class BreathGroupLabel:
                 # 次に向けてリセット
                 accent_labels = []
 
-        # BreathGroup インスタンスを生成する
+        # BreathGroupLabel インスタンスを生成する
         breath_group = cls(accent_phrases=accent_phrases)
 
         return breath_group
 
     def set_context(self, key: str, value: str):
         """
-        BreathGroupに間接的に含まれる全てのLabelのcontextの、指定されたキーの値を変更する
+        BreathGroupLabelに間接的に含まれる全てのLabelのcontextの、指定されたキーの値を変更する
         Parameters
         ----------
         key : str
@@ -259,7 +226,7 @@ class BreathGroupLabel:
         Returns
         -------
         labels : list[Label]
-            BreathGroupに間接的に含まれる全てのLabelを返す
+            BreathGroupLabelに間接的に含まれる全てのLabelを返す
         """
         return list(
             chain.from_iterable(
@@ -270,29 +237,20 @@ class BreathGroupLabel:
 
 @dataclass
 class UtteranceLabel:
-    """
-    発声クラス
-    発声の区切りと無音を複数保持する
-    Attributes
-    ----------
-    breath_groups : list[BreathGroup]
-        発声の区切りのリスト
-    pauses : list[Label]
-        無音のリスト
-    """
+    """発声ラベル"""
 
-    breath_groups: list[BreathGroupLabel]
-    pauses: list[Label]
+    breath_groups: list[BreathGroupLabel] # 発声の区切りのリスト
+    pauses: list[Label] # 無音のリスト
 
     @classmethod
     def from_labels(cls, labels: list[Label]) -> Self:
-        """ラベル系列をポーズで区切りUtteranceインスタンスを生成する"""
+        """ラベル系列をポーズで区切りUtteranceLabelインスタンスを生成する"""
 
-        # NOTE:「BreathGroupごとのラベル系列」はラベル系列をポーズで区切り生成される。
+        # NOTE:「BreathGroupLabelごとのラベル系列」はラベル系列をポーズで区切り生成される。
 
         pauses: list[Label] = []  # ポーズラベルのリスト
-        breath_groups: list[BreathGroupLabel] = []  # BreathGroup のリスト
-        group_labels: list[Label] = []  # BreathGroupごとのラベル系列を一時保存するコンテナ
+        breath_groups: list[BreathGroupLabel] = []  # BreathGroupLabel のリスト
+        group_labels: list[Label] = []  # BreathGroupLabelごとのラベル系列を一時保存するコンテナ
 
         for label in labels:
             # ポーズが出現するまでラベル系列を一時保存する
@@ -304,20 +262,20 @@ class UtteranceLabel:
                 # ポーズラベルを保存する
                 pauses.append(label)
                 if len(group_labels) > 0:
-                    # ラベル系列からBreathGroupを生成して保存する
+                    # ラベル系列からBreathGroupLabelを生成して保存する
                     breath_group = BreathGroupLabel.from_labels(group_labels)
                     breath_groups.append(breath_group)
                     # 次に向けてリセット
                     group_labels = []
 
-        # Utteranceインスタンスを生成する
+        # UtteranceLabelインスタンスを生成する
         utterance = cls(breath_groups=breath_groups, pauses=pauses)
 
         return utterance
 
     def set_context(self, key: str, value: str):
         """
-        Utteranceに間接的に含まれる全てのLabelのcontextの、指定されたキーの値を変更する
+        UtteranceLabelに間接的に含まれる全てのLabelのcontextの、指定されたキーの値を変更する
         Parameters
         ----------
         key : str
@@ -336,7 +294,7 @@ class UtteranceLabel:
         Returns
         -------
         labels : list[Label]
-            Utteranceクラスに直接的・間接的に含まれる、全てのLabelを返す
+            UtteranceLabelクラスに直接的・間接的に含まれる、全てのLabelを返す
         """
         labels: list[Label] = []
         for i in range(len(self.pauses)):

--- a/voicevox_engine/tts_pipeline/full_context_label.py
+++ b/voicevox_engine/tts_pipeline/full_context_label.py
@@ -261,7 +261,7 @@ def mora_to_text(mora: str) -> str:
 def _mora_labels_to_moras(mora_labels: list[MoraLabel]) -> list[Mora]:
     """MoraLabel系列をMora系列へキャストする。音素長と音高は 0 初期化"""
     return [
-        VvMora(
+        Mora(
             text=mora_to_text("".join([p.phoneme for p in mora.labels])),
             consonant=(mora.consonant.phoneme if mora.consonant is not None else None),
             consonant_length=0 if mora.consonant is not None else None,

--- a/voicevox_engine/tts_pipeline/full_context_label.py
+++ b/voicevox_engine/tts_pipeline/full_context_label.py
@@ -5,8 +5,7 @@ from typing import Self
 
 import pyopenjtalk
 
-from ..model import AccentPhrase as VvAccentPhrase  # NOTE: 後にOjtコンテナクラスをリネーム予定
-from ..model import Mora as VvMora
+from ..model import Mora, AccentPhrase
 from .mora_list import openjtalk_mora2text
 
 
@@ -378,10 +377,10 @@ def mora_to_text(mora: str) -> str:
         return mora
 
 
-def _mora_labels_to_moras(mora_labels: list[MoraLabel]) -> list[VvMora]:
+def _mora_labels_to_moras(mora_labels: list[MoraLabel]) -> list[Mora]:
     """MoraLabel系列をMora系列へキャストする。音素長と音高は 0 初期化"""
     return [
-        VvMora(
+        Mora(
             text=mora_to_text("".join([p.phoneme for p in mora.phonemes])),
             consonant=(mora.consonant.phoneme if mora.consonant is not None else None),
             consonant_length=0 if mora.consonant is not None else None,
@@ -393,14 +392,14 @@ def _mora_labels_to_moras(mora_labels: list[MoraLabel]) -> list[VvMora]:
     ]
 
 
-def _utterance_to_accent_phrases(utterance: UtteranceLabel) -> list[VvAccentPhrase]:
+def _utterance_to_accent_phrases(utterance: UtteranceLabel) -> list[AccentPhrase]:
     """UtteranceLabelインスタンスをアクセント句系列へドメイン変換する"""
     return [
-        VvAccentPhrase(
+        AccentPhrase(
             moras=_mora_labels_to_moras(accent_phrase.moras),
             accent=accent_phrase.accent,
             pause_mora=(
-                VvMora(
+                Mora(
                     text="、",
                     consonant=None,
                     consonant_length=None,
@@ -421,7 +420,7 @@ def _utterance_to_accent_phrases(utterance: UtteranceLabel) -> list[VvAccentPhra
     ]
 
 
-def text_to_accent_phrases(text: str) -> list[VvAccentPhrase]:
+def text_to_accent_phrases(text: str) -> list[AccentPhrase]:
     """日本語文からアクセント句系列を生成する"""
     if len(text.strip()) == 0:
         return []

--- a/voicevox_engine/tts_pipeline/full_context_label.py
+++ b/voicevox_engine/tts_pipeline/full_context_label.py
@@ -150,8 +150,8 @@ class BreathGroupLabel:
             accent_labels.append(label)
 
             # 一時的なラベル系列を確定させて処理する
-            # i3はBreathGroupLabelの番号
-            # f5はBreathGroupLabel内でのアクセント句の番号
+            # i3はBreathGroupの番号
+            # f5はBreathGroup内でのアクセント句の番号
             if (
                 next_label is None
                 or label.contexts["i3"] != next_label.contexts["i3"]


### PR DESCRIPTION
## 内容
フルコンテキストラベル系クラスのリネームによるリファクタリング  

以下のクラスをリネーム：  

- `MoraLabel` (← `Mora`)
- `AccentPhraseLabel` (← `AccentPhrase`)
- `BreathGroupLabel` (← `BreathGroup`)
- `UtteranceLabel` (← `Utterance`)

これに伴い、import alias と関連関数名をリファクタリング。  

## 関連 Issue
ref #881  
ref #901  