### PR TITLE
整理: `OjtPhoneme` → `Phoneme` リネーム

### DIFF
--- a/test/test_acoustic_feature_extractor.py
+++ b/test/test_acoustic_feature_extractor.py
@@ -1,27 +1,27 @@
 from unittest import TestCase
 
-from voicevox_engine.tts_pipeline.acoustic_feature_extractor import OjtPhoneme
+from voicevox_engine.tts_pipeline.acoustic_feature_extractor import Phoneme
 
 TRUE_NUM_PHONEME = 45
 
 
-class TestOjtPhoneme(TestCase):
+class TestPhoneme(TestCase):
     def setUp(self):
         super().setUp()
         # list_idx      0 1 2 3 4 5  6 7 8 9  10 1 2 3 4 5 6 7 8   9
         hello_hiho = "sil k o N n i ch i w a pau h i h o d e s U sil".split()
-        self.ojt_hello_hiho = [OjtPhoneme(s) for s in hello_hiho]
+        self.ojt_hello_hiho = [Phoneme(s) for s in hello_hiho]
 
     def test_const(self):
-        self.assertEqual(OjtPhoneme._NUM_PHONEME, TRUE_NUM_PHONEME)
-        self.assertEqual(OjtPhoneme._PHONEME_LIST[1], "A")
-        self.assertEqual(OjtPhoneme._PHONEME_LIST[14], "e")
-        self.assertEqual(OjtPhoneme._PHONEME_LIST[26], "m")
-        self.assertEqual(OjtPhoneme._PHONEME_LIST[38], "ts")
-        self.assertEqual(OjtPhoneme._PHONEME_LIST[41], "v")
+        self.assertEqual(Phoneme._NUM_PHONEME, TRUE_NUM_PHONEME)
+        self.assertEqual(Phoneme._PHONEME_LIST[1], "A")
+        self.assertEqual(Phoneme._PHONEME_LIST[14], "e")
+        self.assertEqual(Phoneme._PHONEME_LIST[26], "m")
+        self.assertEqual(Phoneme._PHONEME_LIST[38], "ts")
+        self.assertEqual(Phoneme._PHONEME_LIST[41], "v")
 
     def test_convert(self):
-        sil_phoneme = OjtPhoneme("sil")
+        sil_phoneme = Phoneme("sil")
         self.assertEqual(sil_phoneme.phoneme, "pau")
 
     def test_phoneme_id(self):

--- a/test/test_synthesis_engine.py
+++ b/test/test_synthesis_engine.py
@@ -470,8 +470,7 @@ class TestTTSEngine(TestCase):
             "sil k o N n i ch i w a pau h i h o d e s U sil".split()
         )
         self.phoneme_data_list_hello_hiho = [
-            Phoneme(p)
-            for p in "pau k o N n i ch i w a pau h i h o d e s U pau".split()
+            Phoneme(p) for p in "pau k o N n i ch i w a pau h i h o d e s U pau".split()
         ]
         self.accent_phrases_hello_hiho = [
             AccentPhrase(

--- a/test/test_synthesis_engine.py
+++ b/test/test_synthesis_engine.py
@@ -7,7 +7,7 @@ import numpy
 
 from voicevox_engine.model import AccentPhrase, AudioQuery, Mora
 from voicevox_engine.tts_pipeline import TTSEngine
-from voicevox_engine.tts_pipeline.acoustic_feature_extractor import OjtPhoneme
+from voicevox_engine.tts_pipeline.acoustic_feature_extractor import Phoneme
 
 # TODO: import from voicevox_engine.synthesis_engine.mora
 from voicevox_engine.tts_pipeline.tts_engine import (
@@ -31,15 +31,15 @@ from voicevox_engine.tts_pipeline.tts_engine import (
 TRUE_NUM_PHONEME = 45
 
 
-def is_same_phoneme(p1: OjtPhoneme, p2: OjtPhoneme) -> bool:
-    """2つのOjtPhonemeが同じ `.phoneme` を持つ"""
+def is_same_phoneme(p1: Phoneme, p2: Phoneme) -> bool:
+    """2つのPhonemeが同じ `.phoneme` を持つ"""
     return p1.phoneme == p2.phoneme
 
 
 def is_same_ojt_phoneme_list(
-    p1s: list[OjtPhoneme | None], p2s: list[OjtPhoneme | None]
+    p1s: list[Phoneme | None], p2s: list[Phoneme | None]
 ) -> bool:
-    """2つのOjtPhonemeリストで全要素ペアが同じ `.phoneme` を持つ"""
+    """2つのPhonemeリストで全要素ペアが同じ `.phoneme` を持つ"""
     if len(p1s) != len(p2s):
         return False
 
@@ -470,7 +470,7 @@ class TestTTSEngine(TestCase):
             "sil k o N n i ch i w a pau h i h o d e s U sil".split()
         )
         self.phoneme_data_list_hello_hiho = [
-            OjtPhoneme(p)
+            Phoneme(p)
             for p in "pau k o N n i ch i w a pau h i h o d e s U pau".split()
         ]
         self.accent_phrases_hello_hiho = [
@@ -520,7 +520,7 @@ class TestTTSEngine(TestCase):
         self.assertEqual(vowel_indexes, [0, 2, 3, 5, 7, 9, 10, 12, 14, 16, 18, 19])
 
         ps = ["pau", "o", "N", "i", "i", "a", "pau", "i", "o", "e", "U", "pau"]
-        true_vowel_phoneme_list = [OjtPhoneme(p) for p in ps]
+        true_vowel_phoneme_list = [Phoneme(p) for p in ps]
         self.assertTrue(
             is_same_ojt_phoneme_list(vowel_phoneme_list, true_vowel_phoneme_list)
         )
@@ -529,16 +529,16 @@ class TestTTSEngine(TestCase):
                 consonant_phoneme_list,
                 [
                     None,
-                    OjtPhoneme("k"),
+                    Phoneme("k"),
                     None,
-                    OjtPhoneme("n"),
-                    OjtPhoneme("ch"),
-                    OjtPhoneme("w"),
+                    Phoneme("n"),
+                    Phoneme("ch"),
+                    Phoneme("w"),
                     None,
-                    OjtPhoneme("h"),
-                    OjtPhoneme("h"),
-                    OjtPhoneme("d"),
-                    OjtPhoneme("s"),
+                    Phoneme("h"),
+                    Phoneme("h"),
+                    Phoneme("d"),
+                    Phoneme("s"),
                     None,
                 ],
             )
@@ -552,7 +552,7 @@ class TestTTSEngine(TestCase):
         mora_index = 0
         phoneme_index = 1
 
-        self.assertTrue(is_same_phoneme(phoneme_data_list[0], OjtPhoneme("pau")))
+        self.assertTrue(is_same_phoneme(phoneme_data_list[0], Phoneme("pau")))
         for accent_phrase in self.accent_phrases_hello_hiho:
             moras = accent_phrase.moras
             for mora in moras:
@@ -561,13 +561,13 @@ class TestTTSEngine(TestCase):
                 if mora.consonant is not None:
                     self.assertTrue(
                         is_same_phoneme(
-                            phoneme_data_list[phoneme_index], OjtPhoneme(mora.consonant)
+                            phoneme_data_list[phoneme_index], Phoneme(mora.consonant)
                         )
                     )
                     phoneme_index += 1
                 self.assertTrue(
                     is_same_phoneme(
-                        phoneme_data_list[phoneme_index], OjtPhoneme(mora.vowel)
+                        phoneme_data_list[phoneme_index], Phoneme(mora.vowel)
                     )
                 )
                 phoneme_index += 1
@@ -575,11 +575,11 @@ class TestTTSEngine(TestCase):
                 self.assertEqual(flatten_moras[mora_index], accent_phrase.pause_mora)
                 mora_index += 1
                 self.assertTrue(
-                    is_same_phoneme(phoneme_data_list[phoneme_index], OjtPhoneme("pau"))
+                    is_same_phoneme(phoneme_data_list[phoneme_index], Phoneme("pau"))
                 )
                 phoneme_index += 1
         self.assertTrue(
-            is_same_phoneme(phoneme_data_list[phoneme_index], OjtPhoneme("pau"))
+            is_same_phoneme(phoneme_data_list[phoneme_index], Phoneme("pau"))
         )
 
     def test_replace_phoneme_length(self):
@@ -683,7 +683,7 @@ class TestTTSEngine(TestCase):
         def result_value(i: int):
             # unvoiced_mora_phoneme_listのPhoneme ID版
             unvoiced_mora_phoneme_id_list = [
-                OjtPhoneme(p).phoneme_id for p in unvoiced_mora_phoneme_list
+                Phoneme(p).phoneme_id for p in unvoiced_mora_phoneme_list
             ]
             if vowel_phoneme_list[i] in unvoiced_mora_phoneme_id_list:
                 return 0

--- a/voicevox_engine/tts_pipeline/acoustic_feature_extractor.py
+++ b/voicevox_engine/tts_pipeline/acoustic_feature_extractor.py
@@ -12,10 +12,8 @@ _PHONEME_LIST = _P_LIST1 + _P_LIST2 + _P_LIST3 + _P_LIST4 + _P_LIST5
 _NUM_PHONEME = len(_PHONEME_LIST)
 
 
-class OjtPhoneme:
-    """
-    OpenJTalkに含まれる音素
-    """
+class Phoneme:
+    """音素"""
 
     _PHONEME_LIST = _PHONEME_LIST
     _NUM_PHONEME = _NUM_PHONEME
@@ -32,25 +30,13 @@ class OjtPhoneme:
         raise NotImplementedError
 
     @property
-    def phoneme_id(self):
-        """
-        phoneme_id (phoneme list内でのindex)を取得する
-        Returns
-        -------
-        id : int
-            phoneme_idを返す
-        """
+    def phoneme_id(self) -> int:
+        """音素ID (音素リスト内でのindex) を取得する"""
         return self._PHONEME_LIST.index(self.phoneme)
 
     @property
     def onehot(self):
-        """
-        音素onehotベクトル
-        Returns
-        -------
-        onehot : numpy.ndarray
-            音素onehotベクトル（listの長さ分の0埋め配列のうち、phoneme id番目が1.0の配列）
-        """
-        array = numpy.zeros(self._NUM_PHONEME, dtype=numpy.float32)
-        array[self.phoneme_id] = 1.0
-        return array
+        """音素onehotベクトルを取得する"""
+        vec = numpy.zeros(self._NUM_PHONEME, dtype=numpy.float32)
+        vec[self.phoneme_id] = 1.0
+        return vec

--- a/voicevox_engine/tts_pipeline/tts_engine.py
+++ b/voicevox_engine/tts_pipeline/tts_engine.py
@@ -8,7 +8,7 @@ from soxr import resample
 
 from ..core_wrapper import CoreWrapper, OldCoreError
 from ..model import AccentPhrase, AudioQuery, Mora
-from .acoustic_feature_extractor import OjtPhoneme
+from .acoustic_feature_extractor import Phoneme
 from .tts_engine_base import TTSEngineBase
 
 unvoiced_mora_phoneme_list = ["A", "I", "U", "E", "O", "cl", "pau"]
@@ -36,46 +36,18 @@ def to_flatten_moras(accent_phrases: list[AccentPhrase]) -> list[Mora]:
     return moras
 
 
-def to_flatten_phonemes(moras: list[Mora]) -> list[OjtPhoneme]:
-    """
-    モーラ系列に含まれる音素の抽出
-    Parameters
-    ----------
-    moras : list[Mora]
-        モーラ系列
-    Returns
-    -------
-    phonemes : list[OjtPhoneme]
-        音素系列
-    """
-    phonemes: list[OjtPhoneme] = []
+def to_flatten_phonemes(moras: list[Mora]) -> list[Phoneme]:
+    """モーラ系列から音素系列を抽出する"""
+    phonemes: list[Phoneme] = []
     for mora in moras:
         if mora.consonant:
-            phonemes += [OjtPhoneme(mora.consonant)]
-        phonemes += [(OjtPhoneme(mora.vowel))]
+            phonemes += [Phoneme(mora.consonant)]
+        phonemes += [(Phoneme(mora.vowel))]
     return phonemes
 
 
-def split_mora(phoneme_list: List[OjtPhoneme]):
-    """
-    OjtPhonemeのリストから、
-    母音の位置(vowel_indexes)
-    母音の音素列(vowel_phoneme_list)
-    子音の音素列(consonant_phoneme_list)
-    を生成し、返す
-    Parameters
-    ----------
-    phoneme_list : List[OjtPhoneme]
-        phonemeクラスのリスト
-    Returns
-    -------
-    consonant_phoneme_list : List[OjtPhoneme]
-        子音の音素列
-    vowel_phoneme_list : List[OjtPhoneme]
-        母音の音素列
-    vowel_indexes : : List[int]
-        母音の位置
-    """
+def split_mora(phoneme_list: List[Phoneme]):
+    """音素系列から子音系列・母音系列・母音位置を抽出する"""
     vowel_indexes = [
         i for i, p in enumerate(phoneme_list) if p.phoneme in mora_phoneme_list
     ]
@@ -85,7 +57,7 @@ def split_mora(phoneme_list: List[OjtPhoneme]):
     # 1の場合はconsonant(子音)が存在しない=母音のみ(a/i/u/e/o/N/cl/pau)で構成されるモーラ(音)である
     # 2の場合はconsonantが存在するモーラである
     # なので、2の場合(else)でphonemeを取り出している
-    consonant_phoneme_list: List[Optional[OjtPhoneme]] = [None] + [
+    consonant_phoneme_list: List[Optional[Phoneme]] = [None] + [
         None if post - prev == 1 else phoneme_list[post - 1]
         for prev, post in zip(vowel_indexes[:-1], vowel_indexes[1:])
     ]
@@ -94,25 +66,13 @@ def split_mora(phoneme_list: List[OjtPhoneme]):
 
 def pre_process(
     accent_phrases: list[AccentPhrase],
-) -> tuple[list[Mora], list[OjtPhoneme]]:
-    """
-    AccentPhraseモデルのリストを整形し、処理に必要なデータの原型を作り出す
-    Parameters
-    ----------
-    accent_phrases : List[AccentPhrase]
-        AccentPhraseモデルのリスト
-    Returns
-    -------
-    flatten_moras : List[Mora]
-        モーラ列（前後の無音含まない）
-    phonemes : List[OjtPhoneme]
-        音素列（前後の無音含む）
-    """
+) -> tuple[list[Mora], list[Phoneme]]:
+    """アクセント句系列から（前後の無音含まない）モーラ系列と（前後の無音含む）音素系列を抽出する"""
     flatten_moras = to_flatten_moras(accent_phrases)
     phonemes = to_flatten_phonemes(flatten_moras)
 
     # 前後無音の追加
-    phonemes = [OjtPhoneme("pau")] + phonemes + [OjtPhoneme("pau")]
+    phonemes = [Phoneme("pau")] + phonemes + [Phoneme("pau")]
 
     return flatten_moras, phonemes
 
@@ -387,7 +347,7 @@ class TTSEngine(TTSEngineBase):
 
         # 音素系列を抽出し前後無音を付加する
         phonemes = to_flatten_phonemes(moras)
-        phonemes = [OjtPhoneme("pau")] + phonemes + [OjtPhoneme("pau")]
+        phonemes = [Phoneme("pau")] + phonemes + [Phoneme("pau")]
 
         # 音素クラスから音素IDスカラへ表現を変換する
         phoneme_ids = numpy.array([p.phoneme_id for p in phonemes], dtype=numpy.int64)
@@ -431,7 +391,7 @@ class TTSEngine(TTSEngineBase):
             return []
 
         # phoneme
-        # AccentPhraseをすべてMoraおよびOjtPhonemeの形に分解し、処理可能な形にする
+        # AccentPhraseをすべてMoraおよびPhonemeの形に分解し、処理可能な形にする
         flatten_moras, phoneme_data_list = pre_process(accent_phrases)
 
         # accent


### PR DESCRIPTION
## 内容
`OjtPhoneme` → `Phoneme` リネームによるリファクタリング  

`OjtPhoneme` は音素コンテナクラスである。  
`Ojt` (OpenJTalk) と prefix されているが、`full_context_label` モジュールでなく `tts_engine` モジュール波形合成の中心にあるクラスである。  
また`Ojt` と prefix されているが、このクラスはOjtにある `sil` 音素を持たない (`pau` にキャストしている)。  
つまり名称と実体が合致していない。  

以前は `full_context_label` モジュールに `Phoneme` クラスが定義されていたため、`OjtPhoneme` のリネームは混乱を招く可能性があった。  
しかし関係者の尽力により現在は `Label` にリネームされており、`Phoneme` というクラス名を利用できる状況にある。  

これらの背景から、`OjtPhoneme` → `Phoneme` リネームによるリファクタリングを提案します。  

## 関連 Issue
ref #893