### PR TITLE
整理: 疑問文 upspeak テスト

### DIFF
--- a/test/test_synthesis_engine_base.py
+++ b/test/test_synthesis_engine_base.py
@@ -216,7 +216,8 @@ class TestTTSEngineBase(TestCase):
         actual = self.synthesis_engine.create_accent_phrases(text, 1)
         self.assertEqual(expected, actual, f"case(text:{text})")
 
-    def test_synthesis_interrogative(self):
+    def test_upspeak_voiced_last_mora(self):
+        # voiced + "？" + flagON -> upspeak
         expected = koreha_arimasuka_base_expected()
         expected[-1].is_interrogative = True
         expected[-1].moras += [
@@ -229,27 +230,18 @@ class TestTTSEngineBase(TestCase):
                 pitch=expected[-1].moras[-1].pitch + 0.3,
             )
         ]
-        self.create_synthesis_test_base(
-            text="これはありますか？",
-            expected=expected,
-            enable_interrogative_upspeak=True,
-        )
+        self.create_synthesis_test_base("これはありますか？", expected, True)
 
+        # voiced + "？" + flagOFF -> non-upspeak
         expected = koreha_arimasuka_base_expected()
         expected[-1].is_interrogative = True
-        self.create_synthesis_test_base(
-            text="これはありますか？",
-            expected=expected,
-            enable_interrogative_upspeak=False,
-        )
+        self.create_synthesis_test_base("これはありますか？", expected, False)
 
+        # voiced + "" + flagON -> non-upspeak
         expected = koreha_arimasuka_base_expected()
-        self.create_synthesis_test_base(
-            text="これはありますか",
-            expected=expected,
-            enable_interrogative_upspeak=True,
-        )
+        self.create_synthesis_test_base("これはありますか", expected, True)
 
+    def test_upspeak_voiced_N_last_mora(self):
         def nn_base_expected():
             return [
                 AccentPhrase(
@@ -269,13 +261,11 @@ class TestTTSEngineBase(TestCase):
                 )
             ]
 
+        # voiced + "" + flagON -> upspeak
         expected = nn_base_expected()
-        self.create_synthesis_test_base(
-            text="ん",
-            expected=expected,
-            enable_interrogative_upspeak=True,
-        )
+        self.create_synthesis_test_base("ん", expected, True)
 
+        # voiced + "？" + flagON -> upspeak
         expected = nn_base_expected()
         expected[-1].is_interrogative = True
         expected[-1].moras += [
@@ -288,20 +278,14 @@ class TestTTSEngineBase(TestCase):
                 pitch=expected[-1].moras[-1].pitch + 0.3,
             )
         ]
-        self.create_synthesis_test_base(
-            text="ん？",
-            expected=expected,
-            enable_interrogative_upspeak=True,
-        )
+        self.create_synthesis_test_base("ん？", expected, True)
 
+        # voiced + "？" + flagOFF -> non-upspeak
         expected = nn_base_expected()
         expected[-1].is_interrogative = True
-        self.create_synthesis_test_base(
-            text="ん？",
-            expected=expected,
-            enable_interrogative_upspeak=False,
-        )
+        self.create_synthesis_test_base("ん？", expected, False)
 
+    def test_upspeak_unvoiced_last_mora(self):
         def ltu_base_expected():
             return [
                 AccentPhrase(
@@ -321,29 +305,21 @@ class TestTTSEngineBase(TestCase):
                 )
             ]
 
+        # unvoiced + "" + flagON -> non-upspeak
         expected = ltu_base_expected()
-        self.create_synthesis_test_base(
-            text="っ",
-            expected=expected,
-            enable_interrogative_upspeak=True,
-        )
+        self.create_synthesis_test_base("っ", expected, True)
 
+        # unvoiced + "？" + flagON -> non-upspeak
         expected = ltu_base_expected()
         expected[-1].is_interrogative = True
-        self.create_synthesis_test_base(
-            text="っ？",
-            expected=expected,
-            enable_interrogative_upspeak=True,
-        )
+        self.create_synthesis_test_base("っ？", expected, True)
 
+        # unvoiced + "？" + flagOFF -> non-upspeak
         expected = ltu_base_expected()
         expected[-1].is_interrogative = True
-        self.create_synthesis_test_base(
-            text="っ？",
-            expected=expected,
-            enable_interrogative_upspeak=False,
-        )
+        self.create_synthesis_test_base("っ？", expected, False)
 
+    def test_upspeak_voiced_u_last_mora(self):
         def su_base_expected():
             return [
                 AccentPhrase(
@@ -363,13 +339,11 @@ class TestTTSEngineBase(TestCase):
                 )
             ]
 
+        # voiced + "" + flagON -> non-upspeak
         expected = su_base_expected()
-        self.create_synthesis_test_base(
-            text="す",
-            expected=expected,
-            enable_interrogative_upspeak=True,
-        )
+        self.create_synthesis_test_base("す", expected, True)
 
+        # voiced + "？" + flagON -> upspeak
         expected = su_base_expected()
         expected[-1].is_interrogative = True
         expected[-1].moras += [
@@ -382,16 +356,9 @@ class TestTTSEngineBase(TestCase):
                 pitch=expected[-1].moras[-1].pitch + 0.3,
             )
         ]
-        self.create_synthesis_test_base(
-            text="す？",
-            expected=expected,
-            enable_interrogative_upspeak=True,
-        )
+        self.create_synthesis_test_base("す？", expected, True)
 
+        # voiced + "？" + flagOFF -> non-upspeak
         expected = su_base_expected()
         expected[-1].is_interrogative = True
-        self.create_synthesis_test_base(
-            text="す？",
-            expected=expected,
-            enable_interrogative_upspeak=False,
-        )
+        self.create_synthesis_test_base("す？", expected, False)

--- a/test/test_synthesis_engine_base.py
+++ b/test/test_synthesis_engine_base.py
@@ -230,16 +230,28 @@ class TestTTSEngineBase(TestCase):
                 pitch=expected[-1].moras[-1].pitch + 0.3,
             )
         ]
-        self.create_synthesis_test_base("これはありますか？", expected, True)
+        self.create_synthesis_test_base(
+            text="これはありますか？",
+            expected=expected,
+            enable_interrogative_upspeak=True,
+        )
 
         # voiced + "？" + flagOFF -> non-upspeak
         expected = koreha_arimasuka_base_expected()
         expected[-1].is_interrogative = True
-        self.create_synthesis_test_base("これはありますか？", expected, False)
+        self.create_synthesis_test_base(
+            text="これはありますか？",
+            expected=expected,
+            enable_interrogative_upspeak=False,
+        )
 
         # voiced + "" + flagON -> non-upspeak
         expected = koreha_arimasuka_base_expected()
-        self.create_synthesis_test_base("これはありますか", expected, True)
+        self.create_synthesis_test_base(
+            text="これはありますか",
+            expected=expected,
+            enable_interrogative_upspeak=True,
+        )
 
     def test_upspeak_voiced_N_last_mora(self):
         def nn_base_expected():
@@ -263,7 +275,11 @@ class TestTTSEngineBase(TestCase):
 
         # voiced + "" + flagON -> upspeak
         expected = nn_base_expected()
-        self.create_synthesis_test_base("ん", expected, True)
+        self.create_synthesis_test_base(
+            text="ん",
+            expected=expected,
+            enable_interrogative_upspeak=True,
+        )
 
         # voiced + "？" + flagON -> upspeak
         expected = nn_base_expected()
@@ -278,12 +294,20 @@ class TestTTSEngineBase(TestCase):
                 pitch=expected[-1].moras[-1].pitch + 0.3,
             )
         ]
-        self.create_synthesis_test_base("ん？", expected, True)
+        self.create_synthesis_test_base(
+            text="ん？",
+            expected=expected,
+            enable_interrogative_upspeak=True,
+        )
 
         # voiced + "？" + flagOFF -> non-upspeak
         expected = nn_base_expected()
         expected[-1].is_interrogative = True
-        self.create_synthesis_test_base("ん？", expected, False)
+        self.create_synthesis_test_base(
+            text="ん？",
+            expected=expected,
+            enable_interrogative_upspeak=False,
+        )
 
     def test_upspeak_unvoiced_last_mora(self):
         def ltu_base_expected():
@@ -307,17 +331,29 @@ class TestTTSEngineBase(TestCase):
 
         # unvoiced + "" + flagON -> non-upspeak
         expected = ltu_base_expected()
-        self.create_synthesis_test_base("っ", expected, True)
+        self.create_synthesis_test_base(
+            text="っ",
+            expected=expected,
+            enable_interrogative_upspeak=True,
+        )
 
         # unvoiced + "？" + flagON -> non-upspeak
         expected = ltu_base_expected()
         expected[-1].is_interrogative = True
-        self.create_synthesis_test_base("っ？", expected, True)
+        self.create_synthesis_test_base(
+            text="っ？",
+            expected=expected,
+            enable_interrogative_upspeak=True,
+        )
 
         # unvoiced + "？" + flagOFF -> non-upspeak
         expected = ltu_base_expected()
         expected[-1].is_interrogative = True
-        self.create_synthesis_test_base("っ？", expected, False)
+        self.create_synthesis_test_base(
+            text="っ？",
+            expected=expected,
+            enable_interrogative_upspeak=False,
+        )
 
     def test_upspeak_voiced_u_last_mora(self):
         def su_base_expected():
@@ -341,7 +377,11 @@ class TestTTSEngineBase(TestCase):
 
         # voiced + "" + flagON -> non-upspeak
         expected = su_base_expected()
-        self.create_synthesis_test_base("す", expected, True)
+        self.create_synthesis_test_base(
+            text="す",
+            expected=expected,
+            enable_interrogative_upspeak=True,
+        )
 
         # voiced + "？" + flagON -> upspeak
         expected = su_base_expected()
@@ -356,9 +396,17 @@ class TestTTSEngineBase(TestCase):
                 pitch=expected[-1].moras[-1].pitch + 0.3,
             )
         ]
-        self.create_synthesis_test_base("す？", expected, True)
+        self.create_synthesis_test_base(
+            text="す？",
+            expected=expected,
+            enable_interrogative_upspeak=True,
+        )
 
         # voiced + "？" + flagOFF -> non-upspeak
         expected = su_base_expected()
         expected[-1].is_interrogative = True
-        self.create_synthesis_test_base("す？", expected, False)
+        self.create_synthesis_test_base(
+            text="す？",
+            expected=expected,
+            enable_interrogative_upspeak=False,
+        )

--- a/test/test_synthesis_engine_base.py
+++ b/test/test_synthesis_engine_base.py
@@ -6,6 +6,7 @@ import numpy
 
 from voicevox_engine.model import AccentPhrase, AudioQuery, Mora
 from voicevox_engine.tts_pipeline import TTSEngine
+from voicevox_engine.tts_pipeline.tts_engine_base import apply_interrogative_upspeak
 
 
 def yukarin_s_mock(length: int, phoneme_list: numpy.ndarray, style_id: numpy.ndarray):
@@ -209,19 +210,9 @@ class TestTTSEngineBase(TestCase):
         """音声合成時に疑問文モーラ処理を行っているかどうかを検証
         (https://github.com/VOICEVOX/voicevox_engine/issues/272#issuecomment-1022610866)
         """
-        accent_phrases = self.synthesis_engine.create_accent_phrases(text, 1)
-        query = create_mock_query(accent_phrases=accent_phrases)
-        self.synthesis_engine.synthesis(
-            query, 0, enable_interrogative_upspeak=enable_interrogative_upspeak
-        )
-        # _synthesis_implの第一引数に与えられたqueryを検証
-        actual = self.synthesis_engine._synthesis_impl.call_args[0][0].accent_phrases
-
-        self.assertEqual(
-            expected,
-            actual,
-            "case(text:" + text + ")",
-        )
+        inputs = self.synthesis_engine.create_accent_phrases(text, 1)
+        outputs = apply_interrogative_upspeak(inputs, enable_interrogative_upspeak)
+        self.assertEqual(expected, outputs, f"case(text:{text})")
 
     def test_create_accent_phrases(self):
         """accent_phrasesの作成時では疑問文モーラ処理を行わない

--- a/test/test_synthesis_engine_base.py
+++ b/test/test_synthesis_engine_base.py
@@ -193,14 +193,6 @@ class TestTTSEngineBase(TestCase):
         )
         self.synthesis_engine._synthesis_impl = Mock()
 
-    def create_accent_phrases_test_base(self, text: str, expected: List[AccentPhrase]):
-        actual = self.synthesis_engine.create_accent_phrases(text, 1)
-        self.assertEqual(
-            expected,
-            actual,
-            "case(text:" + text + ")",
-        )
-
     def create_synthesis_test_base(
         self,
         text: str,
@@ -218,9 +210,11 @@ class TestTTSEngineBase(TestCase):
         """accent_phrasesの作成時では疑問文モーラ処理を行わない
         (https://github.com/VOICEVOX/voicevox_engine/issues/272#issuecomment-1022610866)
         """
+        text = "これはありますか？"
         expected = koreha_arimasuka_base_expected()
         expected[-1].is_interrogative = True
-        self.create_accent_phrases_test_base(text="これはありますか？", expected=expected)
+        actual = self.synthesis_engine.create_accent_phrases(text, 1)
+        self.assertEqual(expected, actual, f"case(text:{text})")
 
     def test_synthesis_interrogative(self):
         expected = koreha_arimasuka_base_expected()


### PR DESCRIPTION
## 内容
疑問文 upspeak テストの簡略化と分割によるリファクタリング

疑問文 upspeak のテストを「`.synthesis()` + `._synthesis_impl()` hook」 から「`apply_interrogative_upspeak()`」へ簡略化した。  
また 1 つのテストに10個以上のテスト（assert）が詰められていたため、これを分割した。  

## 関連 Issue
part of #897

## Reviewer 向け情報
「`apply_interrogative_upspeak()` への切り替え」「ネストの解消」「テストの分割」をまとめているため、diff が多少見辛いです。  
1段階 1commit に log を整理してあるため、review の際にご利用ください。  