### PR TITLE
追加: コア Mock

### DIFF
--- a/build_util/make_docs.py
+++ b/build_util/make_docs.py
@@ -1,7 +1,7 @@
 import json
 from pathlib import Path
 
-from voicevox_engine.dev.core import mock as core
+from voicevox_engine.dev.core import MockCore
 from voicevox_engine.dev.synthesis_engine.mock import MockTTSEngine
 from voicevox_engine.preset import PresetManager
 from voicevox_engine.setting import USER_SETTING_PATH, SettingLoader
@@ -37,7 +37,7 @@ if __name__ == "__main__":
 
     # FastAPI の機能を用いて OpenAPI schema を生成する
     app = run.generate_app(
-        synthesis_engines={"mock": MockTTSEngine(speakers=core.metas())},
+        synthesis_engines={"mock": MockTTSEngine(MockCore())},
         latest_core_version="mock",
         setting_loader=SettingLoader(USER_SETTING_PATH),
         preset_manager=PresetManager(  # FIXME: impl MockPresetManager

--- a/build_util/make_docs.py
+++ b/build_util/make_docs.py
@@ -1,7 +1,7 @@
 import json
 from pathlib import Path
 
-from voicevox_engine.dev.core import MockCore
+from voicevox_engine.dev.core import MockCoreWrapper
 from voicevox_engine.dev.synthesis_engine.mock import MockTTSEngine
 from voicevox_engine.preset import PresetManager
 from voicevox_engine.setting import USER_SETTING_PATH, SettingLoader
@@ -37,7 +37,7 @@ if __name__ == "__main__":
 
     # FastAPI の機能を用いて OpenAPI schema を生成する
     app = run.generate_app(
-        synthesis_engines={"mock": MockTTSEngine(MockCore())},
+        synthesis_engines={"mock": MockTTSEngine(MockCoreWrapper())},
         latest_core_version="mock",
         setting_loader=SettingLoader(USER_SETTING_PATH),
         preset_manager=PresetManager(  # FIXME: impl MockPresetManager

--- a/test/test_mock_synthesis_engine.py
+++ b/test/test_mock_synthesis_engine.py
@@ -1,5 +1,6 @@
 from unittest import TestCase
 
+from voicevox_engine.dev.core import MockCore
 from voicevox_engine.dev.synthesis_engine import MockTTSEngine
 from voicevox_engine.model import AccentPhrase, AudioQuery, Mora
 from voicevox_engine.tts_pipeline.kana_parser import create_kana
@@ -102,7 +103,7 @@ class TestMockTTSEngine(TestCase):
                 pause_mora=None,
             ),
         ]
-        self.engine = MockTTSEngine(speakers="", supported_devices="")
+        self.engine = MockTTSEngine(MockCore())
 
     def test_replace_phoneme_length(self):
         self.assertEqual(

--- a/test/test_mock_synthesis_engine.py
+++ b/test/test_mock_synthesis_engine.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from voicevox_engine.dev.core import MockCore
+from voicevox_engine.dev.core import MockCoreWrapper
 from voicevox_engine.dev.synthesis_engine import MockTTSEngine
 from voicevox_engine.model import AccentPhrase, AudioQuery, Mora
 from voicevox_engine.tts_pipeline.kana_parser import create_kana
@@ -103,7 +103,7 @@ class TestMockTTSEngine(TestCase):
                 pause_mora=None,
             ),
         ]
-        self.engine = MockTTSEngine(MockCore())
+        self.engine = MockTTSEngine(MockCoreWrapper())
 
     def test_replace_phoneme_length(self):
         self.assertEqual(

--- a/voicevox_engine/dev/core/__init__.py
+++ b/voicevox_engine/dev/core/__init__.py
@@ -1,3 +1,3 @@
-from .mock import MockCore
+from .mock import MockCoreWrapper
 
-__all__ = ["MockCore"]
+__all__ = ["MockCoreWrapper"]

--- a/voicevox_engine/dev/core/__init__.py
+++ b/voicevox_engine/dev/core/__init__.py
@@ -1,17 +1,3 @@
-from .mock import (
-    decode_forward,
-    initialize,
-    metas,
-    supported_devices,
-    yukarin_s_forward,
-    yukarin_sa_forward,
-)
+from .mock import MockCore
 
-__all__ = [
-    "decode_forward",
-    "initialize",
-    "yukarin_s_forward",
-    "yukarin_sa_forward",
-    "metas",
-    "supported_devices",
-]
+__all__ = ["MockCore"]

--- a/voicevox_engine/dev/core/mock.py
+++ b/voicevox_engine/dev/core/mock.py
@@ -1,118 +1,86 @@
 import json
-from logging import getLogger
-from typing import Any, Dict, List
+from pathlib import Path
+from unittest.mock import Mock
 
-import numpy as np
-from pyopenjtalk import tts
-from soxr import resample
-
-DUMMY_TEXT = "これはダミーのテキストです"
+from ...core_wrapper import CoreWrapper
 
 
-def initialize(path: str, use_gpu: bool, *args: List[Any]) -> None:
-    pass
+class MockCore(CoreWrapper):
+    """`CoreWrapper` Mock"""
 
+    def __init__(
+        self,
+        use_gpu: bool = False,
+        core_dir: Path | None = None,
+        cpu_num_threads: int = 0,
+        load_all_models: bool = False,
+    ) -> None:
+        self.default_sampling_rate = 24000
 
-def yukarin_s_forward(length: int, **kwargs: Dict[str, Any]) -> np.ndarray:
-    logger = getLogger("uvicorn")  # FastAPI / Uvicorn 内からの利用のため
-    logger.info(
-        "Sorry, yukarin_s_forward() is a mock. Return values are incorrect.",
-    )
-    return np.ones(length) / 5
+        self.yukarin_s_forward = Mock()
+        self.yukarin_sa_forward = Mock()
+        self.decode_forward = Mock()
 
+    def metas(self) -> str:
+        return json.dumps(
+            [
+                {
+                    "name": "dummy1",
+                    "styles": [
+                        {"name": "style0", "id": 0},
+                        {"name": "style1", "id": 2},
+                        {"name": "style2", "id": 4},
+                        {"name": "style3", "id": 6},
+                    ],
+                    "speaker_uuid": "7ffcb7ce-00ec-4bdc-82cd-45a8889e43ff",
+                    "version": "mock",
+                },
+                {
+                    "name": "dummy2",
+                    "styles": [
+                        {"name": "style0", "id": 1},
+                        {"name": "style1", "id": 3},
+                        {"name": "style2", "id": 5},
+                        {"name": "style3", "id": 7},
+                    ],
+                    "speaker_uuid": "388f246b-8c41-4ac1-8e2d-5d79f3ff56d9",
+                    "version": "mock",
+                },
+                {
+                    "name": "dummy3",
+                    "styles": [
+                        {"name": "style0", "id": 8},
+                    ],
+                    "speaker_uuid": "35b2c544-660e-401e-b503-0e14c635303a",
+                    "version": "mock",
+                },
+                {
+                    "name": "dummy4",
+                    "styles": [
+                        {"name": "style0", "id": 9},
+                    ],
+                    "speaker_uuid": "b1a81618-b27b-40d2-b0ea-27a9ad408c4b",
+                    "version": "mock",
+                },
+            ]
+        )
 
-def yukarin_sa_forward(length: int, **kwargs: Dict[str, Any]) -> np.ndarray:
-    logger = getLogger("uvicorn")  # FastAPI / Uvicorn 内からの利用のため
-    logger.info(
-        "Sorry, yukarin_sa_forward() is a mock. Return values are incorrect.",
-    )
-    return np.ones((1, length)) * 5
-
-
-def decode_forward(length: int, **kwargs: Dict[str, Any]) -> np.ndarray:
-    """
-    合成音声の波形データをNumPy配列で返します。ただし、常に固定の文言を読み上げます（DUMMY_TEXT）
-    参照→TTSEngine のdocstring [Mock]
-
-    Parameters
-    ----------
-    length : int
-        フレームの長さ
-
-    Returns
-    -------
-    wave : np.ndarray
-        音声合成した波形データ
-
-    Note
-    -------
-        ここで行う音声合成では、調声（ピッチ等）を反映しない
-        また、入力内容によらず常に固定の文言を読み上げる
-
-        # pyopenjtalk.tts()の出力仕様
-        dtype=np.float64, 16 bit, mono 48000 Hz
-
-        # resampleの説明
-        非モックdecode_forwardと合わせるために、出力を24kHzに変換した。
-    """
-    logger = getLogger("uvicorn")  # FastAPI / Uvicorn 内からの利用のため
-    logger.info(
-        "Sorry, decode_forward() is a mock. Return values are incorrect.",
-    )
-    wave, sr = tts(DUMMY_TEXT)
-    wave = resample(wave.astype("int16"), 48000, 24000)
-    return wave
-
-
-def metas() -> str:
-    return json.dumps(
-        [
+    def supported_devices(self):
+        return json.dumps(
             {
-                "name": "dummy1",
-                "styles": [
-                    {"name": "style0", "id": 0},
-                    {"name": "style1", "id": 2},
-                    {"name": "style2", "id": 4},
-                    {"name": "style3", "id": 6},
-                ],
-                "speaker_uuid": "7ffcb7ce-00ec-4bdc-82cd-45a8889e43ff",
-                "version": "mock",
-            },
-            {
-                "name": "dummy2",
-                "styles": [
-                    {"name": "style0", "id": 1},
-                    {"name": "style1", "id": 3},
-                    {"name": "style2", "id": 5},
-                    {"name": "style3", "id": 7},
-                ],
-                "speaker_uuid": "388f246b-8c41-4ac1-8e2d-5d79f3ff56d9",
-                "version": "mock",
-            },
-            {
-                "name": "dummy3",
-                "styles": [
-                    {"name": "style0", "id": 8},
-                ],
-                "speaker_uuid": "35b2c544-660e-401e-b503-0e14c635303a",
-                "version": "mock",
-            },
-            {
-                "name": "dummy4",
-                "styles": [
-                    {"name": "style0", "id": 9},
-                ],
-                "speaker_uuid": "b1a81618-b27b-40d2-b0ea-27a9ad408c4b",
-                "version": "mock",
-            },
-        ]
-    )
+                "cpu": True,
+                "cuda": False,
+            }
+        )
 
+    def finalize(self) -> None:
+        pass
 
-def supported_devices() -> str:
-    return json.dumps(
-        {
-            "cpu": True,
-            "cuda": False,
-        }
-    )
+    def load_model(self, style_id: int) -> None:
+        pass
+
+    def is_model_loaded(self, style_id: int) -> bool:
+        return True
+
+    def assert_core_success(self, result: bool) -> None:
+        pass

--- a/voicevox_engine/dev/core/mock.py
+++ b/voicevox_engine/dev/core/mock.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock
 from ...core_wrapper import CoreWrapper
 
 
-class MockCore(CoreWrapper):
+class MockCoreWrapper(CoreWrapper):
     """`CoreWrapper` Mock"""
 
     def __init__(

--- a/voicevox_engine/dev/synthesis_engine/mock.py
+++ b/voicevox_engine/dev/synthesis_engine/mock.py
@@ -1,13 +1,14 @@
 from logging import getLogger
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 import numpy as np
 from pyopenjtalk import tts
 from soxr import resample
 
+from ...core_wrapper import CoreWrapper
 from ...model import AccentPhrase, AudioQuery
 from ...tts_pipeline import TTSEngineBase
-from ...tts_pipeline.tts_engine import to_flatten_moras
+from ...tts_pipeline.tts_engine import CoreAdapter, to_flatten_moras
 
 
 class MockTTSEngine(TTSEngineBase):
@@ -15,30 +16,28 @@ class MockTTSEngine(TTSEngineBase):
     TTSEngine [Mock]
     """
 
-    def __init__(
-        self,
-        speakers: str,
-        supported_devices: Optional[str] = None,
-    ):
-        """
-        __init__ [Mock]
-        """
+    def __init__(self, core: CoreWrapper):
         super().__init__()
-
-        self._speakers = speakers
-        self._supported_devices = supported_devices
+        self.core = CoreAdapter(core)
+        # NOTE: self.coreは将来的に消す予定
 
     @property
     def default_sampling_rate(self) -> int:
-        return 24000
+        return self.core.default_sampling_rate
 
     @property
     def speakers(self) -> str:
-        return self._speakers
+        return self.core.speakers
 
     @property
-    def supported_devices(self) -> Optional[str]:
-        return self._supported_devices
+    def supported_devices(self) -> str | None:
+        return self.core.supported_devices
+
+    def initialize_style_id_synthesis(self, style_id: int, skip_reinit: bool):
+        return self.core.initialize_style_id_synthesis(style_id, skip_reinit)
+
+    def is_initialized_style_id_synthesis(self, style_id: int) -> bool:
+        return self.core.is_initialized_style_id_synthesis(style_id)
 
     def replace_phoneme_length(
         self, accent_phrases: List[AccentPhrase], style_id: int

--- a/voicevox_engine/tts_pipeline/make_tts_engines.py
+++ b/voicevox_engine/tts_pipeline/make_tts_engines.py
@@ -127,14 +127,11 @@ def make_synthesis_engines(
 
     else:
         # モック追加
-        from ..dev.core import metas as mock_metas
-        from ..dev.core import supported_devices as mock_supported_devices
+        from ..dev.core import MockCore
         from ..dev.synthesis_engine import MockTTSEngine
 
         if "0.0.0" not in synthesis_engines:
             print("Info: Loading mock.")
-            synthesis_engines["0.0.0"] = MockTTSEngine(
-                speakers=mock_metas(), supported_devices=mock_supported_devices()
-            )
+            synthesis_engines["0.0.0"] = MockTTSEngine(MockCore())
 
     return synthesis_engines

--- a/voicevox_engine/tts_pipeline/make_tts_engines.py
+++ b/voicevox_engine/tts_pipeline/make_tts_engines.py
@@ -127,11 +127,11 @@ def make_synthesis_engines(
 
     else:
         # モック追加
-        from ..dev.core import MockCore
+        from ..dev.core import MockCoreWrapper
         from ..dev.synthesis_engine import MockTTSEngine
 
         if "0.0.0" not in synthesis_engines:
             print("Info: Loading mock.")
-            synthesis_engines["0.0.0"] = MockTTSEngine(MockCore())
+            synthesis_engines["0.0.0"] = MockTTSEngine(MockCoreWrapper())
 
     return synthesis_engines


### PR DESCRIPTION
## 内容
概要: `MockCoreWrapper` の追加

製品版コアを使わずにテスト・docsビルドを行うために、現在の VOICEVOX ENGINEは `MockTTSEngine` モックを定義している。  
`MockTTSEngine` は `TTSEngine` とは異なり、`CoreWrapper` インスタンスでなくplaceholder値を受け取る設計になっている。  

https://github.com/VOICEVOX/voicevox_engine/blob/68a439d979a0b9186bfa9009dece3309ad956696/voicevox_engine/tts_pipeline/tts_engine.py#L352-L355

https://github.com/VOICEVOX/voicevox_engine/blob/68a439d979a0b9186bfa9009dece3309ad956696/voicevox_engine/dev/synthesis_engine/mock.py#L13-L22

コード理解と改変にあたり、`MockTTSEngine` と `TTSEngine` は共通度が高いことが望ましい。  
現に `TTSEngine` 分割リファクタリング (#871) の中で、このモック設計が阻害因子となっている。  
最も単純な方法は `CoreWrapper` モックを定義し、`TTSEngine` 同様に利用する方式である。  

このような背景から、`MockCoreWrapper` の導入を提案します。  

また導入過程で `voicevox_engine.dev.core.mock` に大量の dead code が見つかったため、これらを削除するリファクタリングを同時におこなった。  

## 関連 Issue
ref #871