### PR TITLE
整理: コア機能アクセスの分離

### DIFF
--- a/run.py
+++ b/run.py
@@ -1173,7 +1173,7 @@ def generate_app(
     def supported_devices(
         core_version: str | None = None,
     ) -> Response:
-        supported_devices = get_engine(core_version).supported_devices
+        supported_devices = get_core(core_version).supported_devices
         if supported_devices is None:
             raise HTTPException(status_code=422, detail="非対応の機能です。")
         return Response(

--- a/run.py
+++ b/run.py
@@ -973,8 +973,7 @@ def generate_app(
         指定されたstyle_idのスタイルを初期化します。
         実行しなくても他のAPIは使用できますが、初回実行時に時間がかかることがあります。
         """
-        engine = get_engine(core_version)
-        engine.initialize_style_id_synthesis(style_id=style_id, skip_reinit=skip_reinit)
+        get_core(core_version).initialize_style_id_synthesis(style_id=style_id, skip_reinit=skip_reinit)
         return Response(status_code=204)
 
     @app.get("/is_initialized_style_id", response_model=bool, tags=["その他"])

--- a/run.py
+++ b/run.py
@@ -984,8 +984,7 @@ def generate_app(
         """
         指定されたstyle_idのスタイルが初期化されているかどうかを返します。
         """
-        engine = get_engine(core_version)
-        return engine.is_initialized_style_id_synthesis(style_id)
+        return get_core(core_version).is_initialized_style_id_synthesis(style_id)
 
     @app.post("/initialize_speaker", status_code=204, tags=["その他"], deprecated=True)
     def initialize_speaker(

--- a/run.py
+++ b/run.py
@@ -65,7 +65,11 @@ from voicevox_engine.setting import (
     Setting,
     SettingLoader,
 )
-from voicevox_engine.tts_pipeline import TTSEngineBase, make_synthesis_engines, CoreAdapter
+from voicevox_engine.tts_pipeline import (
+    CoreAdapter,
+    TTSEngineBase,
+    make_synthesis_engines,
+)
 from voicevox_engine.tts_pipeline.kana_parser import create_kana, parse_kana
 from voicevox_engine.user_dict import (
     apply_word,

--- a/run.py
+++ b/run.py
@@ -566,10 +566,10 @@ def generate_app(
         プロパティが存在しない場合は、モーフィングが許可されているとみなします。
         返り値の話者はstring型なので注意。
         """
-        engine = get_engine(core_version)
+        core = get_core(core_version)
 
         try:
-            speakers = metas_store.load_combined_metas(engine=engine)
+            speakers = metas_store.load_combined_metas(core=core)
             morphable_targets = get_morphable_targets(
                 speakers=speakers, base_speakers=base_speakers
             )
@@ -611,7 +611,7 @@ def generate_app(
         core = get_core(core_version)
 
         try:
-            speakers = metas_store.load_combined_metas(engine=engine)
+            speakers = metas_store.load_combined_metas(core=core)
             speaker_lookup = construct_lookup(speakers=speakers)
             is_permitted = is_synthesis_morphing_permitted(
                 speaker_lookup, base_speaker, target_speaker
@@ -784,8 +784,7 @@ def generate_app(
     def speakers(
         core_version: str | None = None,
     ) -> list[Speaker]:
-        engine = get_engine(core_version)
-        return metas_store.load_combined_metas(engine=engine)
+        return metas_store.load_combined_metas(get_core(core_version))
 
     @app.get("/speaker_info", response_model=SpeakerInfo, tags=["その他"])
     def speaker_info(
@@ -825,7 +824,7 @@ def generate_app(
         #           ...
 
         # 該当話者の検索
-        speakers = json.loads(get_engine(core_version).speakers)
+        speakers = json.loads(get_core(core_version).speakers)
         for i in range(len(speakers)):
             if speakers[i]["speaker_uuid"] == speaker_uuid:
                 speaker = speakers[i]

--- a/run.py
+++ b/run.py
@@ -973,7 +973,8 @@ def generate_app(
         指定されたstyle_idのスタイルを初期化します。
         実行しなくても他のAPIは使用できますが、初回実行時に時間がかかることがあります。
         """
-        get_core(core_version).initialize_style_id_synthesis(style_id=style_id, skip_reinit=skip_reinit)
+        core = get_core(core_version)
+        core.initialize_style_id_synthesis(style_id=style_id, skip_reinit=skip_reinit)
         return Response(status_code=204)
 
     @app.get("/is_initialized_style_id", response_model=bool, tags=["その他"])

--- a/voicevox_engine/dev/synthesis_engine/mock.py
+++ b/voicevox_engine/dev/synthesis_engine/mock.py
@@ -25,10 +25,6 @@ class MockTTSEngine(TTSEngineBase):
     def speakers(self) -> str:
         return self.core.speakers
 
-    @property
-    def supported_devices(self) -> str | None:
-        return self.core.supported_devices
-
     def initialize_style_id_synthesis(self, style_id: int, skip_reinit: bool):
         return self.core.initialize_style_id_synthesis(style_id, skip_reinit)
 

--- a/voicevox_engine/dev/synthesis_engine/mock.py
+++ b/voicevox_engine/dev/synthesis_engine/mock.py
@@ -21,9 +21,6 @@ class MockTTSEngine(TTSEngineBase):
         self.core = CoreAdapter(core)
         # NOTE: self.coreは将来的に消す予定
 
-    def initialize_style_id_synthesis(self, style_id: int, skip_reinit: bool):
-        return self.core.initialize_style_id_synthesis(style_id, skip_reinit)
-
     def is_initialized_style_id_synthesis(self, style_id: int) -> bool:
         return self.core.is_initialized_style_id_synthesis(style_id)
 

--- a/voicevox_engine/dev/synthesis_engine/mock.py
+++ b/voicevox_engine/dev/synthesis_engine/mock.py
@@ -22,10 +22,6 @@ class MockTTSEngine(TTSEngineBase):
         # NOTE: self.coreは将来的に消す予定
 
     @property
-    def default_sampling_rate(self) -> int:
-        return self.core.default_sampling_rate
-
-    @property
     def speakers(self) -> str:
         return self.core.speakers
 

--- a/voicevox_engine/dev/synthesis_engine/mock.py
+++ b/voicevox_engine/dev/synthesis_engine/mock.py
@@ -21,9 +21,6 @@ class MockTTSEngine(TTSEngineBase):
         self.core = CoreAdapter(core)
         # NOTE: self.coreは将来的に消す予定
 
-    def is_initialized_style_id_synthesis(self, style_id: int) -> bool:
-        return self.core.is_initialized_style_id_synthesis(style_id)
-
     def replace_phoneme_length(
         self, accent_phrases: List[AccentPhrase], style_id: int
     ) -> List[AccentPhrase]:

--- a/voicevox_engine/dev/synthesis_engine/mock.py
+++ b/voicevox_engine/dev/synthesis_engine/mock.py
@@ -21,10 +21,6 @@ class MockTTSEngine(TTSEngineBase):
         self.core = CoreAdapter(core)
         # NOTE: self.coreは将来的に消す予定
 
-    @property
-    def speakers(self) -> str:
-        return self.core.speakers
-
     def initialize_style_id_synthesis(self, style_id: int, skip_reinit: bool):
         return self.core.initialize_style_id_synthesis(style_id, skip_reinit)
 

--- a/voicevox_engine/metas/MetasStore.py
+++ b/voicevox_engine/metas/MetasStore.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Dict, List, Tuple
 from voicevox_engine.metas.Metas import CoreSpeaker, EngineSpeaker, Speaker, StyleInfo
 
 if TYPE_CHECKING:
-    from voicevox_engine.tts_pipeline.tts_engine_base import TTSEngineBase
+    from voicevox_engine.tts_pipeline.tts_engine import CoreAdapter
 
 
 class MetasStore:
@@ -30,20 +30,20 @@ class MetasStore:
 
     # FIXME: engineではなくList[CoreSpeaker]を渡す形にすることで
     # TTSEngineBaseによる循環importを修正する
-    def load_combined_metas(self, engine: "TTSEngineBase") -> List[Speaker]:
+    def load_combined_metas(self, core: "CoreAdapter") -> List[Speaker]:
         """
         コアに含まれる話者メタ情報とエンジンに含まれる話者メタ情報を統合
         Parameters
         ----------
-        engine : TTSEngineBase
-            コアに含まれる話者メタ情報をもったエンジン
+        core : CoreAdapter
+            話者メタ情報をもったコア
         Returns
         -------
         ret : List[Speaker]
             エンジンとコアに含まれる話者メタ情報
         """
         # コアに含まれる話者メタ情報の収集
-        core_metas = [CoreSpeaker(**speaker) for speaker in json.loads(engine.speakers)]
+        core_metas = [CoreSpeaker(**speaker) for speaker in json.loads(core.speakers)]
         # エンジンに含まれる話者メタ情報との統合
         return [
             Speaker(

--- a/voicevox_engine/morphing.py
+++ b/voicevox_engine/morphing.py
@@ -10,7 +10,7 @@ from soxr import resample
 from .metas.Metas import Speaker, SpeakerSupportPermittedSynthesisMorphing, StyleInfo
 from .metas.MetasStore import construct_lookup
 from .model import AudioQuery, MorphableTargetInfo, StyleIdNotFoundError
-from .tts_pipeline import TTSEngine, CoreAdapter
+from .tts_pipeline import CoreAdapter, TTSEngine
 
 
 # FIXME: ndarray type hint, https://github.com/JeremyCCHsu/Python-Wrapper-for-World-Vocoder/blob/2b64f86197573497c685c785c6e0e743f407b63e/pyworld/pyworld.pyx#L398  # noqa

--- a/voicevox_engine/morphing.py
+++ b/voicevox_engine/morphing.py
@@ -10,7 +10,7 @@ from soxr import resample
 from .metas.Metas import Speaker, SpeakerSupportPermittedSynthesisMorphing, StyleInfo
 from .metas.MetasStore import construct_lookup
 from .model import AudioQuery, MorphableTargetInfo, StyleIdNotFoundError
-from .tts_pipeline import TTSEngine
+from .tts_pipeline import TTSEngine, CoreAdapter
 
 
 # FIXME: ndarray type hint, https://github.com/JeremyCCHsu/Python-Wrapper-for-World-Vocoder/blob/2b64f86197573497c685c785c6e0e743f407b63e/pyworld/pyworld.pyx#L398  # noqa
@@ -129,6 +129,7 @@ def is_synthesis_morphing_permitted(
 
 def synthesis_morphing_parameter(
     engine: TTSEngine,
+    core: CoreAdapter,
     query: AudioQuery,
     base_speaker: int,
     target_speaker: int,
@@ -136,7 +137,7 @@ def synthesis_morphing_parameter(
     query = deepcopy(query)
 
     # 不具合回避のためデフォルトのサンプリングレートでWORLDに掛けた後に指定のサンプリングレートに変換する
-    query.outputSamplingRate = engine.default_sampling_rate
+    query.outputSamplingRate = core.default_sampling_rate
 
     # WORLDに掛けるため合成はモノラルで行う
     query.outputStereo = False

--- a/voicevox_engine/tts_pipeline/__init__.py
+++ b/voicevox_engine/tts_pipeline/__init__.py
@@ -1,10 +1,11 @@
 from ..core_wrapper import CoreWrapper, load_runtime_lib
 from .make_tts_engines import make_synthesis_engines
-from .tts_engine import TTSEngine
+from .tts_engine import TTSEngine, CoreAdapter
 from .tts_engine_base import TTSEngineBase
 
 __all__ = [
     "CoreWrapper",
+    "CoreAdapter",
     "load_runtime_lib",
     "make_synthesis_engines",
     "TTSEngine",

--- a/voicevox_engine/tts_pipeline/__init__.py
+++ b/voicevox_engine/tts_pipeline/__init__.py
@@ -1,6 +1,6 @@
 from ..core_wrapper import CoreWrapper, load_runtime_lib
 from .make_tts_engines import make_synthesis_engines
-from .tts_engine import TTSEngine, CoreAdapter
+from .tts_engine import CoreAdapter, TTSEngine
 from .tts_engine_base import TTSEngineBase
 
 __all__ = [

--- a/voicevox_engine/tts_pipeline/tts_engine.py
+++ b/voicevox_engine/tts_pipeline/tts_engine.py
@@ -260,7 +260,7 @@ class CoreAdapter:
             pass  # コアが古い場合はどうしようもないので何もしない
 
     def is_initialized_style_id_synthesis(self, style_id: int) -> bool:
-        # Coreプロキシ
+        """指定したスタイルでの音声合成が初期化されているかどうかを返す"""
         try:
             return self.core.is_model_loaded(style_id)
         except OldCoreError:
@@ -326,9 +326,6 @@ class TTSEngine(TTSEngineBase):
         super().__init__()
         self.core = CoreAdapter(core)
         # NOTE: self.coreは将来的に消す予定
-
-    def is_initialized_style_id_synthesis(self, style_id: int) -> bool:
-        return self.core.is_initialized_style_id_synthesis(style_id)
 
     def replace_phoneme_length(
         self, accent_phrases: list[AccentPhrase], style_id: int

--- a/voicevox_engine/tts_pipeline/tts_engine.py
+++ b/voicevox_engine/tts_pipeline/tts_engine.py
@@ -324,10 +324,6 @@ class TTSEngine(TTSEngineBase):
     def speakers(self) -> str:
         return self.core.speakers
 
-    @property
-    def supported_devices(self) -> str | None:
-        return self.core.supported_devices
-
     def initialize_style_id_synthesis(self, style_id: int, skip_reinit: bool):
         return self.core.initialize_style_id_synthesis(style_id, skip_reinit)
 

--- a/voicevox_engine/tts_pipeline/tts_engine.py
+++ b/voicevox_engine/tts_pipeline/tts_engine.py
@@ -321,10 +321,6 @@ class TTSEngine(TTSEngineBase):
         # NOTE: self.coreは将来的に消す予定
 
     @property
-    def default_sampling_rate(self) -> int:
-        return self.core.default_sampling_rate
-
-    @property
     def speakers(self) -> str:
         return self.core.speakers
 

--- a/voicevox_engine/tts_pipeline/tts_engine.py
+++ b/voicevox_engine/tts_pipeline/tts_engine.py
@@ -320,10 +320,6 @@ class TTSEngine(TTSEngineBase):
         self.core = CoreAdapter(core)
         # NOTE: self.coreは将来的に消す予定
 
-    @property
-    def speakers(self) -> str:
-        return self.core.speakers
-
     def initialize_style_id_synthesis(self, style_id: int, skip_reinit: bool):
         return self.core.initialize_style_id_synthesis(style_id, skip_reinit)
 

--- a/voicevox_engine/tts_pipeline/tts_engine.py
+++ b/voicevox_engine/tts_pipeline/tts_engine.py
@@ -227,13 +227,11 @@ class CoreAdapter:
     @property
     def speakers(self) -> str:
         """話者情報（json文字列）"""
-        # Coreプロキシ
         return self.core.metas()
 
     @property
     def supported_devices(self) -> str | None:
-        """デバイスサポート情報"""
-        # Coreプロキシ
+        """デバイスサポート情報（None: 情報無し）"""
         try:
             supported_devices = self.core.supported_devices()
         except OldCoreError:
@@ -241,7 +239,16 @@ class CoreAdapter:
         return supported_devices
 
     def initialize_style_id_synthesis(self, style_id: int, skip_reinit: bool):
-        # Core管理
+        """
+        指定したスタイルでの音声合成を初期化する。
+        何度も実行可能。未実装の場合は何もしない。
+        Parameters
+        ----------
+        style_id : int
+            スタイルID
+        skip_reinit : bool
+            True の場合, 既に初期化済みの話者の再初期化をスキップします
+        """
         try:
             with self.mutex:
                 # 以下の条件のいずれかを満たす場合, 初期化を実行する
@@ -319,9 +326,6 @@ class TTSEngine(TTSEngineBase):
         super().__init__()
         self.core = CoreAdapter(core)
         # NOTE: self.coreは将来的に消す予定
-
-    def initialize_style_id_synthesis(self, style_id: int, skip_reinit: bool):
-        return self.core.initialize_style_id_synthesis(style_id, skip_reinit)
 
     def is_initialized_style_id_synthesis(self, style_id: int) -> bool:
         return self.core.is_initialized_style_id_synthesis(style_id)

--- a/voicevox_engine/tts_pipeline/tts_engine_base.py
+++ b/voicevox_engine/tts_pipeline/tts_engine_base.py
@@ -44,11 +44,6 @@ def apply_interrogative_upspeak(
 class TTSEngineBase(metaclass=ABCMeta):
     @property
     @abstractmethod
-    def default_sampling_rate(self) -> int:
-        raise NotImplementedError
-
-    @property
-    @abstractmethod
     def speakers(self) -> str:
         """話者情報（json文字列）"""
         # FIXME: jsonではなくModelを返すようにする

--- a/voicevox_engine/tts_pipeline/tts_engine_base.py
+++ b/voicevox_engine/tts_pipeline/tts_engine_base.py
@@ -42,13 +42,6 @@ def apply_interrogative_upspeak(
 
 
 class TTSEngineBase(metaclass=ABCMeta):
-    @property
-    @abstractmethod
-    def speakers(self) -> str:
-        """話者情報（json文字列）"""
-        # FIXME: jsonではなくModelを返すようにする
-        raise NotImplementedError
-
     def initialize_style_id_synthesis(  # noqa: B027
         self, style_id: int, skip_reinit: bool
     ):

--- a/voicevox_engine/tts_pipeline/tts_engine_base.py
+++ b/voicevox_engine/tts_pipeline/tts_engine_base.py
@@ -42,21 +42,6 @@ def apply_interrogative_upspeak(
 
 
 class TTSEngineBase(metaclass=ABCMeta):
-    def initialize_style_id_synthesis(  # noqa: B027
-        self, style_id: int, skip_reinit: bool
-    ):
-        """
-        指定したスタイルでの音声合成を初期化する。
-        何度も実行可能。未実装の場合は何もしない。
-        Parameters
-        ----------
-        style_id : int
-            スタイルID
-        skip_reinit : bool
-            True の場合, 既に初期化済みの話者の再初期化をスキップします
-        """
-        pass
-
     def is_initialized_style_id_synthesis(self, style_id: int) -> bool:
         """
         指定したスタイルでの音声合成が初期化されているかどうかを返す

--- a/voicevox_engine/tts_pipeline/tts_engine_base.py
+++ b/voicevox_engine/tts_pipeline/tts_engine_base.py
@@ -49,17 +49,6 @@ class TTSEngineBase(metaclass=ABCMeta):
         # FIXME: jsonではなくModelを返すようにする
         raise NotImplementedError
 
-    @property
-    @abstractmethod
-    def supported_devices(self) -> Optional[str]:
-        """
-        デバイス対応情報
-        Returns
-        -------
-            対応デバイス一覧（None: 情報取得不可）
-        """
-        raise NotImplementedError
-
     def initialize_style_id_synthesis(  # noqa: B027
         self, style_id: int, skip_reinit: bool
     ):

--- a/voicevox_engine/tts_pipeline/tts_engine_base.py
+++ b/voicevox_engine/tts_pipeline/tts_engine_base.py
@@ -42,20 +42,6 @@ def apply_interrogative_upspeak(
 
 
 class TTSEngineBase(metaclass=ABCMeta):
-    def is_initialized_style_id_synthesis(self, style_id: int) -> bool:
-        """
-        指定したスタイルでの音声合成が初期化されているかどうかを返す
-        Parameters
-        ----------
-        style_id : int
-            スタイルID
-        Returns
-        -------
-        bool
-            初期化されているかどうか
-        """
-        return True
-
     @abstractmethod
     def replace_phoneme_length(
         self, accent_phrases: List[AccentPhrase], style_id: int

--- a/voicevox_engine/tts_pipeline/tts_engine_base.py
+++ b/voicevox_engine/tts_pipeline/tts_engine_base.py
@@ -1,6 +1,6 @@
 import copy
 from abc import ABCMeta, abstractmethod
-from typing import List, Optional
+from typing import List
 
 import numpy as np
 


### PR DESCRIPTION
## 内容
コア機能アクセスの分離によるリファクタリング  

従来 `TTSEngineBase` を経由し `CoreAdapter` を叩いて利用していたコアを、`CoreAdapter` を直接叩いて利用するようにリファクタリングした。  
変更概略は以下：  

- `get_engine()` に相当する `get_core()` を導入
- 5つのラッパーメソッドを廃止
- `MetasStore.load_combined_metas()` の引数を engine から core へ変更
- `synthesis_morphing_parameter()` 引数に core を追加

## 関連 Issue
step2 and 3 of #871