### PR TITLE
整理: `._synthesis_impl()` の廃止

### DIFF
--- a/test/test_synthesis_engine_base.py
+++ b/test/test_synthesis_engine_base.py
@@ -188,10 +188,7 @@ class MockCore:
 class TestTTSEngineBase(TestCase):
     def setUp(self):
         super().setUp()
-        self.synthesis_engine = TTSEngine(
-            core=MockCore(),
-        )
-        self.synthesis_engine._synthesis_impl = Mock()
+        self.synthesis_engine = TTSEngine(core=MockCore())
 
     def create_synthesis_test_base(
         self,

--- a/voicevox_engine/dev/synthesis_engine/mock.py
+++ b/voicevox_engine/dev/synthesis_engine/mock.py
@@ -79,22 +79,14 @@ class MockTTSEngine(TTSEngineBase):
         """
         return accent_phrases
 
-    def _synthesis_impl(self, query: AudioQuery, style_id: int) -> np.ndarray:
-        """
-        synthesis voicevox coreを使わずに、音声合成する [Mock]
+    def synthesis(
+        self,
+        query: AudioQuery,
+        style_id: int,
+        enable_interrogative_upspeak: bool = True,
+    ) -> np.ndarray:
+        """音声合成用のクエリに含まれる読み仮名に基づいてOpenJTalkで音声波形を生成する (Mock)"""
 
-        Parameters
-        ----------
-        query : AudioQuery
-            音声合成用のクエリ
-        style_id : int
-            スタイルID
-
-        Returns
-        -------
-        wave [npt.NDArray[np.int16]]
-            音声波形データをNumPy配列で返します
-        """
         # recall text in katakana
         flatten_moras = to_flatten_moras(query.accent_phrases)
         kana_text = "".join([mora.text for mora in flatten_moras])

--- a/voicevox_engine/dev/synthesis_engine/mock.py
+++ b/voicevox_engine/dev/synthesis_engine/mock.py
@@ -1,3 +1,4 @@
+import copy
 from logging import getLogger
 from typing import Any, Dict, List
 
@@ -86,6 +87,8 @@ class MockTTSEngine(TTSEngineBase):
         enable_interrogative_upspeak: bool = True,
     ) -> np.ndarray:
         """音声合成用のクエリに含まれる読み仮名に基づいてOpenJTalkで音声波形を生成する (Mock)"""
+        # モーフィング時などに同一参照のqueryで複数回呼ばれる可能性があるので、元の引数のqueryに破壊的変更を行わない
+        query = copy.deepcopy(query)
 
         # recall text in katakana
         flatten_moras = to_flatten_moras(query.accent_phrases)

--- a/voicevox_engine/tts_pipeline/tts_engine.py
+++ b/voicevox_engine/tts_pipeline/tts_engine.py
@@ -1,3 +1,4 @@
+import copy
 import math
 import threading
 from typing import List, Optional
@@ -9,7 +10,7 @@ from soxr import resample
 from ..core_wrapper import CoreWrapper, OldCoreError
 from ..model import AccentPhrase, AudioQuery, Mora
 from .acoustic_feature_extractor import Phoneme
-from .tts_engine_base import TTSEngineBase
+from .tts_engine_base import TTSEngineBase, apply_interrogative_upspeak
 
 unvoiced_mora_phoneme_list = ["A", "I", "U", "E", "O", "cl", "pau"]
 mora_phoneme_list = ["a", "i", "u", "e", "o", "N"] + unvoiced_mora_phoneme_list
@@ -506,20 +507,19 @@ class TTSEngine(TTSEngineBase):
 
         return accent_phrases
 
-    def _synthesis_impl(self, query: AudioQuery, style_id: int):
-        """
-        音声合成用のクエリから音声合成に必要な情報を構成し、実際に音声合成を行う
-        Parameters
-        ----------
-        query : AudioQuery
-            音声合成用のクエリ
-        style_id : int
-            スタイルID
-        Returns
-        -------
-        wave : numpy.ndarray
-            音声合成結果
-        """
+    def synthesis(
+        self,
+        query: AudioQuery,
+        style_id: int,
+        enable_interrogative_upspeak: bool = True,
+    ) -> ndarray:
+        """音声合成用のクエリ・スタイルID・疑問文語尾自動調整フラグに基づいて音声波形を生成する"""
+        # モーフィング時などに同一参照のqueryで複数回呼ばれる可能性があるので、元の引数のqueryに破壊的変更を行わない
+        query = copy.deepcopy(query)
+        query.accent_phrases = apply_interrogative_upspeak(
+            query.accent_phrases, enable_interrogative_upspeak
+        )
+
         phoneme, f0 = query_to_decoder_feature(query)
         raw_wave, sr_raw_wave = self.core.safe_decode_forward(phoneme, f0, style_id)
         wave = raw_wave_to_output_wave(query, raw_wave, sr_raw_wave)

--- a/voicevox_engine/tts_pipeline/tts_engine_base.py
+++ b/voicevox_engine/tts_pipeline/tts_engine_base.py
@@ -186,46 +186,5 @@ class TTSEngineBase(metaclass=ABCMeta):
         style_id: int,
         enable_interrogative_upspeak: bool = True,
     ) -> np.ndarray:
-        """
-        音声合成用のクエリ内の疑問文指定されたMoraを変形した後、
-        継承先における実装`_synthesis_impl`を使い音声合成を行う
-        Parameters
-        ----------
-        query : AudioQuery
-            音声合成用のクエリ
-        style_id : int
-            スタイルID
-        enable_interrogative_upspeak : bool
-            疑問系のテキストの語尾を自動調整する機能を有効にするか
-        Returns
-        -------
-        wave : numpy.ndarray
-            音声合成結果
-        """
-        # モーフィング時などに同一参照のqueryで複数回呼ばれる可能性があるので、元の引数のqueryに破壊的変更を行わない
-        query = copy.deepcopy(query)
-        query.accent_phrases = apply_interrogative_upspeak(
-            query.accent_phrases, enable_interrogative_upspeak
-        )
-        return self._synthesis_impl(query, style_id)
-
-    @abstractmethod
-    def _synthesis_impl(
-        self,
-        query: AudioQuery,
-        style_id: int,
-    ) -> np.ndarray:
-        """
-        音声合成用のクエリから音声合成に必要な情報を構成し、実際に音声合成を行う
-        Parameters
-        ----------
-        query : AudioQuery
-            音声合成用のクエリ
-        style_id : int
-            スタイルID
-        Returns
-        -------
-        wave : numpy.ndarray
-            音声合成結果
-        """
+        """音声合成用のクエリ・スタイルID・疑問文語尾自動調整フラグに基づいて音声波形を生成する"""
         raise NotImplementedError()


### PR DESCRIPTION
## 内容
`._synthesis_impl()` の廃止によるリファクタリング  

`.synthesis()` が共通前処理として提供していたのは以下の2機能：  

- `AudioQuery` の deepcopy
- upspeak処理

前者は `MockTTSEngine`・`TTSEngine` 両方へ移植した。  
後者の結果は `MockTTSEngine` でほぼ無視されている（ピッチを無視するので upspeak Mora が謎の長音になるだけ）ため不要と判断し、`TTSEngine` へのみ移植した。  

また `TestTTSEngineBase` に使われていない `._synthesis_impl = Mock()` が残っていたため、削除した。  

## 関連 Issue
resolve #897 (final step 🎉)