### PR TITLE
整理: `core_adapter` モジュール切り出し

### DIFF
--- a/run.py
+++ b/run.py
@@ -65,8 +65,8 @@ from voicevox_engine.setting import (
     Setting,
     SettingLoader,
 )
+from voicevox_engine.core_adapter import CoreAdapter
 from voicevox_engine.tts_pipeline import (
-    CoreAdapter,
     TTSEngineBase,
     make_synthesis_engines,
 )

--- a/run.py
+++ b/run.py
@@ -28,6 +28,7 @@ from starlette.responses import FileResponse
 
 from voicevox_engine import __version__
 from voicevox_engine.cancellable_engine import CancellableEngine
+from voicevox_engine.core_adapter import CoreAdapter
 from voicevox_engine.engine_manifest import EngineManifestLoader
 from voicevox_engine.engine_manifest.EngineManifest import EngineManifest
 from voicevox_engine.library_manager import LibraryManager
@@ -65,11 +66,7 @@ from voicevox_engine.setting import (
     Setting,
     SettingLoader,
 )
-from voicevox_engine.core_adapter import CoreAdapter
-from voicevox_engine.tts_pipeline import (
-    TTSEngineBase,
-    make_synthesis_engines,
-)
+from voicevox_engine.tts_pipeline import TTSEngineBase, make_synthesis_engines
 from voicevox_engine.tts_pipeline.kana_parser import create_kana, parse_kana
 from voicevox_engine.user_dict import (
     apply_word,

--- a/voicevox_engine/core_adapter.py
+++ b/voicevox_engine/core_adapter.py
@@ -4,7 +4,6 @@ import numpy
 from numpy import ndarray
 
 from .core_wrapper import CoreWrapper, OldCoreError
-from .model import AccentPhrase, AudioQuery, Mora
 
 
 class CoreAdapter:

--- a/voicevox_engine/core_adapter.py
+++ b/voicevox_engine/core_adapter.py
@@ -1,0 +1,117 @@
+import threading
+
+import numpy
+from numpy import ndarray
+
+from .core_wrapper import CoreWrapper, OldCoreError
+from .model import AccentPhrase, AudioQuery, Mora
+
+
+class CoreAdapter:
+    """
+    コアのアダプター。
+    ついでにコア内部で推論している処理をプロセスセーフにする。
+    """
+
+    def __init__(self, core: CoreWrapper):
+        super().__init__()
+        self.core = core
+        self.mutex = threading.Lock()
+
+    @property
+    def default_sampling_rate(self) -> int:
+        return self.core.default_sampling_rate
+
+    @property
+    def speakers(self) -> str:
+        """話者情報（json文字列）"""
+        return self.core.metas()
+
+    @property
+    def supported_devices(self) -> str | None:
+        """デバイスサポート情報（None: 情報無し）"""
+        try:
+            supported_devices = self.core.supported_devices()
+        except OldCoreError:
+            supported_devices = None
+        return supported_devices
+
+    def initialize_style_id_synthesis(self, style_id: int, skip_reinit: bool):
+        """
+        指定したスタイルでの音声合成を初期化する。
+        何度も実行可能。未実装の場合は何もしない。
+        Parameters
+        ----------
+        style_id : int
+            スタイルID
+        skip_reinit : bool
+            True の場合, 既に初期化済みの話者の再初期化をスキップします
+        """
+        try:
+            with self.mutex:
+                # 以下の条件のいずれかを満たす場合, 初期化を実行する
+                # 1. 引数 skip_reinit が False の場合
+                # 2. 話者が初期化されていない場合
+                if (not skip_reinit) or (not self.core.is_model_loaded(style_id)):
+                    self.core.load_model(style_id)
+        except OldCoreError:
+            pass  # コアが古い場合はどうしようもないので何もしない
+
+    def is_initialized_style_id_synthesis(self, style_id: int) -> bool:
+        """指定したスタイルでの音声合成が初期化されているかどうかを返す"""
+        try:
+            return self.core.is_model_loaded(style_id)
+        except OldCoreError:
+            return True  # コアが古い場合はどうしようもないのでTrueを返す
+
+    def safe_yukarin_s_forward(self, phoneme_list_s: ndarray, style_id: int) -> ndarray:
+        # 「指定スタイルを初期化」「mutexによる安全性」「系列長・データ型に関するアダプター」を提供する
+        self.initialize_style_id_synthesis(style_id, skip_reinit=True)
+        with self.mutex:
+            phoneme_length = self.core.yukarin_s_forward(
+                length=len(phoneme_list_s),
+                phoneme_list=phoneme_list_s,
+                style_id=numpy.array(style_id, dtype=numpy.int64).reshape(-1),
+            )
+        return phoneme_length
+
+    def safe_yukarin_sa_forward(
+        self,
+        vowel_phoneme_list: ndarray,
+        consonant_phoneme_list: ndarray,
+        start_accent_list: ndarray,
+        end_accent_list: ndarray,
+        start_accent_phrase_list: ndarray,
+        end_accent_phrase_list: ndarray,
+        style_id: int,
+    ) -> ndarray:
+        # 「指定スタイルを初期化」「mutexによる安全性」「系列長・データ型に関するアダプター」を提供する
+        self.initialize_style_id_synthesis(style_id, skip_reinit=True)
+        with self.mutex:
+            f0_list = self.core.yukarin_sa_forward(
+                length=vowel_phoneme_list.shape[0],
+                vowel_phoneme_list=vowel_phoneme_list[numpy.newaxis],
+                consonant_phoneme_list=consonant_phoneme_list[numpy.newaxis],
+                start_accent_list=start_accent_list[numpy.newaxis],
+                end_accent_list=end_accent_list[numpy.newaxis],
+                start_accent_phrase_list=start_accent_phrase_list[numpy.newaxis],
+                end_accent_phrase_list=end_accent_phrase_list[numpy.newaxis],
+                style_id=numpy.array(style_id, dtype=numpy.int64).reshape(-1),
+            )[0]
+        return f0_list
+
+    def safe_decode_forward(
+        self, phoneme: ndarray, f0: ndarray, style_id: int
+    ) -> tuple[ndarray, int]:
+        # 「指定スタイルを初期化」「mutexによる安全性」「系列長・データ型に関するアダプター」を提供する
+        self.initialize_style_id_synthesis(style_id, skip_reinit=True)
+        with self.mutex:
+            wave = self.core.decode_forward(
+                length=phoneme.shape[0],
+                phoneme_size=phoneme.shape[1],
+                f0=f0[:, numpy.newaxis],
+                phoneme=phoneme,
+                style_id=numpy.array(style_id, dtype=numpy.int64).reshape(-1),
+            )
+        sr_wave = self.default_sampling_rate
+        return wave, sr_wave

--- a/voicevox_engine/dev/synthesis_engine/mock.py
+++ b/voicevox_engine/dev/synthesis_engine/mock.py
@@ -6,11 +6,11 @@ import numpy as np
 from pyopenjtalk import tts
 from soxr import resample
 
-from ...core_wrapper import CoreWrapper
 from ...core_adapter import CoreAdapter
+from ...core_wrapper import CoreWrapper
 from ...model import AccentPhrase, AudioQuery
 from ...tts_pipeline import TTSEngineBase
-from ...tts_pipeline.tts_engine import CoreAdapter, to_flatten_moras
+from ...tts_pipeline.tts_engine import to_flatten_moras
 
 
 class MockTTSEngine(TTSEngineBase):

--- a/voicevox_engine/dev/synthesis_engine/mock.py
+++ b/voicevox_engine/dev/synthesis_engine/mock.py
@@ -7,6 +7,7 @@ from pyopenjtalk import tts
 from soxr import resample
 
 from ...core_wrapper import CoreWrapper
+from ...core_adapter import CoreAdapter
 from ...model import AccentPhrase, AudioQuery
 from ...tts_pipeline import TTSEngineBase
 from ...tts_pipeline.tts_engine import CoreAdapter, to_flatten_moras

--- a/voicevox_engine/metas/MetasStore.py
+++ b/voicevox_engine/metas/MetasStore.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Dict, List, Tuple
 from voicevox_engine.metas.Metas import CoreSpeaker, EngineSpeaker, Speaker, StyleInfo
 
 if TYPE_CHECKING:
-    from voicevox_engine.tts_pipeline.tts_engine import CoreAdapter
+    from voicevox_engine.core_adapter import CoreAdapter
 
 
 class MetasStore:

--- a/voicevox_engine/morphing.py
+++ b/voicevox_engine/morphing.py
@@ -10,7 +10,8 @@ from soxr import resample
 from .metas.Metas import Speaker, SpeakerSupportPermittedSynthesisMorphing, StyleInfo
 from .metas.MetasStore import construct_lookup
 from .model import AudioQuery, MorphableTargetInfo, StyleIdNotFoundError
-from .tts_pipeline import CoreAdapter, TTSEngine
+from .tts_pipeline import TTSEngine
+from .core_adapter import CoreAdapter
 
 
 # FIXME: ndarray type hint, https://github.com/JeremyCCHsu/Python-Wrapper-for-World-Vocoder/blob/2b64f86197573497c685c785c6e0e743f407b63e/pyworld/pyworld.pyx#L398  # noqa

--- a/voicevox_engine/morphing.py
+++ b/voicevox_engine/morphing.py
@@ -7,11 +7,11 @@ import numpy as np
 import pyworld as pw
 from soxr import resample
 
+from .core_adapter import CoreAdapter
 from .metas.Metas import Speaker, SpeakerSupportPermittedSynthesisMorphing, StyleInfo
 from .metas.MetasStore import construct_lookup
 from .model import AudioQuery, MorphableTargetInfo, StyleIdNotFoundError
 from .tts_pipeline import TTSEngine
-from .core_adapter import CoreAdapter
 
 
 # FIXME: ndarray type hint, https://github.com/JeremyCCHsu/Python-Wrapper-for-World-Vocoder/blob/2b64f86197573497c685c785c6e0e743f407b63e/pyworld/pyworld.pyx#L398  # noqa

--- a/voicevox_engine/tts_pipeline/__init__.py
+++ b/voicevox_engine/tts_pipeline/__init__.py
@@ -1,11 +1,10 @@
 from ..core_wrapper import CoreWrapper, load_runtime_lib
 from .make_tts_engines import make_synthesis_engines
-from .tts_engine import CoreAdapter, TTSEngine
+from .tts_engine import TTSEngine
 from .tts_engine_base import TTSEngineBase
 
 __all__ = [
     "CoreWrapper",
-    "CoreAdapter",
     "load_runtime_lib",
     "make_synthesis_engines",
     "TTSEngine",

--- a/voicevox_engine/tts_pipeline/tts_engine.py
+++ b/voicevox_engine/tts_pipeline/tts_engine.py
@@ -11,6 +11,7 @@ from ..core_wrapper import CoreWrapper, OldCoreError
 from ..model import AccentPhrase, AudioQuery, Mora
 from .acoustic_feature_extractor import Phoneme
 from .tts_engine_base import TTSEngineBase, apply_interrogative_upspeak
+from ..core_adapter import CoreAdapter
 
 unvoiced_mora_phoneme_list = ["A", "I", "U", "E", "O", "cl", "pau"]
 mora_phoneme_list = ["a", "i", "u", "e", "o", "N"] + unvoiced_mora_phoneme_list
@@ -208,116 +209,6 @@ def raw_wave_to_output_wave(query: AudioQuery, wave: ndarray, sr_wave: int) -> n
     wave = apply_output_sampling_rate(wave, sr_wave, query)
     wave = apply_output_stereo(wave, query)
     return wave
-
-
-class CoreAdapter:
-    """
-    コアのアダプター。
-    ついでにコア内部で推論している処理をプロセスセーフにする。
-    """
-
-    def __init__(self, core: CoreWrapper):
-        super().__init__()
-        self.core = core
-        self.mutex = threading.Lock()
-
-    @property
-    def default_sampling_rate(self) -> int:
-        return self.core.default_sampling_rate
-
-    @property
-    def speakers(self) -> str:
-        """話者情報（json文字列）"""
-        return self.core.metas()
-
-    @property
-    def supported_devices(self) -> str | None:
-        """デバイスサポート情報（None: 情報無し）"""
-        try:
-            supported_devices = self.core.supported_devices()
-        except OldCoreError:
-            supported_devices = None
-        return supported_devices
-
-    def initialize_style_id_synthesis(self, style_id: int, skip_reinit: bool):
-        """
-        指定したスタイルでの音声合成を初期化する。
-        何度も実行可能。未実装の場合は何もしない。
-        Parameters
-        ----------
-        style_id : int
-            スタイルID
-        skip_reinit : bool
-            True の場合, 既に初期化済みの話者の再初期化をスキップします
-        """
-        try:
-            with self.mutex:
-                # 以下の条件のいずれかを満たす場合, 初期化を実行する
-                # 1. 引数 skip_reinit が False の場合
-                # 2. 話者が初期化されていない場合
-                if (not skip_reinit) or (not self.core.is_model_loaded(style_id)):
-                    self.core.load_model(style_id)
-        except OldCoreError:
-            pass  # コアが古い場合はどうしようもないので何もしない
-
-    def is_initialized_style_id_synthesis(self, style_id: int) -> bool:
-        """指定したスタイルでの音声合成が初期化されているかどうかを返す"""
-        try:
-            return self.core.is_model_loaded(style_id)
-        except OldCoreError:
-            return True  # コアが古い場合はどうしようもないのでTrueを返す
-
-    def safe_yukarin_s_forward(self, phoneme_list_s: ndarray, style_id: int) -> ndarray:
-        # 「指定スタイルを初期化」「mutexによる安全性」「系列長・データ型に関するアダプター」を提供する
-        self.initialize_style_id_synthesis(style_id, skip_reinit=True)
-        with self.mutex:
-            phoneme_length = self.core.yukarin_s_forward(
-                length=len(phoneme_list_s),
-                phoneme_list=phoneme_list_s,
-                style_id=numpy.array(style_id, dtype=numpy.int64).reshape(-1),
-            )
-        return phoneme_length
-
-    def safe_yukarin_sa_forward(
-        self,
-        vowel_phoneme_list: ndarray,
-        consonant_phoneme_list: ndarray,
-        start_accent_list: ndarray,
-        end_accent_list: ndarray,
-        start_accent_phrase_list: ndarray,
-        end_accent_phrase_list: ndarray,
-        style_id: int,
-    ) -> ndarray:
-        # 「指定スタイルを初期化」「mutexによる安全性」「系列長・データ型に関するアダプター」を提供する
-        self.initialize_style_id_synthesis(style_id, skip_reinit=True)
-        with self.mutex:
-            f0_list = self.core.yukarin_sa_forward(
-                length=vowel_phoneme_list.shape[0],
-                vowel_phoneme_list=vowel_phoneme_list[numpy.newaxis],
-                consonant_phoneme_list=consonant_phoneme_list[numpy.newaxis],
-                start_accent_list=start_accent_list[numpy.newaxis],
-                end_accent_list=end_accent_list[numpy.newaxis],
-                start_accent_phrase_list=start_accent_phrase_list[numpy.newaxis],
-                end_accent_phrase_list=end_accent_phrase_list[numpy.newaxis],
-                style_id=numpy.array(style_id, dtype=numpy.int64).reshape(-1),
-            )[0]
-        return f0_list
-
-    def safe_decode_forward(
-        self, phoneme: ndarray, f0: ndarray, style_id: int
-    ) -> tuple[ndarray, int]:
-        # 「指定スタイルを初期化」「mutexによる安全性」「系列長・データ型に関するアダプター」を提供する
-        self.initialize_style_id_synthesis(style_id, skip_reinit=True)
-        with self.mutex:
-            wave = self.core.decode_forward(
-                length=phoneme.shape[0],
-                phoneme_size=phoneme.shape[1],
-                f0=f0[:, numpy.newaxis],
-                phoneme=phoneme,
-                style_id=numpy.array(style_id, dtype=numpy.int64).reshape(-1),
-            )
-        sr_wave = self.default_sampling_rate
-        return wave, sr_wave
 
 
 class TTSEngine(TTSEngineBase):

--- a/voicevox_engine/tts_pipeline/tts_engine.py
+++ b/voicevox_engine/tts_pipeline/tts_engine.py
@@ -1,17 +1,16 @@
 import copy
 import math
-import threading
 from typing import List, Optional
 
 import numpy
 from numpy import ndarray
 from soxr import resample
 
-from ..core_wrapper import CoreWrapper, OldCoreError
+from ..core_adapter import CoreAdapter
+from ..core_wrapper import CoreWrapper
 from ..model import AccentPhrase, AudioQuery, Mora
 from .acoustic_feature_extractor import Phoneme
 from .tts_engine_base import TTSEngineBase, apply_interrogative_upspeak
-from ..core_adapter import CoreAdapter
 
 unvoiced_mora_phoneme_list = ["A", "I", "U", "E", "O", "cl", "pau"]
 mora_phoneme_list = ["a", "i", "u", "e", "o", "N"] + unvoiced_mora_phoneme_list


### PR DESCRIPTION
## 内容
`core_adapter` モジュールへの `CoreAdapter` 切り出し

昨今のリファクタリングにより、`CoreAdapter` と `TTSEngine` の役割分担が明確になった。  
一方で `CoreAdapter` は（歴史的経緯から）`tts_engine` に配置されており、役割分担とのズレが生じている。  

このような背景から、`core_adapter` モジュールを新設し `CoreAdapter` をここへ移植することを提案します。  

## 関連 Issue
part of #871