### PR TITLE
追加: `TTSEngine` に近いモック

### DIFF
--- a/test/test_mock_synthesis_engine.py
+++ b/test/test_mock_synthesis_engine.py
@@ -105,6 +105,20 @@ class TestMockTTSEngine(TestCase):
         ]
         self.engine = MockTTSEngine(MockCoreWrapper())
 
+    def test_replace_phoneme_length(self):
+        """`.replace_phoneme_length()` がエラー無く生成をおこなう"""
+        self.engine.replace_phoneme_length(
+            accent_phrases=self.accent_phrases_hello_hiho,
+            style_id=0,
+        )
+
+    def test_replace_mora_pitch(self):
+        """`.replace_mora_pitch()` がエラー無く生成をおこなう"""
+        self.engine.replace_mora_pitch(
+            accent_phrases=self.accent_phrases_hello_hiho,
+            style_id=0,
+        )
+
     def test_synthesis(self):
         """`.synthesis()` がエラー無く生成をおこなう"""
         self.engine.synthesis(

--- a/test/test_mock_synthesis_engine.py
+++ b/test/test_mock_synthesis_engine.py
@@ -105,25 +105,8 @@ class TestMockTTSEngine(TestCase):
         ]
         self.engine = MockTTSEngine(MockCoreWrapper())
 
-    def test_replace_phoneme_length(self):
-        self.assertEqual(
-            self.engine.replace_phoneme_length(
-                accent_phrases=self.accent_phrases_hello_hiho,
-                style_id=0,
-            ),
-            self.accent_phrases_hello_hiho,
-        )
-
-    def test_replace_mora_pitch(self):
-        self.assertEqual(
-            self.engine.replace_mora_pitch(
-                accent_phrases=self.accent_phrases_hello_hiho,
-                style_id=0,
-            ),
-            self.accent_phrases_hello_hiho,
-        )
-
     def test_synthesis(self):
+        """`.synthesis()` がエラー無く生成をおこなう"""
         self.engine.synthesis(
             AudioQuery(
                 accent_phrases=self.accent_phrases_hello_hiho,

--- a/voicevox_engine/dev/core/mock.py
+++ b/voicevox_engine/dev/core/mock.py
@@ -87,7 +87,7 @@ class MockCoreWrapper(CoreWrapper):
         pitch = 100 * numpy.ones((1, length), dtype=numpy.float32)
         pitch[0, 0] = 0.0  # 開始無音 (pau)
         pitch[0, 1] = 200.0  # 分散 0 を避けるため
-        pitch[0, length] = 0.0  # 終了無音 (pau)
+        pitch[0, length - 1] = 0.0  # 終了無音 (pau)
         return pitch
 
     def decode_forward(

--- a/voicevox_engine/dev/synthesis_engine/mock.py
+++ b/voicevox_engine/dev/synthesis_engine/mock.py
@@ -1,67 +1,24 @@
 import copy
 from logging import getLogger
-from typing import Any, Dict, List
+from typing import Any, Dict
 
 import numpy as np
 from pyopenjtalk import tts
 from soxr import resample
 
-from ...core_adapter import CoreAdapter
 from ...core_wrapper import CoreWrapper
-from ...model import AccentPhrase, AudioQuery
-from ...tts_pipeline import TTSEngineBase
+from ...model import AudioQuery
+from ...tts_pipeline import TTSEngine
 from ...tts_pipeline.tts_engine import to_flatten_moras
 
 
-class MockTTSEngine(TTSEngineBase):
+class MockTTSEngine(TTSEngine):
     """
     TTSEngine [Mock]
     """
 
     def __init__(self, core: CoreWrapper):
-        super().__init__()
-        self.core = CoreAdapter(core)
-        # NOTE: self.coreは将来的に消す予定
-
-    def replace_phoneme_length(
-        self, accent_phrases: List[AccentPhrase], style_id: int
-    ) -> List[AccentPhrase]:
-        """
-        replace_phoneme_length 入力accent_phrasesを変更せずにそのまま返します [Mock]
-
-        Parameters
-        ----------
-        accent_phrases : List[AccentPhrase]
-            フレーズ句のリスト
-        style_id : int
-            スタイルID
-
-        Returns
-        -------
-        List[AccentPhrase]
-            フレーズ句のリスト（変更なし）
-        """
-        return accent_phrases
-
-    def replace_mora_pitch(
-        self, accent_phrases: List[AccentPhrase], style_id: int
-    ) -> List[AccentPhrase]:
-        """
-        replace_mora_pitch 入力accent_phrasesを変更せずにそのまま返します [Mock]
-
-        Parameters
-        ----------
-        accent_phrases : List[AccentPhrase]
-            フレーズ句のリスト
-        style_id : int
-            スタイルID
-
-        Returns
-        -------
-        List[AccentPhrase]
-            フレーズ句のリスト（変更なし）
-        """
-        return accent_phrases
+        super().__init__(core)
 
     def synthesis(
         self,


### PR DESCRIPTION
## 内容
概要: `MockTTSEngine` を `TTSEngine` により似た実装へ変更

`MockTTSEngine` の目的は「`TTSEngine` の軽量疑似 Dummy Object」である。  
すなわち、出来るだけ `TTSEngine` と同じ振る舞いをしたうえで重い生成/推論処理のみを別手法で近似したい。  

現在の `MockTTSEngine` は `TTSEngineBase` を継承し、`.replace_phoneme_length()` / `.replace_mora_pitch()` / `.synthesis()`を独自実装している。  
`.synthesis()` は pyopenjtalk の軽量生成機能を使うために独自実装が必須である。  
一方 `.replace_phoneme_length()` / `.replace_mora_pitch()` は昨今のコア Mock 改善により `TTSEngine` をそのまま流用できる（振る舞いを合わせられる）。  
このため、`TTSEngineBase` を継承し 3 メソッドを独自実装するのではなく、`TTSEngine` を継承すれば `.synthesis()` のオーバーライドのみで要件を満たせる。  

このような背景から、`MockTTSEngine` の `.replace_phoneme_length()` / `.replace_mora_pitch()` 独自実装削除と `TTSEngine` 継承による、より  `TTSEngine` に似た実装へ変更を提案します。  

## 関連 Issue
close #931 