### PR TITLE
整理: コア生成とTTSEngine生成の分離

### DIFF
--- a/run.py
+++ b/run.py
@@ -66,7 +66,11 @@ from voicevox_engine.setting import (
     Setting,
     SettingLoader,
 )
-from voicevox_engine.tts_pipeline import TTSEngineBase, cores_to_tts_engines, make_cores
+from voicevox_engine.tts_pipeline import (
+    TTSEngineBase,
+    make_cores,
+    make_tts_engines_from_cores,
+)
 from voicevox_engine.tts_pipeline.kana_converter import create_kana, parse_kana
 from voicevox_engine.user_dict import (
     apply_word,
@@ -1485,7 +1489,7 @@ def main() -> None:
         enable_mock=enable_mock,
         load_all_models=load_all_models,
     )
-    synthesis_engines = cores_to_tts_engines(cores)
+    synthesis_engines = make_tts_engines_from_cores(cores)
     assert len(synthesis_engines) != 0, "音声合成エンジンがありません。"
     latest_core_version = get_latest_core_version(versions=synthesis_engines.keys())
 

--- a/run.py
+++ b/run.py
@@ -66,7 +66,7 @@ from voicevox_engine.setting import (
     Setting,
     SettingLoader,
 )
-from voicevox_engine.tts_pipeline import TTSEngineBase, make_synthesis_engines_and_cores
+from voicevox_engine.tts_pipeline import TTSEngineBase, cores_to_tts_engines, make_cores
 from voicevox_engine.tts_pipeline.kana_converter import create_kana, parse_kana
 from voicevox_engine.user_dict import (
     apply_word,
@@ -1476,7 +1476,7 @@ def main() -> None:
     cpu_num_threads: int | None = args.cpu_num_threads
     load_all_models: bool = args.load_all_models
 
-    synthesis_engines, cores = make_synthesis_engines_and_cores(
+    cores = make_cores(
         use_gpu=use_gpu,
         voicelib_dirs=voicelib_dirs,
         voicevox_dir=voicevox_dir,
@@ -1485,6 +1485,7 @@ def main() -> None:
         enable_mock=enable_mock,
         load_all_models=load_all_models,
     )
+    synthesis_engines = cores_to_tts_engines(cores)
     assert len(synthesis_engines) != 0, "音声合成エンジンがありません。"
     latest_core_version = get_latest_core_version(versions=synthesis_engines.keys())
 

--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -8,7 +8,7 @@ from syrupy.extensions.json import JSONSnapshotExtension
 
 from voicevox_engine.preset import PresetManager
 from voicevox_engine.setting import SettingLoader
-from voicevox_engine.tts_pipeline import make_synthesis_engines_and_cores
+from voicevox_engine.tts_pipeline import cores_to_tts_engines, make_cores
 from voicevox_engine.utility.core_version_utility import get_latest_core_version
 
 
@@ -27,7 +27,8 @@ def snapshot_json(snapshot: SnapshotAssertion):
 
 @pytest.fixture(scope="session")
 def app_params():
-    synthesis_engines, cores = make_synthesis_engines_and_cores(use_gpu=False)
+    cores = make_cores(use_gpu=False)
+    synthesis_engines = cores_to_tts_engines(cores)
     latest_core_version = get_latest_core_version(versions=synthesis_engines.keys())
     setting_loader = SettingLoader(Path("./not_exist.yaml"))
     preset_manager = PresetManager(  # FIXME: impl MockPresetManager

--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -8,7 +8,7 @@ from syrupy.extensions.json import JSONSnapshotExtension
 
 from voicevox_engine.preset import PresetManager
 from voicevox_engine.setting import SettingLoader
-from voicevox_engine.tts_pipeline import cores_to_tts_engines, make_cores
+from voicevox_engine.tts_pipeline import make_cores, make_tts_engines_from_cores
 from voicevox_engine.utility.core_version_utility import get_latest_core_version
 
 
@@ -28,7 +28,7 @@ def snapshot_json(snapshot: SnapshotAssertion):
 @pytest.fixture(scope="session")
 def app_params():
     cores = make_cores(use_gpu=False)
-    synthesis_engines = cores_to_tts_engines(cores)
+    synthesis_engines = make_tts_engines_from_cores(cores)
     latest_core_version = get_latest_core_version(versions=synthesis_engines.keys())
     setting_loader = SettingLoader(Path("./not_exist.yaml"))
     preset_manager = PresetManager(  # FIXME: impl MockPresetManager

--- a/voicevox_engine/cancellable_engine.py
+++ b/voicevox_engine/cancellable_engine.py
@@ -17,7 +17,7 @@ import soundfile
 from fastapi import HTTPException, Request
 
 from .model import AudioQuery
-from .tts_pipeline import make_synthesis_engines_and_cores
+from .tts_pipeline import cores_to_tts_engines, make_cores
 from .utility import get_latest_core_version
 
 
@@ -219,7 +219,7 @@ def start_synthesis_subprocess(
         メインプロセスと通信するためのPipe
     """
 
-    synthesis_engines, _ = make_synthesis_engines_and_cores(
+    cores = make_cores(
         use_gpu=use_gpu,
         voicelib_dirs=voicelib_dirs,
         voicevox_dir=voicevox_dir,
@@ -227,6 +227,8 @@ def start_synthesis_subprocess(
         cpu_num_threads=cpu_num_threads,
         enable_mock=enable_mock,
     )
+    synthesis_engines = cores_to_tts_engines(cores)
+
     assert len(synthesis_engines) != 0, "音声合成エンジンがありません。"
     latest_core_version = get_latest_core_version(versions=synthesis_engines.keys())
     while True:

--- a/voicevox_engine/cancellable_engine.py
+++ b/voicevox_engine/cancellable_engine.py
@@ -17,7 +17,7 @@ import soundfile
 from fastapi import HTTPException, Request
 
 from .model import AudioQuery
-from .tts_pipeline import cores_to_tts_engines, make_cores
+from .tts_pipeline import make_cores, make_tts_engines_from_cores
 from .utility import get_latest_core_version
 
 
@@ -227,7 +227,7 @@ def start_synthesis_subprocess(
         cpu_num_threads=cpu_num_threads,
         enable_mock=enable_mock,
     )
-    synthesis_engines = cores_to_tts_engines(cores)
+    synthesis_engines = make_tts_engines_from_cores(cores)
 
     assert len(synthesis_engines) != 0, "音声合成エンジンがありません。"
     latest_core_version = get_latest_core_version(versions=synthesis_engines.keys())

--- a/voicevox_engine/tts_pipeline/__init__.py
+++ b/voicevox_engine/tts_pipeline/__init__.py
@@ -1,12 +1,13 @@
 from ..core_wrapper import CoreWrapper, load_runtime_lib
-from .make_tts_engines import make_synthesis_engines_and_cores
-from .tts_engine import TTSEngine
+from .make_tts_engines import make_cores
+from .tts_engine import TTSEngine, cores_to_tts_engines
 from .tts_engine_base import TTSEngineBase
 
 __all__ = [
     "CoreWrapper",
     "load_runtime_lib",
-    "make_synthesis_engines_and_cores",
+    "make_cores",
+    "cores_to_tts_engines",
     "TTSEngine",
     "TTSEngineBase",
 ]

--- a/voicevox_engine/tts_pipeline/__init__.py
+++ b/voicevox_engine/tts_pipeline/__init__.py
@@ -1,13 +1,13 @@
 from ..core_wrapper import CoreWrapper, load_runtime_lib
 from .make_tts_engines import make_cores
-from .tts_engine import TTSEngine, cores_to_tts_engines
+from .tts_engine import TTSEngine, make_tts_engines_from_cores
 from .tts_engine_base import TTSEngineBase
 
 __all__ = [
     "CoreWrapper",
     "load_runtime_lib",
     "make_cores",
-    "cores_to_tts_engines",
+    "make_tts_engines_from_cores",
     "TTSEngine",
     "TTSEngineBase",
 ]

--- a/voicevox_engine/tts_pipeline/make_tts_engines.py
+++ b/voicevox_engine/tts_pipeline/make_tts_engines.py
@@ -10,6 +10,7 @@ from .tts_engine import CoreAdapter
 MOCK_VER = "0.0.0"
 
 
+# FIXME: ファイル名を変えるか関数の場所を変える
 def make_cores(
     use_gpu: bool,
     voicelib_dirs: Optional[List[Path]] = None,

--- a/voicevox_engine/tts_pipeline/make_tts_engines.py
+++ b/voicevox_engine/tts_pipeline/make_tts_engines.py
@@ -5,10 +5,12 @@ from typing import List, Optional
 
 from ..core_wrapper import CoreWrapper, load_runtime_lib
 from ..utility import engine_root, get_save_dir
-from .tts_engine import CoreAdapter, TTSEngine, TTSEngineBase
+from .tts_engine import CoreAdapter
+
+MOCK_VER = "0.0.0"
 
 
-def make_synthesis_engines_and_cores(
+def make_cores(
     use_gpu: bool,
     voicelib_dirs: Optional[List[Path]] = None,
     voicevox_dir: Optional[Path] = None,
@@ -16,9 +18,9 @@ def make_synthesis_engines_and_cores(
     cpu_num_threads: Optional[int] = None,
     enable_mock: bool = True,
     load_all_models: bool = False,
-) -> tuple[dict[str, TTSEngineBase], dict[str, CoreAdapter]]:
+) -> dict[str, CoreAdapter]:
     """
-    音声ライブラリをロードして、音声合成エンジンを生成
+    音声ライブラリをロードしてコアを生成
 
     Parameters
     ----------
@@ -72,15 +74,14 @@ def make_synthesis_engines_and_cores(
     # ランタイムをロードする
     load_runtime_lib(runtime_dirs)
 
-    # コアをロードし `cores` と `synthesis_engines` へ登録する
+    # コアをロードし `cores` へ登録する
     cores: dict[str, CoreAdapter] = {}
-    synthesis_engines: dict[str, TTSEngineBase] = {}
 
     if not enable_mock:
 
         def load_core_library(core_dir: Path, suppress_error: bool = False):
             """
-            指定されたコアをロードし `synthesis_engines` へ登録する。
+            指定されたコアをロードし `cores` へ登録する。
             Parameters
             ----------
             core_dir : Path
@@ -96,14 +97,13 @@ def make_synthesis_engines_and_cores(
                 metas = json.loads(core.metas())
                 core_version = metas[0]["version"]
                 print(f"Info: Loading core {core_version}.")
-                if core_version in synthesis_engines:
+                if core_version in cores:
                     print(
                         "Warning: Core loading is skipped because of version duplication.",
                         file=sys.stderr,
                     )
                 else:
                     cores[core_version] = CoreAdapter(core)
-                    synthesis_engines[core_version] = TTSEngine(core)
             except Exception:
                 # コアでなかった場合のエラーを抑制する
                 if not suppress_error:
@@ -130,13 +130,10 @@ def make_synthesis_engines_and_cores(
     else:
         # モック追加
         from ..dev.core import MockCoreWrapper
-        from ..dev.synthesis_engine import MockTTSEngine
 
-        mock_ver = "0.0.0"
-        if mock_ver not in synthesis_engines:
+        if MOCK_VER not in cores:
             print("Info: Loading mock.")
             core = MockCoreWrapper()
-            cores[mock_ver] = CoreAdapter(core)
-            synthesis_engines[mock_ver] = MockTTSEngine(core)
+            cores[MOCK_VER] = CoreAdapter(core)
 
-    return synthesis_engines, cores
+    return cores

--- a/voicevox_engine/tts_pipeline/tts_engine.py
+++ b/voicevox_engine/tts_pipeline/tts_engine.py
@@ -440,6 +440,7 @@ class TTSEngine(TTSEngineBase):
 
 def cores_to_tts_engines(cores: dict[str, CoreAdapter]) -> dict[str, TTSEngineBase]:
     """コア一覧からTTSエンジン一覧を生成する"""
+    # FIXME: `MOCK_VER` を循環 import 無しに `make_cores()` 関連モジュールから import する
     MOCK_VER = "0.0.0"
     tts_engines: dict[str, TTSEngineBase] = {}
     for ver, core in cores.items():

--- a/voicevox_engine/tts_pipeline/tts_engine.py
+++ b/voicevox_engine/tts_pipeline/tts_engine.py
@@ -436,3 +436,17 @@ class TTSEngine(TTSEngineBase):
         raw_wave, sr_raw_wave = self.core.safe_decode_forward(phoneme, f0, style_id)
         wave = raw_wave_to_output_wave(query, raw_wave, sr_raw_wave)
         return wave
+
+
+def cores_to_tts_engines(cores: dict[str, CoreAdapter]) -> dict[str, TTSEngineBase]:
+    """コア一覧からTTSエンジン一覧を生成する"""
+    MOCK_VER = "0.0.0"
+    tts_engines: dict[str, TTSEngineBase] = {}
+    for ver, core in cores.items():
+        if ver == MOCK_VER:
+            from ..dev.synthesis_engine import MockTTSEngine
+
+            tts_engines[ver] = MockTTSEngine(core.core)
+        else:
+            tts_engines[ver] = TTSEngine(core.core)
+    return tts_engines

--- a/voicevox_engine/tts_pipeline/tts_engine.py
+++ b/voicevox_engine/tts_pipeline/tts_engine.py
@@ -438,7 +438,9 @@ class TTSEngine(TTSEngineBase):
         return wave
 
 
-def cores_to_tts_engines(cores: dict[str, CoreAdapter]) -> dict[str, TTSEngineBase]:
+def make_tts_engines_from_cores(
+    cores: dict[str, CoreAdapter]
+) -> dict[str, TTSEngineBase]:
     """コア一覧からTTSエンジン一覧を生成する"""
     # FIXME: `MOCK_VER` を循環 import 無しに `make_cores()` 関連モジュールから import する
     MOCK_VER = "0.0.0"


### PR DESCRIPTION
## 内容
`CoreAdapter` 生成と`TTSEngine` 生成の分離によるリファクタリング  

`TTSEngine` 生成と `CoreAdapter` 生成は本来独立した事象である。  
しかし現在の `make_synthesis_engines_and_cores()` はこれを一体化して扱っている。  
昨今のリファクタリングによりこの2つを隔離できるようになった。  

このような背景から、`CoreAdapter` 生成と`TTSEngine` 生成の分離によるリファクタリングを提案します。  

## 関連 Issue
part of #871