### PR TITLE
追加: `MockCoreWrapper` 入力反映出力

### DIFF
--- a/test/test_synthesis_engine_base.py
+++ b/test/test_synthesis_engine_base.py
@@ -1,76 +1,11 @@
-from typing import List, Union
 from unittest import TestCase
-from unittest.mock import Mock
 
-import numpy
-
+from voicevox_engine.dev.core.mock import MockCoreWrapper
 from voicevox_engine.model import AccentPhrase, AudioQuery, Mora
 from voicevox_engine.tts_pipeline import TTSEngine
 from voicevox_engine.tts_pipeline.tts_engine import (
     apply_interrogative_upspeak,  # FIXME: この関数を使うテストをTTSEngine用のテストに移動する
 )
-
-
-def yukarin_s_mock(length: int, phoneme_list: numpy.ndarray, style_id: numpy.ndarray):
-    result = []
-    # mockとしての適当な処理、特に意味はない
-    for i in range(length):
-        result.append(round((phoneme_list[i] * 0.0625 + style_id).item(), 2))
-    return numpy.array(result)
-
-
-def yukarin_sa_mock(
-    length: int,
-    vowel_phoneme_list: numpy.ndarray,
-    consonant_phoneme_list: numpy.ndarray,
-    start_accent_list: numpy.ndarray,
-    end_accent_list: numpy.ndarray,
-    start_accent_phrase_list: numpy.ndarray,
-    end_accent_phrase_list: numpy.ndarray,
-    style_id: numpy.ndarray,
-):
-    result = []
-    # mockとしての適当な処理、特に意味はない
-    for i in range(length):
-        result.append(
-            round(
-                (
-                    (
-                        vowel_phoneme_list[0][i]
-                        + consonant_phoneme_list[0][i]
-                        + start_accent_list[0][i]
-                        + end_accent_list[0][i]
-                        + start_accent_phrase_list[0][i]
-                        + end_accent_phrase_list[0][i]
-                    )
-                    * 0.0625
-                    + style_id
-                ).item(),
-                2,
-            )
-        )
-    return numpy.array(result)[numpy.newaxis]
-
-
-def decode_mock(
-    length: int,
-    phoneme_size: int,
-    f0: numpy.ndarray,
-    phoneme: numpy.ndarray,
-    style_id: Union[numpy.ndarray, int],
-):
-    result = []
-    # mockとしての適当な処理、特に意味はない
-    for i in range(length):
-        # decode forwardはデータサイズがlengthの256倍になるのでとりあえず256回データをresultに入れる
-        for _ in range(256):
-            result.append(
-                (
-                    f0[i][0] * (numpy.where(phoneme[i] == 1)[0] / phoneme_size)
-                    + style_id
-                ).item()
-            )
-    return numpy.array(result)
 
 
 def koreha_arimasuka_base_expected():
@@ -171,31 +106,15 @@ def create_mock_query(accent_phrases):
     )
 
 
-class MockCore:
-    default_sampling_rate = 24000
-    yukarin_s_forward = Mock(side_effect=yukarin_s_mock)
-    yukarin_sa_forward = Mock(side_effect=yukarin_sa_mock)
-    decode_forward = Mock(side_effect=decode_mock)
-
-    def metas(self):
-        return ""
-
-    def supported_devices(self):
-        return ""
-
-    def is_model_loaded(self, style_id):
-        return True
-
-
 class TestTTSEngineBase(TestCase):
     def setUp(self):
         super().setUp()
-        self.synthesis_engine = TTSEngine(core=MockCore())
+        self.synthesis_engine = TTSEngine(core=MockCoreWrapper())
 
     def create_synthesis_test_base(
         self,
         text: str,
-        expected: List[AccentPhrase],
+        expected: list[AccentPhrase],
         enable_interrogative_upspeak: bool,
     ):
         """音声合成時に疑問文モーラ処理を行っているかどうかを検証

--- a/test/test_synthesis_engine_base.py
+++ b/test/test_synthesis_engine_base.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 
 from voicevox_engine.dev.core.mock import MockCoreWrapper
-from voicevox_engine.model import AccentPhrase, AudioQuery, Mora
+from voicevox_engine.model import AccentPhrase, Mora
 from voicevox_engine.tts_pipeline import TTSEngine
 from voicevox_engine.tts_pipeline.tts_engine import (
     apply_interrogative_upspeak,  # FIXME: この関数を使うテストをTTSEngine用のテストに移動する
@@ -89,21 +89,6 @@ def koreha_arimasuka_base_expected():
             is_interrogative=False,
         ),
     ]
-
-
-def create_mock_query(accent_phrases):
-    return AudioQuery(
-        accent_phrases=accent_phrases,
-        speedScale=1,
-        pitchScale=0,
-        intonationScale=1,
-        volumeScale=1,
-        prePhonemeLength=0.1,
-        postPhonemeLength=0.1,
-        outputSamplingRate=24000,
-        outputStereo=False,
-        kana="",
-    )
 
 
 class TestTTSEngineBase(TestCase):

--- a/voicevox_engine/dev/core/mock.py
+++ b/voicevox_engine/dev/core/mock.py
@@ -67,8 +67,11 @@ class MockCoreWrapper(CoreWrapper):
         self, length: int, phoneme_list: ndarray, style_id: ndarray
     ) -> ndarray:
         """音素系列サイズ・音素ID系列・スタイルIDから音素長系列を生成する"""
-        # Mock: 定数の音素長系列を生成。[0.1, 0.1, ...]
-        return 0.1 * numpy.ones((length,), dtype=numpy.float32)
+        result = []
+        # mockとしての適当な処理、特に意味はない
+        for i in range(length):
+            result.append(round((phoneme_list[i] * 0.0625 + style_id).item(), 2))
+        return numpy.array(result)
 
     def yukarin_sa_forward(
         self,
@@ -83,12 +86,28 @@ class MockCoreWrapper(CoreWrapper):
     ) -> ndarray:
         """モーラ系列サイズ・母音系列・子音系列・アクセント位置・アクセント句区切り・スタイルIDからモーラ音高系列を生成する"""
         assert length > 1, "前後無音を必ず付与しなければならない"
-        # Mock: 定数のモーラ音高系列を生成。[0, 200, 100, 100, ..., 100, 0]
-        pitch = 100 * numpy.ones((1, length), dtype=numpy.float32)
-        pitch[0, 0] = 0.0  # 開始無音 (pau)
-        pitch[0, 1] = 200.0  # 分散 0 を避けるため
-        pitch[0, length - 1] = 0.0  # 終了無音 (pau)
-        return pitch
+
+        result = []
+        # mockとしての適当な処理、特に意味はない
+        for i in range(length):
+            result.append(
+                round(
+                    (
+                        (
+                            vowel_phoneme_list[0][i]
+                            + consonant_phoneme_list[0][i]
+                            + start_accent_list[0][i]
+                            + end_accent_list[0][i]
+                            + start_accent_phrase_list[0][i]
+                            + end_accent_phrase_list[0][i]
+                        )
+                        * 0.0625
+                        + style_id
+                    ).item(),
+                    2,
+                )
+            )
+        return numpy.array(result)[numpy.newaxis]
 
     def decode_forward(
         self,
@@ -99,8 +118,18 @@ class MockCoreWrapper(CoreWrapper):
         style_id: ndarray,
     ) -> ndarray:
         """フレーム長・音素種類数・フレーム音高・フレーム音素onehot・スタイルIDから音声波形を生成する"""
-        # Mock: 定数の音声波形を生成。[0.1, 0.1, ..., 0.1, 0.1]
-        return 0.1 * numpy.ones((length * 256,), dtype=numpy.float32)
+        result = []
+        # mockとしての適当な処理、特に意味はない
+        for i in range(length):
+            # decode forwardはデータサイズがlengthの256倍になるのでとりあえず256回データをresultに入れる
+            for _ in range(256):
+                result.append(
+                    (
+                        f0[i][0] * (numpy.where(phoneme[i] == 1)[0] / phoneme_size)
+                        + style_id
+                    ).item()
+                )
+        return numpy.array(result)
 
     def supported_devices(self):
         return json.dumps(


### PR DESCRIPTION
## 内容
`MockCoreWrapper` 入力反映出力の追加

現在の `MockCoreWrapper` は入力を（ほぼ）無視し、固定出力を返している。  
この出力が入力値を反映した値になれば、より意味のあるスナップショットテストが可能になる。  
`test_synthesis_engine_base.py` が動的出力するコアを独自に定義しており、これは動的出力のスタート地点として有意義である。  
また `MockCoreWrapper` をテストでも利用することでメンテコストを削減できる。  

このような背景から、`MockCoreWrapper` 入力反映出力の追加を提案します。  

## 関連 Issue
ref #899