### PR TITLE
整理: `mora_list` 無子音表現

### DIFF
--- a/voicevox_engine/tts_pipeline/kana_converter.py
+++ b/voicevox_engine/tts_pipeline/kana_converter.py
@@ -33,8 +33,8 @@ _text2mora_with_unvoice = {}
 for text, (consonant, vowel) in openjtalk_text2mora.items():
     _text2mora_with_unvoice[text] = Mora(
         text=text,
-        consonant=consonant if len(consonant) > 0 else None,
-        consonant_length=0 if len(consonant) > 0 else None,
+        consonant=consonant,
+        consonant_length=0 if consonant else None,
         vowel=vowel,
         vowel_length=0,
         pitch=0,
@@ -44,8 +44,8 @@ for text, (consonant, vowel) in openjtalk_text2mora.items():
         # 例: "_ホ" -> "hO"
         _text2mora_with_unvoice[_UNVOICE_SYMBOL + text] = Mora(
             text=text,
-            consonant=consonant if len(consonant) > 0 else None,
-            consonant_length=0 if len(consonant) > 0 else None,
+            consonant=consonant,
+            consonant_length=0 if consonant else None,
             vowel=vowel.upper(),
             vowel_length=0,
             pitch=0,

--- a/voicevox_engine/tts_pipeline/mora_list.py
+++ b/voicevox_engine/tts_pipeline/mora_list.py
@@ -42,13 +42,13 @@ OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 """
 
-_mora_list_minimum: list[tuple[str, str, str]] = [
+_mora_list_minimum: list[tuple[str, str | None, str]] = [
     ("ヴォ", "v", "o"),
     ("ヴェ", "v", "e"),
     ("ヴィ", "v", "i"),
     ("ヴァ", "v", "a"),
     ("ヴ", "v", "u"),
-    ("ン", "", "N"),
+    ("ン", None, "N"),
     ("ワ", "w", "a"),
     ("ロ", "r", "o"),
     ("レ", "r", "e"),
@@ -131,7 +131,7 @@ _mora_list_minimum: list[tuple[str, str, str]] = [
     ("ツィ", "ts", "i"),
     ("ツァ", "ts", "a"),
     ("ツ", "ts", "u"),
-    ("ッ", "", "cl"),
+    ("ッ", None, "cl"),
     ("チョ", "ch", "o"),
     ("チュ", "ch", "u"),
     ("チャ", "ch", "a"),
@@ -179,23 +179,23 @@ _mora_list_minimum: list[tuple[str, str, str]] = [
     ("キ", "k", "i"),
     ("ガ", "g", "a"),
     ("カ", "k", "a"),
-    ("オ", "", "o"),
-    ("エ", "", "e"),
+    ("オ", None, "o"),
+    ("エ", None, "e"),
     ("ウォ", "w", "o"),
     ("ウェ", "w", "e"),
     ("ウィ", "w", "i"),
-    ("ウ", "", "u"),
+    ("ウ", None, "u"),
     ("イェ", "y", "e"),
-    ("イ", "", "i"),
-    ("ア", "", "a"),
+    ("イ", None, "i"),
+    ("ア", None, "a"),
 ]
-_mora_list_additional: list[tuple[str, str, str]] = [
+_mora_list_additional: list[tuple[str, str | None, str]] = [
     ("ヴョ", "by", "o"),
     ("ヴュ", "by", "u"),
     ("ヴャ", "by", "a"),
-    ("ヲ", "", "o"),
-    ("ヱ", "", "e"),
-    ("ヰ", "", "i"),
+    ("ヲ", None, "o"),
+    ("ヱ", None, "e"),
+    ("ヰ", None, "i"),
     ("ヮ", "w", "a"),
     ("ョ", "y", "o"),
     ("ュ", "y", "u"),
@@ -203,15 +203,15 @@ _mora_list_additional: list[tuple[str, str, str]] = [
     ("ヂ", "j", "i"),
     ("ヶ", "k", "e"),
     ("ャ", "y", "a"),
-    ("ォ", "", "o"),
-    ("ェ", "", "e"),
-    ("ゥ", "", "u"),
-    ("ィ", "", "i"),
-    ("ァ", "", "a"),
+    ("ォ", None, "o"),
+    ("ェ", None, "e"),
+    ("ゥ", None, "u"),
+    ("ィ", None, "i"),
+    ("ァ", None, "a"),
 ]
 
 openjtalk_mora2text = {
-    consonant + vowel: text for [text, consonant, vowel] in _mora_list_minimum
+    (consonant or "") + vowel: text for [text, consonant, vowel] in _mora_list_minimum
 }
 openjtalk_text2mora = {
     text: (consonant, vowel)


### PR DESCRIPTION
## 内容
`mora_list` 無子音表現の変更によるリファクタリング  

`mora_list` は音素と読み仮名の対応を担っている。  
現在の `mora_list` は無子音を `""` で表現しているが、`mora_list` 利用側では `""` チェックに基づいて `None` への変換をおこなっている。  
無子音の表現を `None` へ変更すればこのキャストを削減できる。  

このような背景から、`mora_list` 無子音表現の変更によるリファクタリングを提案します。  

## 関連 Issue
ref #894