### PR TITLE
追加: `OjtPhoneme` 型

### DIFF
--- a/voicevox_engine/tts_pipeline/text_analyzer.py
+++ b/voicevox_engine/tts_pipeline/text_analyzer.py
@@ -83,6 +83,7 @@ class Label:
     @property
     def phoneme(self) -> OjtPhoneme:
         """このラベルに含まれる音素。子音 or 母音 (無音含む)。"""
+        # FIXME: バリデーションする
         return self.contexts["p3"]  # type: ignore
 
     def is_pause(self):

--- a/voicevox_engine/tts_pipeline/text_analyzer.py
+++ b/voicevox_engine/tts_pipeline/text_analyzer.py
@@ -82,7 +82,7 @@ class Label:
     @property
     def phoneme(self) -> OjtPhoneme:
         """このラベルに含まれる音素。子音 or 母音 (無音含む)。"""
-        return self.contexts["p3"] # type: ignore
+        return self.contexts["p3"]  # type: ignore
 
     def is_pause(self):
         """このラベルが無音 (silent/pause) であれば True、そうでなければ False を返す"""

--- a/voicevox_engine/tts_pipeline/text_analyzer.py
+++ b/voicevox_engine/tts_pipeline/text_analyzer.py
@@ -1,12 +1,51 @@
 import re
 from dataclasses import dataclass
 from itertools import chain
-from typing import Self
+from typing import Literal, Self
 
 import pyopenjtalk
 
 from ..model import AccentPhrase, Mora
 from .mora_list import openjtalk_mora2text
+
+OjtVowel = Literal[
+    "A", "E", "I", "N", "O", "U", "a", "cl", "e", "i", "o", "pau", "sil", "u", "xx"
+]
+OjtConsonant = Literal[
+    "b",
+    "by",
+    "ch",
+    "d",
+    "dy",
+    "f",
+    "g",
+    "gw",
+    "gy",
+    "h",
+    "hy",
+    "j",
+    "k",
+    "kw",
+    "ky",
+    "m",
+    "my",
+    "n",
+    "ny",
+    "p",
+    "py",
+    "r",
+    "ry",
+    "s",
+    "sh",
+    "t",
+    "ts",
+    "ty",
+    "v",
+    "w",
+    "y",
+    "z",
+]
+OjtPhoneme = OjtVowel | OjtConsonant
 
 
 @dataclass
@@ -41,9 +80,9 @@ class Label:
         return cls(contexts=contexts)
 
     @property
-    def phoneme(self):
+    def phoneme(self) -> OjtPhoneme:
         """このラベルに含まれる音素。子音 or 母音 (無音含む)。"""
-        return self.contexts["p3"]
+        return self.contexts["p3"] # type: ignore
 
     def is_pause(self):
         """このラベルが無音 (silent/pause) であれば True、そうでなければ False を返す"""

--- a/voicevox_engine/tts_pipeline/text_analyzer.py
+++ b/voicevox_engine/tts_pipeline/text_analyzer.py
@@ -9,7 +9,7 @@ from ..model import AccentPhrase, Mora
 from .mora_list import openjtalk_mora2text
 
 OjtVowel = Literal[
-    "A", "E", "I", "N", "O", "U", "a", "cl", "e", "i", "o", "pau", "sil", "u", "xx"
+    "A", "E", "I", "N", "O", "U", "a", "cl", "e", "i", "o", "pau", "sil", "u"
 ]
 OjtConsonant = Literal[
     "b",
@@ -45,7 +45,8 @@ OjtConsonant = Literal[
     "y",
     "z",
 ]
-OjtPhoneme = OjtVowel | OjtConsonant
+OjtUnknown = Literal["xx"]
+OjtPhoneme = OjtVowel | OjtConsonant | OjtUnknown
 
 
 @dataclass


### PR DESCRIPTION
## 内容
`OjtPhoneme` 型の追加

OpenJTalkドメイン (`text_analyzer`) で音素が取りうる値を型で表現した。  

## 関連 Issue
resolve #954  
part of #894  
ref #942