### PR TITLE
廃止: `__repr__` と deprecated `__eq__`

### DIFF
--- a/voicevox_engine/tts_pipeline/acoustic_feature_extractor.py
+++ b/voicevox_engine/tts_pipeline/acoustic_feature_extractor.py
@@ -25,10 +25,6 @@ class Phoneme:
 
         self.phoneme = phoneme
 
-    def __eq__(self, o: object) -> bool:
-        """Deprecated."""
-        raise NotImplementedError
-
     @property
     def phoneme_id(self) -> int:
         """音素ID (音素リスト内でのindex) を取得する"""

--- a/voicevox_engine/tts_pipeline/text_analyzer.py
+++ b/voicevox_engine/tts_pipeline/text_analyzer.py
@@ -49,9 +49,6 @@ class Label:
         """このラベルが無音 (silent/pause) であれば True、そうでなければ False を返す"""
         return self.contexts["f1"] == "xx"
 
-    def __repr__(self):
-        return f"<Label phoneme='{self.phoneme}'>"
-
 
 @dataclass
 class MoraLabel:


### PR DESCRIPTION
## 内容
`Label.__repr__()` と deprecated `Phoneme.__eq__()` の廃止

`Label.__repr__()` はOJTラベルの内容を print する関数であるが、利用されていない。  
よって廃止可能であり、廃止によりメンテコストを削減できる。  

`Phoneme.__eq__()` はVVドメインの音素クラスにおける特殊 equal チェック関数であり、deprecated かつ raise error 実装となっている。この形で維持されてきたのは開発者の誤利用を防ぐためである。  
deprecated から約 80 commit 経過したことから削除可能と考えられ、廃止によりメンテコストを削減できる。  

このような背景から、`Label.__repr__()` と deprecated `Phoneme.__eq__()` の廃止を提案します。  

## 関連 Issue
無し