### PR TITLE
起動時にsettingを設定ファイルに保存するように変更

### DIFF
--- a/run.py
+++ b/run.py
@@ -186,6 +186,13 @@ def generate_app(
         allow_headers=["*"],
     )
 
+    # 起動時の設定を保存
+    settings = Setting(
+        cors_policy_mode=cors_policy_mode,
+        allow_origin=" ".join(allowed_origins),
+    )
+    setting_loader.dump_setting_file(settings)
+
     # 許可されていないOriginを遮断するミドルウェア
     @app.middleware("http")
     async def block_origin_middleware(


### PR DESCRIPTION
## 内容

generate_appにおいて、cors_policy_mode, allow_originを設定ファイルに保存するように変更。
<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue
close #963

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->


## その他
