### PR TITLE
APIのstyle_idの型をStyleId型に

### DIFF
--- a/run.py
+++ b/run.py
@@ -271,8 +271,8 @@ def generate_app(
     )
     def audio_query(
         text: str,
-        style_id: int | None = Query(default=None),  # noqa: B008
-        speaker: int | None = Query(default=None, deprecated=True),  # noqa: B008
+        style_id: StyleId | None = Query(default=None),  # noqa: B008
+        speaker: StyleId | None = Query(default=None, deprecated=True),  # noqa: B008
         core_version: str | None = None,
     ) -> AudioQuery:
         """
@@ -323,7 +323,7 @@ def generate_app(
             raise HTTPException(status_code=422, detail="該当するプリセットIDが見つかりません")
 
         accent_phrases = engine.create_accent_phrases(
-            text, style_id=StyleId(selected_preset.style_id)
+            text, style_id=selected_preset.style_id
         )
         return AudioQuery(
             accent_phrases=accent_phrases,
@@ -352,8 +352,8 @@ def generate_app(
     )
     def accent_phrases(
         text: str,
-        style_id: int | None = Query(default=None),  # noqa: B008
-        speaker: int | None = Query(default=None, deprecated=True),  # noqa: B008
+        style_id: StyleId | None = Query(default=None),  # noqa: B008
+        speaker: StyleId | None = Query(default=None, deprecated=True),  # noqa: B008
         is_kana: bool = False,
         core_version: str | None = None,
     ) -> list[AccentPhrase]:
@@ -392,8 +392,8 @@ def generate_app(
     )
     def mora_data(
         accent_phrases: list[AccentPhrase],
-        style_id: int | None = Query(default=None),  # noqa: B008
-        speaker: int | None = Query(default=None, deprecated=True),  # noqa: B008
+        style_id: StyleId | None = Query(default=None),  # noqa: B008
+        speaker: StyleId | None = Query(default=None, deprecated=True),  # noqa: B008
         core_version: str | None = None,
     ) -> list[AccentPhrase]:
         style_id = get_style_id_from_deprecated(style_id=style_id, speaker_id=speaker)
@@ -408,8 +408,8 @@ def generate_app(
     )
     def mora_length(
         accent_phrases: list[AccentPhrase],
-        style_id: int | None = Query(default=None),  # noqa: B008
-        speaker: int | None = Query(default=None, deprecated=True),  # noqa: B008
+        style_id: StyleId | None = Query(default=None),  # noqa: B008
+        speaker: StyleId | None = Query(default=None, deprecated=True),  # noqa: B008
         core_version: str | None = None,
     ) -> list[AccentPhrase]:
         style_id = get_style_id_from_deprecated(style_id=style_id, speaker_id=speaker)
@@ -426,8 +426,8 @@ def generate_app(
     )
     def mora_pitch(
         accent_phrases: list[AccentPhrase],
-        style_id: int | None = Query(default=None),  # noqa: B008
-        speaker: int | None = Query(default=None, deprecated=True),  # noqa: B008
+        style_id: StyleId | None = Query(default=None),  # noqa: B008
+        speaker: StyleId | None = Query(default=None, deprecated=True),  # noqa: B008
         core_version: str | None = None,
     ) -> list[AccentPhrase]:
         style_id = get_style_id_from_deprecated(style_id=style_id, speaker_id=speaker)
@@ -451,8 +451,8 @@ def generate_app(
     )
     def synthesis(
         query: AudioQuery,
-        style_id: int | None = Query(default=None),  # noqa: B008
-        speaker: int | None = Query(default=None, deprecated=True),  # noqa: B008
+        style_id: StyleId | None = Query(default=None),  # noqa: B008
+        speaker: StyleId | None = Query(default=None, deprecated=True),  # noqa: B008
         enable_interrogative_upspeak: bool = Query(  # noqa: B008
             default=True,
             description="疑問系のテキストが与えられたら語尾を自動調整する",
@@ -494,8 +494,8 @@ def generate_app(
     def cancellable_synthesis(
         query: AudioQuery,
         request: Request,
-        style_id: int | None = Query(default=None),  # noqa: B008
-        speaker: int | None = Query(default=None, deprecated=True),  # noqa: B008
+        style_id: StyleId | None = Query(default=None),  # noqa: B008
+        speaker: StyleId | None = Query(default=None, deprecated=True),  # noqa: B008
         core_version: str | None = None,
     ) -> FileResponse:
         style_id = get_style_id_from_deprecated(style_id=style_id, speaker_id=speaker)
@@ -536,8 +536,8 @@ def generate_app(
     )
     def multi_synthesis(
         queries: list[AudioQuery],
-        style_id: int | None = Query(default=None),  # noqa: B008
-        speaker: int | None = Query(default=None, deprecated=True),  # noqa: B008
+        style_id: StyleId | None = Query(default=None),  # noqa: B008
+        speaker: StyleId | None = Query(default=None, deprecated=True),  # noqa: B008
         core_version: str | None = None,
     ) -> FileResponse:
         style_id = get_style_id_from_deprecated(style_id=style_id, speaker_id=speaker)

--- a/run.py
+++ b/run.py
@@ -322,9 +322,7 @@ def generate_app(
         else:
             raise HTTPException(status_code=422, detail="該当するプリセットIDが見つかりません")
 
-        accent_phrases = engine.create_accent_phrases(
-            text, selected_preset.style_id
-        )
+        accent_phrases = engine.create_accent_phrases(text, selected_preset.style_id)
         return AudioQuery(
             accent_phrases=accent_phrases,
             speedScale=selected_preset.speedScale,

--- a/run.py
+++ b/run.py
@@ -563,7 +563,7 @@ def generate_app(
         summary="指定した話者に対してエンジン内の話者がモーフィングが可能か判定する",
     )
     def morphable_targets(
-        base_speakers: list[int],
+        base_speakers: list[int],  # FIXME: StyleId型にする
         core_version: str | None = None,
     ) -> list[dict[str, MorphableTargetInfo]]:
         """
@@ -604,7 +604,7 @@ def generate_app(
     )
     def _synthesis_morphing(
         query: AudioQuery,
-        base_speaker: int,
+        base_speaker: int,  # FIXME: StyleId型にする
         target_speaker: int,
         morph_rate: float = Query(..., ge=0.0, le=1.0),  # noqa: B008
         core_version: str | None = None,

--- a/run.py
+++ b/run.py
@@ -34,6 +34,7 @@ from voicevox_engine.core_initializer import initialize_cores
 from voicevox_engine.engine_manifest import EngineManifestLoader
 from voicevox_engine.engine_manifest.EngineManifest import EngineManifest
 from voicevox_engine.library_manager import LibraryManager
+from voicevox_engine.metas.Metas import StyleId
 from voicevox_engine.metas.MetasStore import MetasStore, construct_lookup
 from voicevox_engine.model import (
     AccentPhrase,
@@ -46,7 +47,6 @@ from voicevox_engine.model import (
     ParseKanaError,
     Speaker,
     SpeakerInfo,
-    StyleId,
     StyleIdNotFoundError,
     SupportedDevicesInfo,
     UserDictWord,

--- a/run.py
+++ b/run.py
@@ -1354,8 +1354,7 @@ def generate_app(
             ref_template="#/components/schemas/{model}"
         )
         # definitionsは既存のモデルを重複して定義するため、不要なので削除
-        if "definitions" in base_library_info:
-            del base_library_info["definitions"]
+        del base_library_info["definitions"]
         openapi_schema["components"]["schemas"]["BaseLibraryInfo"] = base_library_info
         app.openapi_schema = openapi_schema
         return openapi_schema

--- a/test/test_mock_tts_engine.py
+++ b/test/test_mock_tts_engine.py
@@ -1,7 +1,8 @@
 from unittest import TestCase
 
 from voicevox_engine.dev.tts_engine import MockTTSEngine
-from voicevox_engine.model import AccentPhrase, AudioQuery, Mora, StyleId
+from voicevox_engine.metas.Metas import StyleId
+from voicevox_engine.model import AccentPhrase, AudioQuery, Mora
 from voicevox_engine.tts_pipeline.kana_converter import create_kana
 
 

--- a/test/test_tts_engine.py
+++ b/test/test_tts_engine.py
@@ -5,7 +5,8 @@ from unittest.mock import Mock
 
 import numpy
 
-from voicevox_engine.model import AccentPhrase, AudioQuery, Mora, StyleId
+from voicevox_engine.metas.Metas import StyleId
+from voicevox_engine.model import AccentPhrase, AudioQuery, Mora
 from voicevox_engine.tts_pipeline import TTSEngine
 from voicevox_engine.tts_pipeline.acoustic_feature_extractor import Phoneme
 from voicevox_engine.tts_pipeline.tts_engine import (

--- a/test/test_tts_engine_base.py
+++ b/test/test_tts_engine_base.py
@@ -1,7 +1,8 @@
 from unittest import TestCase
 
 from voicevox_engine.dev.core.mock import MockCoreWrapper
-from voicevox_engine.model import AccentPhrase, Mora, StyleId
+from voicevox_engine.metas.Metas import StyleId
+from voicevox_engine.model import AccentPhrase, Mora
 from voicevox_engine.tts_pipeline import TTSEngine
 from voicevox_engine.tts_pipeline.tts_engine import (
     apply_interrogative_upspeak,  # FIXME: この関数を使うテストをTTSEngine用のテストに移動する

--- a/voicevox_engine/cancellable_engine.py
+++ b/voicevox_engine/cancellable_engine.py
@@ -3,6 +3,8 @@ import queue
 import sys
 from multiprocessing import Pipe, Process
 
+from .metas.Metas import StyleId
+
 if sys.platform == "win32":
     from multiprocessing.connection import PipeConnection as ConnectionType
 else:
@@ -17,7 +19,7 @@ import soundfile
 from fastapi import HTTPException, Request
 
 from .core_initializer import initialize_cores
-from .model import AudioQuery, StyleId
+from .model import AudioQuery
 from .tts_pipeline import make_tts_engines_from_cores
 from .utility import get_latest_core_version
 

--- a/voicevox_engine/cancellable_engine.py
+++ b/voicevox_engine/cancellable_engine.py
@@ -3,8 +3,6 @@ import queue
 import sys
 from multiprocessing import Pipe, Process
 
-from .metas.Metas import StyleId
-
 if sys.platform == "win32":
     from multiprocessing.connection import PipeConnection as ConnectionType
 else:
@@ -19,6 +17,7 @@ import soundfile
 from fastapi import HTTPException, Request
 
 from .core_initializer import initialize_cores
+from .metas.Metas import StyleId
 from .model import AudioQuery
 from .tts_pipeline import make_tts_engines_from_cores
 from .utility import get_latest_core_version

--- a/voicevox_engine/core_adapter.py
+++ b/voicevox_engine/core_adapter.py
@@ -4,7 +4,7 @@ import numpy
 from numpy import ndarray
 
 from .core_wrapper import CoreWrapper, OldCoreError
-from .model import StyleId
+from .metas.Metas import StyleId
 
 
 class CoreAdapter:

--- a/voicevox_engine/dev/tts_engine/mock.py
+++ b/voicevox_engine/dev/tts_engine/mock.py
@@ -6,7 +6,8 @@ import numpy as np
 from pyopenjtalk import tts
 from soxr import resample
 
-from ...model import AudioQuery, StyleId
+from ...metas.Metas import StyleId
+from ...model import AudioQuery
 from ...tts_pipeline import TTSEngine
 from ...tts_pipeline.tts_engine import to_flatten_moras
 from ..core.mock import MockCoreWrapper

--- a/voicevox_engine/metas/Metas.py
+++ b/voicevox_engine/metas/Metas.py
@@ -3,6 +3,8 @@ from typing import List, Optional
 
 from pydantic import BaseModel, Field
 
+from voicevox_engine.model import StyleId
+
 
 class SpeakerStyle(BaseModel):
     """
@@ -10,7 +12,7 @@ class SpeakerStyle(BaseModel):
     """
 
     name: str = Field(title="スタイル名")
-    id: int = Field(title="スタイルID")
+    id: StyleId = Field(title="スタイルID")
 
 
 class SpeakerSupportPermittedSynthesisMorphing(str, Enum):
@@ -67,7 +69,7 @@ class StyleInfo(BaseModel):
     スタイルの追加情報
     """
 
-    id: int = Field(title="スタイルID")
+    id: StyleId = Field(title="スタイルID")
     icon: str = Field(title="当該スタイルのアイコンをbase64エンコードしたもの")
     portrait: Optional[str] = Field(title="当該スタイルのportrait.pngをbase64エンコードしたもの")
     voice_samples: List[str] = Field(title="voice_sampleのwavファイルをbase64エンコードしたもの")

--- a/voicevox_engine/metas/Metas.py
+++ b/voicevox_engine/metas/Metas.py
@@ -1,9 +1,9 @@
 from enum import Enum
-from typing import List, Optional
+from typing import List, NewType, Optional
 
 from pydantic import BaseModel, Field
 
-from voicevox_engine.model import StyleId
+StyleId = NewType("StyleId", int)
 
 
 class SpeakerStyle(BaseModel):

--- a/voicevox_engine/metas/Metas.py
+++ b/voicevox_engine/metas/Metas.py
@@ -3,6 +3,8 @@ from typing import List, NewType, Optional
 
 from pydantic import BaseModel, Field
 
+# NOTE: 循環importを防ぐためにとりあえずここに書いている
+# FIXME: 他のmodelに依存せず、全modelから参照できる場所に配置する
 StyleId = NewType("StyleId", int)
 
 

--- a/voicevox_engine/model.py
+++ b/voicevox_engine/model.py
@@ -1,6 +1,6 @@
 from enum import Enum
 from re import findall, fullmatch
-from typing import Any, Dict, List, NewType, Optional
+from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field, StrictStr, validator
 
@@ -43,9 +43,6 @@ class AccentPhrase(BaseModel):
             for k, v in self.__dict__.items()
         ]
         return hash(tuple(sorted(items)))
-
-
-StyleId = NewType("StyleId", int)
 
 
 class AudioQuery(BaseModel):

--- a/voicevox_engine/morphing.py
+++ b/voicevox_engine/morphing.py
@@ -52,7 +52,7 @@ def create_morphing_parameter(
 def get_morphable_targets(
     speakers: List[Speaker],
     base_speakers: List[int],
-) -> List[Dict[int, MorphableTargetInfo]]:
+) -> List[Dict[StyleId, MorphableTargetInfo]]:
     """
     speakers: 全話者の情報
     base_speakers: モーフィング可能か判定したいベースの話者リスト（スタイルID）

--- a/voicevox_engine/morphing.py
+++ b/voicevox_engine/morphing.py
@@ -8,9 +8,14 @@ import pyworld as pw
 from soxr import resample
 
 from .core_adapter import CoreAdapter
-from .metas.Metas import Speaker, SpeakerStyle, SpeakerSupportPermittedSynthesisMorphing
+from .metas.Metas import (
+    Speaker,
+    SpeakerStyle,
+    SpeakerSupportPermittedSynthesisMorphing,
+    StyleId,
+)
 from .metas.MetasStore import construct_lookup
-from .model import AudioQuery, MorphableTargetInfo, StyleId, StyleIdNotFoundError
+from .model import AudioQuery, MorphableTargetInfo, StyleIdNotFoundError
 from .tts_pipeline import TTSEngine
 
 

--- a/voicevox_engine/preset/Preset.py
+++ b/voicevox_engine/preset/Preset.py
@@ -1,6 +1,6 @@
 from pydantic import BaseModel, Field
 
-from voicevox_engine.model import StyleId
+from voicevox_engine.metas.Metas import StyleId
 
 
 class Preset(BaseModel):

--- a/voicevox_engine/preset/Preset.py
+++ b/voicevox_engine/preset/Preset.py
@@ -1,5 +1,7 @@
 from pydantic import BaseModel, Field
 
+from voicevox_engine.model import StyleId
+
 
 class Preset(BaseModel):
     """
@@ -9,7 +11,7 @@ class Preset(BaseModel):
     id: int = Field(title="プリセットID")
     name: str = Field(title="プリセット名")
     speaker_uuid: str = Field(title="話者のUUID")
-    style_id: int = Field(title="スタイルID")
+    style_id: StyleId = Field(title="スタイルID")
     speedScale: float = Field(title="全体の話速")
     pitchScale: float = Field(title="全体の音高")
     intonationScale: float = Field(title="全体の抑揚")

--- a/voicevox_engine/tts_pipeline/tts_engine.py
+++ b/voicevox_engine/tts_pipeline/tts_engine.py
@@ -7,7 +7,8 @@ from soxr import resample
 
 from ..core_adapter import CoreAdapter
 from ..core_wrapper import CoreWrapper
-from ..model import AccentPhrase, AudioQuery, Mora, StyleId
+from ..metas.Metas import StyleId
+from ..model import AccentPhrase, AudioQuery, Mora
 from .acoustic_feature_extractor import Phoneme
 from .mora_list import openjtalk_mora2text
 from .text_analyzer import text_to_accent_phrases


### PR DESCRIPTION
## 内容

- https://github.com/VOICEVOX/voicevox_engine/pull/965

の続きです。
タイトルの通りで、ついでにSpeakerStyle.idやPreset.style_idもStyleId型にしています。

## その他

よかったら @tarepan さんレビューいただけると･･･！