### PR TITLE
audio_queryのe2eテスト

### DIFF
--- a/test/e2e/__snapshots__/test_audio_query/test_speakerを指定しても音声合成クエリが取得できる.json
+++ b/test/e2e/__snapshots__/test_audio_query/test_speakerを指定しても音声合成クエリが取得できる.json
@@ -1,0 +1,60 @@
+{
+  "accent_phrases": [
+    {
+      "accent": 1,
+      "is_interrogative": false,
+      "moras": [
+        {
+          "consonant": "t",
+          "consonant_length": 2.31,
+          "pitch": 3.38,
+          "text": "テ",
+          "vowel": "e",
+          "vowel_length": 0.88
+        },
+        {
+          "consonant": "s",
+          "consonant_length": 2.19,
+          "pitch": 0.0,
+          "text": "ス",
+          "vowel": "U",
+          "vowel_length": 0.38
+        },
+        {
+          "consonant": "t",
+          "consonant_length": 2.31,
+          "pitch": 4.19,
+          "text": "ト",
+          "vowel": "o",
+          "vowel_length": 1.88
+        },
+        {
+          "consonant": "d",
+          "consonant_length": 0.75,
+          "pitch": 1.62,
+          "text": "デ",
+          "vowel": "e",
+          "vowel_length": 0.88
+        },
+        {
+          "consonant": "s",
+          "consonant_length": 2.19,
+          "pitch": 0.0,
+          "text": "ス",
+          "vowel": "U",
+          "vowel_length": 0.38
+        }
+      ],
+      "pause_mora": null
+    }
+  ],
+  "intonationScale": 1.0,
+  "kana": "テ'_ストデ_ス",
+  "outputSamplingRate": 24000,
+  "outputStereo": false,
+  "pitchScale": 0.0,
+  "postPhonemeLength": 0.1,
+  "prePhonemeLength": 0.1,
+  "speedScale": 1.0,
+  "volumeScale": 1.0
+}

--- a/test/e2e/__snapshots__/test_audio_query/test_style_idを指定して音声合成クエリが取得できる.json
+++ b/test/e2e/__snapshots__/test_audio_query/test_style_idを指定して音声合成クエリが取得できる.json
@@ -1,0 +1,60 @@
+{
+  "accent_phrases": [
+    {
+      "accent": 1,
+      "is_interrogative": false,
+      "moras": [
+        {
+          "consonant": "t",
+          "consonant_length": 2.31,
+          "pitch": 3.38,
+          "text": "テ",
+          "vowel": "e",
+          "vowel_length": 0.88
+        },
+        {
+          "consonant": "s",
+          "consonant_length": 2.19,
+          "pitch": 0.0,
+          "text": "ス",
+          "vowel": "U",
+          "vowel_length": 0.38
+        },
+        {
+          "consonant": "t",
+          "consonant_length": 2.31,
+          "pitch": 4.19,
+          "text": "ト",
+          "vowel": "o",
+          "vowel_length": 1.88
+        },
+        {
+          "consonant": "d",
+          "consonant_length": 0.75,
+          "pitch": 1.62,
+          "text": "デ",
+          "vowel": "e",
+          "vowel_length": 0.88
+        },
+        {
+          "consonant": "s",
+          "consonant_length": 2.19,
+          "pitch": 0.0,
+          "text": "ス",
+          "vowel": "U",
+          "vowel_length": 0.38
+        }
+      ],
+      "pause_mora": null
+    }
+  ],
+  "intonationScale": 1.0,
+  "kana": "テ'_ストデ_ス",
+  "outputSamplingRate": 24000,
+  "outputStereo": false,
+  "pitchScale": 0.0,
+  "postPhonemeLength": 0.1,
+  "prePhonemeLength": 0.1,
+  "speedScale": 1.0,
+  "volumeScale": 1.0
+}

--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -28,7 +28,7 @@ def snapshot_json(snapshot: SnapshotAssertion) -> SnapshotAssertion:
 
 @pytest.fixture(scope="session")
 def app_params():
-    cores = initialize_cores(use_gpu=False)
+    cores = initialize_cores(use_gpu=False, enable_mock=True)
     tts_engines = make_tts_engines_from_cores(cores)
     latest_core_version = get_latest_core_version(versions=list(tts_engines.keys()))
     setting_loader = SettingLoader(Path("./not_exist.yaml"))

--- a/test/e2e/test_audio_query.py
+++ b/test/e2e/test_audio_query.py
@@ -1,0 +1,29 @@
+"""
+AudioQuery APIのテスト
+"""
+
+from fastapi.testclient import TestClient
+from syrupy.extensions.json import JSONSnapshotExtension
+
+
+def test_style_idを指定して音声合成クエリが取得できる(
+    client: TestClient, snapshot_json: JSONSnapshotExtension
+) -> None:
+    response = client.post("/audio_query", params={"text": "テストです", "style_id": 0})
+    assert response.status_code == 200
+    assert snapshot_json == response.json()
+
+
+def test_speakerを指定しても音声合成クエリが取得できる(
+    client: TestClient, snapshot_json: JSONSnapshotExtension
+) -> None:
+    response = client.post("/audio_query", params={"text": "テストです", "speaker": 0})
+    assert response.status_code == 200
+    assert snapshot_json == response.json()
+
+
+def test_style_idとspeakerを両方指定するとエラー(client: TestClient) -> None:
+    response = client.post(
+        "/audio_query", params={"text": "テストです", "style_id": 0, "speaker": 0}
+    )
+    assert response.status_code == 400


### PR DESCRIPTION
## 内容

↓のチェックにあると便利そうだったので導入しました。

- https://github.com/VOICEVOX/voicevox_engine/pull/826



## 関連 Issue

- https://github.com/VOICEVOX/voicevox_engine/issues/730

## その他

スナップショットファイルと目的の対応がわかりやすい＆テストの内容がわかりやすいように、`def test_[テストの目的]`という関数を許容する方針の提案も含んでいます。
こうしておけば、何を対象としているのかわかりやすくなり、テストの目的コメントを省けて、スナップショットのわかりやすいファイル名を書き足す必要もなくなるので、良いかなと･･･。

（テストフレームワークが充実していれば、`it("テストの目的")`みたいな形で[書ける](https://github.com/VOICEVOX/voicevox/blob/fb340815ebb1b2afcc516d54625fffc10cc36f97/tests/e2e/browser/%E8%A4%87%E6%95%B0%E9%81%B8%E6%8A%9E/%E5%80%A4%E5%A4%89%E6%9B%B4.spec.ts#L80)のですが。。）

@y-chan さんや @takana-v さんや @tarepan さん的にどうでしょう･･･？
