### PR TITLE
追加: テキスト分析のテスト

### DIFF
--- a/test/test_acoustic_feature_extractor.py
+++ b/test/test_acoustic_feature_extractor.py
@@ -1,8 +1,20 @@
 from unittest import TestCase
 
+import pytest
+
 from voicevox_engine.tts_pipeline.acoustic_feature_extractor import Phoneme
 
 TRUE_NUM_PHONEME = 45
+
+
+def test_unknown_phoneme():
+    """Unknown音素 `xx` のID取得を拒否する"""
+    # Inputs
+    unknown_phoneme = Phoneme("xx")
+
+    # Tests
+    with pytest.raises(ValueError) as _:
+        _ = unknown_phoneme.phoneme_id
 
 
 class TestPhoneme(TestCase):

--- a/test/test_text_analyzer.py
+++ b/test/test_text_analyzer.py
@@ -365,8 +365,8 @@ def test_text_to_accent_phrases_normal():
     assert accent_phrases == true_accent_phrases
 
 
-def fixed_features_koxx(_: str) -> list[str]:
-    # sil-k-o-xx-sil
+def stub_unknown_features_koxx(_: str) -> list[str]:
+    """`sil-k-o-xx-sil` に相当する features を常に返す `text_to_features()` のStub"""
     return [
         ".^.-sil+.=./A:.+xx+./B:.-._./C:._.+./D:.+._./E:._.!._.-./F:xx_xx#xx_.@xx_.|._./G:._.%._._./H:._./I:.-.@xx+.&.-.|.+./J:._./K:.+.-.",
         ".^.-k+.=./A:.+1+./B:.-._./C:._.+./D:.+._./E:._.!._.-./F:2_1#0_.@1_.|._./G:._.%._._./H:._./I:.-.@1+.&.-.|.+./J:._./K:.+.-.",
@@ -390,6 +390,8 @@ def test_text_to_accent_phrases_unknown():
         ),
     ]
     # Outputs
-    accent_phrases = text_to_accent_phrases("koxx", fixed_features_koxx)
+    accent_phrases = text_to_accent_phrases(
+        "dummy", text_to_features=stub_unknown_features_koxx
+    )
     # Tests
     assert accent_phrases == true_accent_phrases

--- a/test/test_text_analyzer.py
+++ b/test/test_text_analyzer.py
@@ -367,7 +367,6 @@ def test_text_to_accent_phrases_normal():
 
 def fixed_features_koxx(_: str) -> list[str]:
     # sil-k-o-xx-sil
-    # p3 phoneme / a2 moraIdx / f1 n_mora / f2 pos_accent / f3 疑問形 / f5 アクセント句Idx / i3 BreathGroupIdx  # noqa: B950
     return [
         ".^.-sil+.=./A:.+xx+./B:.-._./C:._.+./D:.+._./E:._.!._.-./F:xx_xx#xx_.@xx_.|._./G:._.%._._./H:._./I:.-.@xx+.&.-.|.+./J:._./K:.+.-.",
         ".^.-k+.=./A:.+1+./B:.-._./C:._.+./D:.+._./E:._.!._.-./F:2_1#0_.@1_.|._./G:._.%._._./H:._./I:.-.@1+.&.-.|.+./J:._./K:.+.-.",

--- a/voicevox_engine/tts_pipeline/text_analyzer.py
+++ b/voicevox_engine/tts_pipeline/text_analyzer.py
@@ -59,6 +59,7 @@ class Label:
     def from_feature(cls, feature: str) -> Self:
         """OpenJTalk feature から Label インスタンスを生成する"""
         # フルコンテキストラベルの仕様は、http://hts.sp.nitech.ac.jp/?Download の HTS-2.3のJapanese tar.bz2 (126 MB)をダウンロードして、data/lab_format.pdfを見るとリストが見つかります。 # noqa
+        # VOICEVOX ENGINE で利用されている属性: p3 phoneme / a2 moraIdx / f1 n_mora / f2 pos_accent / f3 疑問形 / f5 アクセント句Idx / i3 BreathGroupIdx  # noqa: B950
         result = re.search(
             r"^(?P<p1>.+?)\^(?P<p2>.+?)\-(?P<p3>.+?)\+(?P<p4>.+?)\=(?P<p5>.+?)"
             r"/A\:(?P<a1>.+?)\+(?P<a2>.+?)\+(?P<a3>.+?)"

--- a/voicevox_engine/tts_pipeline/text_analyzer.py
+++ b/voicevox_engine/tts_pipeline/text_analyzer.py
@@ -1,7 +1,7 @@
 import re
 from dataclasses import dataclass
 from itertools import chain
-from typing import Literal, Self
+from typing import Callable, Literal, Self
 
 import pyopenjtalk
 
@@ -332,13 +332,16 @@ def _utterance_to_accent_phrases(utterance: UtteranceLabel) -> list[AccentPhrase
     ]
 
 
-def text_to_accent_phrases(text: str) -> list[AccentPhrase]:
+def text_to_accent_phrases(
+    text: str,
+    text_to_features: Callable[[str], list[str]] = pyopenjtalk.extract_fullcontext,
+) -> list[AccentPhrase]:
     """日本語文からアクセント句系列を生成する"""
     if len(text.strip()) == 0:
         return []
 
     # 日本語文からUtteranceLabelを抽出する
-    features: list[str] = pyopenjtalk.extract_fullcontext(text)  # type: ignore
+    features = text_to_features(text)
     utterance = UtteranceLabel.from_labels(list(map(Label.from_feature, features)))
 
     # ドメインを変換する


### PR DESCRIPTION
## 内容
テキスト分析のテストを追加

現在のテキスト分析モジュール `text_analyzer` は中心的関数である `text_to_accent_phrases()` をテストしていない。  
またこの関数は pyopenjtalk へ 直接 call 形式で依存しており、異常系テストが困難である。  
また現在の VOICEVOX ENGINE は `text_analyzer` の異常系出力が正常系に乗って下流モジュールに伝播する仕様となっているが、そのテストもなされていない。  
すなわち、テキスト分析関連テストに関する改良の余地が多分にある。  

よってテキスト分析のテスト関連改良を提案します。  

具体的には次の改良を提案する：  

- `pyopenjtalk` の DI (`text_to_features` 引数の追加)
- `text_to_accent_phrases()` の正常系テスト
- `text_to_accent_phrases()` の異常系テスト (`xx` 音素への応答)
- 下流 `Phoneme` クラスの異常系テスト (`xx` 音素への応答)

## 関連 Issue
ref #894