### PR TITLE
廃止: `pre_process()`

### DIFF
--- a/test/tts_pipeline/test_tts_engine.py
+++ b/test/tts_pipeline/test_tts_engine.py
@@ -23,7 +23,6 @@ from voicevox_engine.tts_pipeline.tts_engine import (
     apply_speed_scale,
     apply_volume_scale,
     count_frame_per_unit,
-    pre_process,
     query_to_decoder_feature,
     raw_wave_to_output_wave,
     split_mora,
@@ -528,42 +527,6 @@ class TestTTSEngine(TestCase):
             true_accent_phrases_hello_hiho[0].moras
             + [true_accent_phrases_hello_hiho[0].pause_mora]
             + true_accent_phrases_hello_hiho[1].moras,
-        )
-
-    def test_pre_process(self):
-        flatten_moras, phoneme_data_list = pre_process(_gen_hello_hiho_accent_phrases())
-
-        mora_index = 0
-        phoneme_index = 1
-
-        self.assertTrue(is_same_phoneme(phoneme_data_list[0], Phoneme("pau")))
-        for accent_phrase in _gen_hello_hiho_accent_phrases():
-            moras = accent_phrase.moras
-            for mora in moras:
-                self.assertEqual(flatten_moras[mora_index], mora)
-                mora_index += 1
-                if mora.consonant is not None:
-                    self.assertTrue(
-                        is_same_phoneme(
-                            phoneme_data_list[phoneme_index], Phoneme(mora.consonant)
-                        )
-                    )
-                    phoneme_index += 1
-                self.assertTrue(
-                    is_same_phoneme(
-                        phoneme_data_list[phoneme_index], Phoneme(mora.vowel)
-                    )
-                )
-                phoneme_index += 1
-            if accent_phrase.pause_mora:
-                self.assertEqual(flatten_moras[mora_index], accent_phrase.pause_mora)
-                mora_index += 1
-                self.assertTrue(
-                    is_same_phoneme(phoneme_data_list[phoneme_index], Phoneme("pau"))
-                )
-                phoneme_index += 1
-        self.assertTrue(
-            is_same_phoneme(phoneme_data_list[phoneme_index], Phoneme("pau"))
         )
 
     def test_update_length(self):

--- a/voicevox_engine/tts_pipeline/tts_engine.py
+++ b/voicevox_engine/tts_pipeline/tts_engine.py
@@ -69,19 +69,6 @@ def split_mora(phonemes: list[Phoneme]) -> tuple[list[Phoneme | None], list[Phon
     return consonants, vowels
 
 
-def pre_process(
-    accent_phrases: list[AccentPhrase],
-) -> tuple[list[Mora], list[Phoneme]]:
-    """アクセント句系列から（前後の無音含まない）モーラ系列と（前後の無音含む）音素系列を抽出する"""
-    flatten_moras = to_flatten_moras(accent_phrases)
-    phonemes = to_flatten_phonemes(flatten_moras)
-
-    # 前後無音の追加
-    phonemes = [Phoneme("pau")] + phonemes + [Phoneme("pau")]
-
-    return flatten_moras, phonemes
-
-
 def generate_silence_mora(length: float) -> Mora:
     """無音モーラの生成"""
     return Mora(text="　", vowel="sil", vowel_length=length, pitch=0.0)
@@ -360,7 +347,9 @@ class TTSEngine:
         end_accent_phrase_list = np.array(end_accent_phrase_list, dtype=np.int64)
 
         # アクセント句系列から（前後の無音含まない）モーラ系列と（前後の無音含む）音素系列を抽出する
-        moras, phonemes = pre_process(accent_phrases)
+        moras = to_flatten_moras(accent_phrases)
+        phonemes = to_flatten_phonemes(moras)
+        phonemes = [Phoneme("pau")] + phonemes + [Phoneme("pau")]
 
         # 前後無音付加済みの音素系列から子音ID系列・母音ID系列を抽出する
         consonants, vowels = split_mora(phonemes)


### PR DESCRIPTION
## 内容
`pre_process()` の廃止

`pre_process()` は3行のコードからなる小さい関数であり、そのうち2行で使われている関数は個別にテストされている。  
また `pre_process()` は1箇所からのみ call されている。  

このような背景から、`pre_process()` とそのテストの廃止を提案します。  

## 関連 Issue
part of #801

## Reviewer 向け情報
### 依存 issues
review が可能です
<del>以下の issues/ PRs に依存しているため、これら解消後に review が可能です：</del>  

- [x] #974