### PR TITLE
pyinstallerのbootloaderの自前ビルドにおまじない効果があるっぽいことをコメント追記する

### DIFF
--- a/build_util/modify_pyinstaller.bash
+++ b/build_util/modify_pyinstaller.bash
@@ -4,6 +4,8 @@
 # 良いGPUが自動的に選択されるようにしている
 # https://github.com/VOICEVOX/voicevox_engine/issues/502
 
+# 自前ビルドすることでブートローダーのハッシュ値が変わってウイルス判定を回避する効果もあるかも
+
 set -eux
 
 pyinstaller_version=$(pyinstaller -v)


### PR DESCRIPTION
## 内容

Discordで話題に上がっていた点をメモしてみました。

* Pyinstallerを使ってビルドするとウイルス判定されやすいらしい
* でもブートローダーを自前ビルドしているとハッシュが変わって判定をほぼ回避できるらしい
* VOICEVOX ENGINEは偶然それをやっていたので、該当箇所にコメントを追加してみました。
* https://twitter.com/izutorishima/status/1743241430263636208


## その他

本当におまじないレベルな気がしないでもないですが、もしかしたら意味があるかもなので残しておきたいなと。。
