### PR TITLE
追加: `TTSEngine.create_accent_phrases_from_kana()`

### DIFF
--- a/run.py
+++ b/run.py
@@ -384,15 +384,11 @@ def generate_app(
         engine = get_engine(core_version)
         if is_kana:
             try:
-                accent_phrases = parse_kana(text)
+                return engine.create_accent_phrases_from_kana(text, style_id)
             except ParseKanaError as err:
                 raise HTTPException(
-                    status_code=400,
-                    detail=ParseKanaBadRequest(err).dict(),
+                    status_code=400, detail=ParseKanaBadRequest(err).dict()
                 )
-            accent_phrases = engine.update_length_and_pitch(accent_phrases, style_id)
-
-            return accent_phrases
         else:
             return engine.create_accent_phrases(text, style_id)
 

--- a/voicevox_engine/tts_pipeline/tts_engine.py
+++ b/voicevox_engine/tts_pipeline/tts_engine.py
@@ -10,6 +10,7 @@ from ..core_wrapper import CoreWrapper
 from ..metas.Metas import StyleId
 from ..model import AccentPhrase, AudioQuery, Mora
 from .acoustic_feature_extractor import Phoneme
+from .kana_converter import parse_kana
 from .mora_list import mora_phonemes_to_mora_kana
 from .text_analyzer import text_to_accent_phrases
 
@@ -417,6 +418,14 @@ class TTSEngine:
     def create_accent_phrases(self, text: str, style_id: StyleId) -> list[AccentPhrase]:
         """テキストからアクセント句系列を生成し、スタイルIDに基づいてその音素長・モーラ音高を更新する"""
         accent_phrases = text_to_accent_phrases(text)
+        accent_phrases = self.update_length_and_pitch(accent_phrases, style_id)
+        return accent_phrases
+
+    def create_accent_phrases_from_kana(
+        self, kana: str, style_id: StyleId
+    ) -> list[AccentPhrase]:
+        """AquesTalk 風記法テキストからアクセント句系列を生成し、スタイルIDに基づいてその音素長・モーラ音高を更新する"""
+        accent_phrases = parse_kana(kana)
         accent_phrases = self.update_length_and_pitch(accent_phrases, style_id)
         return accent_phrases
 


### PR DESCRIPTION
## 内容
`TTSEngine.create_accent_phrases_from_kana()` の追加

VOICEVOX ENGINE では TTS 関連機能を `TTSEngine` クラスへ集約し、`run.py` でそのメソッドをコールしている。  
しかし `run.py` の `accent_phrases(is_kana=True)` では個別関数を複数コールしている。  
これらは `TTSEngine` へ集約できる。  

このような背景から、`is_kana=True` フローを集約した `TTSEngine.create_accent_phrases_from_kana()` の追加を提案します。  

## 関連 Issue
無し