### PR TITLE
TYP: numpyの型情報を追加

### DIFF
--- a/voicevox_engine/core_adapter.py
+++ b/voicevox_engine/core_adapter.py
@@ -1,7 +1,7 @@
 import threading
 
-import numpy
-from numpy import ndarray
+import numpy as np
+import numpy.typing as npt
 
 from .core_wrapper import CoreWrapper, OldCoreError
 from .metas.Metas import StyleId
@@ -67,55 +67,58 @@ class CoreAdapter:
             return True  # コアが古い場合はどうしようもないのでTrueを返す
 
     def safe_yukarin_s_forward(
-        self, phoneme_list_s: ndarray, style_id: StyleId
-    ) -> ndarray:
+        self, phoneme_list_s: npt.NDArray[np.integer], style_id: StyleId
+    ) -> npt.NDArray[np.float32]:
         # 「指定スタイルを初期化」「mutexによる安全性」「系列長・データ型に関するアダプター」を提供する
         self.initialize_style_id_synthesis(style_id, skip_reinit=True)
         with self.mutex:
             phoneme_length = self.core.yukarin_s_forward(
                 length=len(phoneme_list_s),
                 phoneme_list=phoneme_list_s,
-                style_id=numpy.array(style_id, dtype=numpy.int64).reshape(-1),
+                style_id=np.array(style_id, dtype=np.int64).reshape(-1),
             )
         return phoneme_length
 
     def safe_yukarin_sa_forward(
         self,
-        vowel_phoneme_list: ndarray,
-        consonant_phoneme_list: ndarray,
-        start_accent_list: ndarray,
-        end_accent_list: ndarray,
-        start_accent_phrase_list: ndarray,
-        end_accent_phrase_list: ndarray,
+        vowel_phoneme_list: npt.NDArray[np.integer],
+        consonant_phoneme_list: npt.NDArray[np.integer],
+        start_accent_list: npt.NDArray[np.integer],
+        end_accent_list: npt.NDArray[np.integer],
+        start_accent_phrase_list: npt.NDArray[np.integer],
+        end_accent_phrase_list: npt.NDArray[np.integer],
         style_id: StyleId,
-    ) -> ndarray:
+    ) -> npt.NDArray[np.float32]:
         # 「指定スタイルを初期化」「mutexによる安全性」「系列長・データ型に関するアダプター」を提供する
         self.initialize_style_id_synthesis(style_id, skip_reinit=True)
         with self.mutex:
             f0_list = self.core.yukarin_sa_forward(
                 length=vowel_phoneme_list.shape[0],
-                vowel_phoneme_list=vowel_phoneme_list[numpy.newaxis],
-                consonant_phoneme_list=consonant_phoneme_list[numpy.newaxis],
-                start_accent_list=start_accent_list[numpy.newaxis],
-                end_accent_list=end_accent_list[numpy.newaxis],
-                start_accent_phrase_list=start_accent_phrase_list[numpy.newaxis],
-                end_accent_phrase_list=end_accent_phrase_list[numpy.newaxis],
-                style_id=numpy.array(style_id, dtype=numpy.int64).reshape(-1),
+                vowel_phoneme_list=vowel_phoneme_list[np.newaxis],
+                consonant_phoneme_list=consonant_phoneme_list[np.newaxis],
+                start_accent_list=start_accent_list[np.newaxis],
+                end_accent_list=end_accent_list[np.newaxis],
+                start_accent_phrase_list=start_accent_phrase_list[np.newaxis],
+                end_accent_phrase_list=end_accent_phrase_list[np.newaxis],
+                style_id=np.array(style_id, dtype=np.int64).reshape(-1),
             )[0]
         return f0_list
 
     def safe_decode_forward(
-        self, phoneme: ndarray, f0: ndarray, style_id: StyleId
-    ) -> tuple[ndarray, int]:
+        self,
+        phoneme: npt.NDArray[np.floating],
+        f0: npt.NDArray[np.floating],
+        style_id: StyleId,
+    ) -> tuple[npt.NDArray[np.float32], int]:
         # 「指定スタイルを初期化」「mutexによる安全性」「系列長・データ型に関するアダプター」を提供する
         self.initialize_style_id_synthesis(style_id, skip_reinit=True)
         with self.mutex:
             wave = self.core.decode_forward(
                 length=phoneme.shape[0],
                 phoneme_size=phoneme.shape[1],
-                f0=f0[:, numpy.newaxis],
+                f0=f0[:, np.newaxis],
                 phoneme=phoneme,
-                style_id=numpy.array(style_id, dtype=numpy.int64).reshape(-1),
+                style_id=np.array(style_id, dtype=np.int64).reshape(-1),
             )
         sr_wave = self.default_sampling_rate
         return wave, sr_wave

--- a/voicevox_engine/core_adapter.py
+++ b/voicevox_engine/core_adapter.py
@@ -1,7 +1,7 @@
 import threading
 
 import numpy as np
-import numpy.typing as npt
+from numpy.typing import NDArray
 
 from .core_wrapper import CoreWrapper, OldCoreError
 from .metas.Metas import StyleId
@@ -67,8 +67,8 @@ class CoreAdapter:
             return True  # コアが古い場合はどうしようもないのでTrueを返す
 
     def safe_yukarin_s_forward(
-        self, phoneme_list_s: npt.NDArray[np.integer], style_id: StyleId
-    ) -> npt.NDArray[np.float32]:
+        self, phoneme_list_s: NDArray[np.integer], style_id: StyleId
+    ) -> NDArray[np.float32]:
         # 「指定スタイルを初期化」「mutexによる安全性」「系列長・データ型に関するアダプター」を提供する
         self.initialize_style_id_synthesis(style_id, skip_reinit=True)
         with self.mutex:
@@ -81,14 +81,14 @@ class CoreAdapter:
 
     def safe_yukarin_sa_forward(
         self,
-        vowel_phoneme_list: npt.NDArray[np.integer],
-        consonant_phoneme_list: npt.NDArray[np.integer],
-        start_accent_list: npt.NDArray[np.integer],
-        end_accent_list: npt.NDArray[np.integer],
-        start_accent_phrase_list: npt.NDArray[np.integer],
-        end_accent_phrase_list: npt.NDArray[np.integer],
+        vowel_phoneme_list: NDArray[np.integer],
+        consonant_phoneme_list: NDArray[np.integer],
+        start_accent_list: NDArray[np.integer],
+        end_accent_list: NDArray[np.integer],
+        start_accent_phrase_list: NDArray[np.integer],
+        end_accent_phrase_list: NDArray[np.integer],
         style_id: StyleId,
-    ) -> npt.NDArray[np.float32]:
+    ) -> NDArray[np.float32]:
         # 「指定スタイルを初期化」「mutexによる安全性」「系列長・データ型に関するアダプター」を提供する
         self.initialize_style_id_synthesis(style_id, skip_reinit=True)
         with self.mutex:
@@ -106,10 +106,10 @@ class CoreAdapter:
 
     def safe_decode_forward(
         self,
-        phoneme: npt.NDArray[np.floating],
-        f0: npt.NDArray[np.floating],
+        phoneme: NDArray[np.floating],
+        f0: NDArray[np.floating],
         style_id: StyleId,
-    ) -> tuple[npt.NDArray[np.float32], int]:
+    ) -> tuple[NDArray[np.float32], int]:
         # 「指定スタイルを初期化」「mutexによる安全性」「系列長・データ型に関するアダプター」を提供する
         self.initialize_style_id_synthesis(style_id, skip_reinit=True)
         with self.mutex:

--- a/voicevox_engine/core_adapter.py
+++ b/voicevox_engine/core_adapter.py
@@ -106,8 +106,8 @@ class CoreAdapter:
 
     def safe_decode_forward(
         self,
-        phoneme: NDArray[np.floating],
-        f0: NDArray[np.floating],
+        phoneme: NDArray[np.float32],
+        f0: NDArray[np.float32],
         style_id: StyleId,
     ) -> tuple[NDArray[np.float32], int]:
         # 「指定スタイルを初期化」「mutexによる安全性」「系列長・データ型に関するアダプター」を提供する

--- a/voicevox_engine/core_adapter.py
+++ b/voicevox_engine/core_adapter.py
@@ -67,7 +67,7 @@ class CoreAdapter:
             return True  # コアが古い場合はどうしようもないのでTrueを返す
 
     def safe_yukarin_s_forward(
-        self, phoneme_list_s: NDArray[np.integer], style_id: StyleId
+        self, phoneme_list_s: NDArray[np.int64], style_id: StyleId
     ) -> NDArray[np.float32]:
         # 「指定スタイルを初期化」「mutexによる安全性」「系列長・データ型に関するアダプター」を提供する
         self.initialize_style_id_synthesis(style_id, skip_reinit=True)
@@ -81,12 +81,12 @@ class CoreAdapter:
 
     def safe_yukarin_sa_forward(
         self,
-        vowel_phoneme_list: NDArray[np.integer],
-        consonant_phoneme_list: NDArray[np.integer],
-        start_accent_list: NDArray[np.integer],
-        end_accent_list: NDArray[np.integer],
-        start_accent_phrase_list: NDArray[np.integer],
-        end_accent_phrase_list: NDArray[np.integer],
+        vowel_phoneme_list: NDArray[np.int64],
+        consonant_phoneme_list: NDArray[np.int64],
+        start_accent_list: NDArray[np.int64],
+        end_accent_list: NDArray[np.int64],
+        start_accent_phrase_list: NDArray[np.int64],
+        end_accent_phrase_list: NDArray[np.int64],
         style_id: StyleId,
     ) -> NDArray[np.float32]:
         # 「指定スタイルを初期化」「mutexによる安全性」「系列長・データ型に関するアダプター」を提供する

--- a/voicevox_engine/core_wrapper.py
+++ b/voicevox_engine/core_wrapper.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Literal
 
 import numpy as np
-import numpy.typing as npt
+from numpy.typing import NDArray
 
 
 class OldCoreError(Exception):
@@ -528,22 +528,22 @@ class CoreWrapper:
     def yukarin_s_forward(
         self,
         length: int,
-        phoneme_list: npt.NDArray[np.integer],
-        style_id: npt.NDArray[np.integer],
-    ) -> npt.NDArray[np.float32]:
+        phoneme_list: NDArray[np.integer],
+        style_id: NDArray[np.integer],
+    ) -> NDArray[np.float32]:
         """
         音素列から、音素ごとの長さを求める関数
         Parameters
         ----------
         length : int
             音素列の長さ
-        phoneme_list : npt.NDArray[np.integer]
+        phoneme_list : NDArray[np.integer]
             音素列
-        style_id : npt.NDArray[np.integer]
+        style_id : NDArray[np.integer]
             スタイル番号
         Returns
         -------
-        output : npt.NDArray[np.float32]
+        output : NDArray[np.float32]
             音素ごとの長さ
         """
         output = np.zeros((length,), dtype=np.float32)
@@ -560,37 +560,37 @@ class CoreWrapper:
     def yukarin_sa_forward(
         self,
         length: int,
-        vowel_phoneme_list: npt.NDArray[np.integer],
-        consonant_phoneme_list: npt.NDArray[np.integer],
-        start_accent_list: npt.NDArray[np.integer],
-        end_accent_list: npt.NDArray[np.integer],
-        start_accent_phrase_list: npt.NDArray[np.integer],
-        end_accent_phrase_list: npt.NDArray[np.integer],
-        style_id: npt.NDArray[np.integer],
-    ) -> npt.NDArray[np.float32]:
+        vowel_phoneme_list: NDArray[np.integer],
+        consonant_phoneme_list: NDArray[np.integer],
+        start_accent_list: NDArray[np.integer],
+        end_accent_list: NDArray[np.integer],
+        start_accent_phrase_list: NDArray[np.integer],
+        end_accent_phrase_list: NDArray[np.integer],
+        style_id: NDArray[np.integer],
+    ) -> NDArray[np.float32]:
         """
         モーラごとの音素列とアクセント情報から、モーラごとの音高を求める関数
         Parameters
         ----------
         length : int
             モーラ列の長さ
-        vowel_phoneme_list : npt.NDArray[np.integer]
+        vowel_phoneme_list : NDArray[np.integer]
             母音の音素列
-        consonant_phoneme_list : npt.NDArray[np.integer]
+        consonant_phoneme_list : NDArray[np.integer]
             子音の音素列
-        start_accent_list : npt.NDArray[np.integer]
+        start_accent_list : NDArray[np.integer]
         アクセントの開始位置
-        end_accent_list : npt.NDArray[np.integer]
+        end_accent_list : NDArray[np.integer]
             アクセントの終了位置
-        start_accent_phrase_list : npt.NDArray[np.integer]
+        start_accent_phrase_list : NDArray[np.integer]
             アクセント句の開始位置
-        end_accent_phrase_list : npt.NDArray[np.integer]
+        end_accent_phrase_list : NDArray[np.integer]
             アクセント句の終了位置
-        style_id : npt.NDArray[np.integer]
+        style_id : NDArray[np.integer]
             スタイル番号
         Returns
         -------
-        output : npt.NDArray[np.float32]
+        output : NDArray[np.float32]
             モーラごとの音高
         """
         output = np.empty(
@@ -619,10 +619,10 @@ class CoreWrapper:
         self,
         length: int,
         phoneme_size: int,
-        f0: npt.NDArray[np.floating],
-        phoneme: npt.NDArray[np.floating],
-        style_id: npt.NDArray[np.integer],
-    ) -> npt.NDArray[np.float32]:
+        f0: NDArray[np.floating],
+        phoneme: NDArray[np.floating],
+        style_id: NDArray[np.integer],
+    ) -> NDArray[np.float32]:
         """
         フレームごとの音素と音高から波形を求める関数
         Parameters
@@ -631,15 +631,15 @@ class CoreWrapper:
             フレームの長さ
         phoneme_size : int
             音素の種類数
-        f0 : npt.NDArray[np.floating]
+        f0 : NDArray[np.floating]
             フレームごとの音高
-        phoneme : npt.NDArray[np.floating]
+        phoneme : NDArray[np.floating]
             フレームごとの音素
-        style_id : npt.NDArray[np.integer]
+        style_id : NDArray[np.integer]
             スタイル番号
         Returns
         -------
-        output : npt.NDArray[np.float32]
+        output : NDArray[np.float32]
             音声波形
         """
 

--- a/voicevox_engine/core_wrapper.py
+++ b/voicevox_engine/core_wrapper.py
@@ -528,8 +528,8 @@ class CoreWrapper:
     def yukarin_s_forward(
         self,
         length: int,
-        phoneme_list: NDArray[np.integer],
-        style_id: NDArray[np.integer],
+        phoneme_list: NDArray[np.int64],
+        style_id: NDArray[np.int64],
     ) -> NDArray[np.float32]:
         """
         音素列から、音素ごとの長さを求める関数
@@ -537,9 +537,9 @@ class CoreWrapper:
         ----------
         length : int
             音素列の長さ
-        phoneme_list : NDArray[np.integer]
+        phoneme_list : NDArray[np.int64]
             音素列
-        style_id : NDArray[np.integer]
+        style_id : NDArray[np.int64]
             スタイル番号
         Returns
         -------
@@ -560,13 +560,13 @@ class CoreWrapper:
     def yukarin_sa_forward(
         self,
         length: int,
-        vowel_phoneme_list: NDArray[np.integer],
-        consonant_phoneme_list: NDArray[np.integer],
-        start_accent_list: NDArray[np.integer],
-        end_accent_list: NDArray[np.integer],
-        start_accent_phrase_list: NDArray[np.integer],
-        end_accent_phrase_list: NDArray[np.integer],
-        style_id: NDArray[np.integer],
+        vowel_phoneme_list: NDArray[np.int64],
+        consonant_phoneme_list: NDArray[np.int64],
+        start_accent_list: NDArray[np.int64],
+        end_accent_list: NDArray[np.int64],
+        start_accent_phrase_list: NDArray[np.int64],
+        end_accent_phrase_list: NDArray[np.int64],
+        style_id: NDArray[np.int64],
     ) -> NDArray[np.float32]:
         """
         モーラごとの音素列とアクセント情報から、モーラごとの音高を求める関数
@@ -574,19 +574,19 @@ class CoreWrapper:
         ----------
         length : int
             モーラ列の長さ
-        vowel_phoneme_list : NDArray[np.integer]
+        vowel_phoneme_list : NDArray[np.int64]
             母音の音素列
-        consonant_phoneme_list : NDArray[np.integer]
+        consonant_phoneme_list : NDArray[np.int64]
             子音の音素列
-        start_accent_list : NDArray[np.integer]
+        start_accent_list : NDArray[np.int64]
         アクセントの開始位置
-        end_accent_list : NDArray[np.integer]
+        end_accent_list : NDArray[np.int64]
             アクセントの終了位置
-        start_accent_phrase_list : NDArray[np.integer]
+        start_accent_phrase_list : NDArray[np.int64]
             アクセント句の開始位置
-        end_accent_phrase_list : NDArray[np.integer]
+        end_accent_phrase_list : NDArray[np.int64]
             アクセント句の終了位置
-        style_id : NDArray[np.integer]
+        style_id : NDArray[np.int64]
             スタイル番号
         Returns
         -------
@@ -621,7 +621,7 @@ class CoreWrapper:
         phoneme_size: int,
         f0: NDArray[np.floating],
         phoneme: NDArray[np.floating],
-        style_id: NDArray[np.integer],
+        style_id: NDArray[np.int64],
     ) -> NDArray[np.float32]:
         """
         フレームごとの音素と音高から波形を求める関数
@@ -635,7 +635,7 @@ class CoreWrapper:
             フレームごとの音高
         phoneme : NDArray[np.floating]
             フレームごとの音素
-        style_id : NDArray[np.integer]
+        style_id : NDArray[np.int64]
             スタイル番号
         Returns
         -------

--- a/voicevox_engine/core_wrapper.py
+++ b/voicevox_engine/core_wrapper.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Literal
 
 import numpy as np
+import numpy.typing as npt
 
 
 class OldCoreError(Exception):
@@ -525,21 +526,24 @@ class CoreWrapper:
         return self.core.metas().decode("utf-8")
 
     def yukarin_s_forward(
-        self, length: int, phoneme_list: np.ndarray, style_id: np.ndarray
-    ) -> np.ndarray:
+        self,
+        length: int,
+        phoneme_list: npt.NDArray[np.integer],
+        style_id: npt.NDArray[np.integer],
+    ) -> npt.NDArray[np.float32]:
         """
         音素列から、音素ごとの長さを求める関数
         Parameters
         ----------
         length : int
             音素列の長さ
-        phoneme_list : np.ndarray
+        phoneme_list : npt.NDArray[np.integer]
             音素列
-        style_id : np.ndarray
+        style_id : npt.NDArray[np.integer]
             スタイル番号
         Returns
         -------
-        output : np.ndarray
+        output : npt.NDArray[np.float32]
             音素ごとの長さ
         """
         output = np.zeros((length,), dtype=np.float32)
@@ -556,37 +560,37 @@ class CoreWrapper:
     def yukarin_sa_forward(
         self,
         length: int,
-        vowel_phoneme_list: np.ndarray,
-        consonant_phoneme_list: np.ndarray,
-        start_accent_list: np.ndarray,
-        end_accent_list: np.ndarray,
-        start_accent_phrase_list: np.ndarray,
-        end_accent_phrase_list: np.ndarray,
-        style_id: np.ndarray,
-    ) -> np.ndarray:
+        vowel_phoneme_list: npt.NDArray[np.integer],
+        consonant_phoneme_list: npt.NDArray[np.integer],
+        start_accent_list: npt.NDArray[np.integer],
+        end_accent_list: npt.NDArray[np.integer],
+        start_accent_phrase_list: npt.NDArray[np.integer],
+        end_accent_phrase_list: npt.NDArray[np.integer],
+        style_id: npt.NDArray[np.integer],
+    ) -> npt.NDArray[np.float32]:
         """
         モーラごとの音素列とアクセント情報から、モーラごとの音高を求める関数
         Parameters
         ----------
         length : int
             モーラ列の長さ
-        vowel_phoneme_list : np.ndarray
+        vowel_phoneme_list : npt.NDArray[np.integer]
             母音の音素列
-        consonant_phoneme_list : np.ndarray
+        consonant_phoneme_list : npt.NDArray[np.integer]
             子音の音素列
-        start_accent_list : np.ndarray
+        start_accent_list : npt.NDArray[np.integer]
         アクセントの開始位置
-        end_accent_list : np.ndarray
+        end_accent_list : npt.NDArray[np.integer]
             アクセントの終了位置
-        start_accent_phrase_list : np.ndarray
+        start_accent_phrase_list : npt.NDArray[np.integer]
             アクセント句の開始位置
-        end_accent_phrase_list : np.ndarray
+        end_accent_phrase_list : npt.NDArray[np.integer]
             アクセント句の終了位置
-        style_id : np.ndarray
+        style_id : npt.NDArray[np.integer]
             スタイル番号
         Returns
         -------
-        output : np.ndarray
+        output : npt.NDArray[np.float32]
             モーラごとの音高
         """
         output = np.empty(
@@ -615,10 +619,10 @@ class CoreWrapper:
         self,
         length: int,
         phoneme_size: int,
-        f0: np.ndarray,
-        phoneme: np.ndarray,
-        style_id: np.ndarray,
-    ) -> np.ndarray:
+        f0: npt.NDArray[np.floating],
+        phoneme: npt.NDArray[np.floating],
+        style_id: npt.NDArray[np.integer],
+    ) -> npt.NDArray[np.float32]:
         """
         フレームごとの音素と音高から波形を求める関数
         Parameters
@@ -627,15 +631,15 @@ class CoreWrapper:
             フレームの長さ
         phoneme_size : int
             音素の種類数
-        f0 : np.ndarray
+        f0 : npt.NDArray[np.floating]
             フレームごとの音高
-        phoneme : np.ndarray
+        phoneme : npt.NDArray[np.floating]
             フレームごとの音素
-        style_id : np.ndarray
+        style_id : npt.NDArray[np.integer]
             スタイル番号
         Returns
         -------
-        output : np.ndarray
+        output : npt.NDArray[np.float32]
             音声波形
         """
 

--- a/voicevox_engine/core_wrapper.py
+++ b/voicevox_engine/core_wrapper.py
@@ -619,8 +619,8 @@ class CoreWrapper:
         self,
         length: int,
         phoneme_size: int,
-        f0: NDArray[np.floating],
-        phoneme: NDArray[np.floating],
+        f0: NDArray[np.float32],
+        phoneme: NDArray[np.float32],
         style_id: NDArray[np.int64],
     ) -> NDArray[np.float32]:
         """
@@ -631,9 +631,9 @@ class CoreWrapper:
             フレームの長さ
         phoneme_size : int
             音素の種類数
-        f0 : NDArray[np.floating]
+        f0 : NDArray[np.float32]
             フレームごとの音高
-        phoneme : NDArray[np.floating]
+        phoneme : NDArray[np.float32]
             フレームごとの音素
         style_id : NDArray[np.int64]
             スタイル番号

--- a/voicevox_engine/dev/core/mock.py
+++ b/voicevox_engine/dev/core/mock.py
@@ -1,7 +1,8 @@
 import json
 from pathlib import Path
 
-import numpy
+import numpy as np
+import numpy.typing as npt
 from numpy import ndarray
 
 from ...core_wrapper import CoreWrapper
@@ -65,13 +66,13 @@ class MockCoreWrapper(CoreWrapper):
 
     def yukarin_s_forward(
         self, length: int, phoneme_list: ndarray, style_id: ndarray
-    ) -> ndarray:
+    ) -> npt.NDArray[np.floating]:
         """音素系列サイズ・音素ID系列・スタイルIDから音素長系列を生成する"""
         result = []
         # mockとしての適当な処理、特に意味はない
         for i in range(length):
             result.append(round((phoneme_list[i] * 0.0625 + style_id).item(), 2))
-        return numpy.array(result)
+        return np.array(result)
 
     def yukarin_sa_forward(
         self,
@@ -83,7 +84,7 @@ class MockCoreWrapper(CoreWrapper):
         start_accent_phrase_list: ndarray,
         end_accent_phrase_list: ndarray,
         style_id: ndarray,
-    ) -> ndarray:
+    ) -> npt.NDArray[np.floating]:
         """モーラ系列サイズ・母音系列・子音系列・アクセント位置・アクセント句区切り・スタイルIDからモーラ音高系列を生成する"""
         assert length > 1, "前後無音を必ず付与しなければならない"
 
@@ -107,7 +108,7 @@ class MockCoreWrapper(CoreWrapper):
                     2,
                 )
             )
-        return numpy.array(result)[numpy.newaxis]
+        return np.array(result)[np.newaxis]
 
     def decode_forward(
         self,
@@ -116,15 +117,15 @@ class MockCoreWrapper(CoreWrapper):
         f0: ndarray,
         phoneme: ndarray,
         style_id: ndarray,
-    ) -> ndarray:
+    ) -> npt.NDArray[np.floating]:
         """フレーム長・音素種類数・フレーム音高・フレーム音素onehot・スタイルIDからダミー音声波形を生成する"""
         # 入力値を反映し、長さが 256 倍であるダミー配列を出力する
         result: list[ndarray] = []
         for i in range(length):
             result += [
-                (f0[i, 0] * (numpy.where(phoneme[i] == 1)[0] / phoneme_size) + style_id)
+                (f0[i, 0] * (np.where(phoneme[i] == 1)[0] / phoneme_size) + style_id)
             ] * 256
-        return numpy.array(result)
+        return np.array(result)
 
     def supported_devices(self):
         return json.dumps(

--- a/voicevox_engine/dev/core/mock.py
+++ b/voicevox_engine/dev/core/mock.py
@@ -2,8 +2,8 @@ import json
 from pathlib import Path
 
 import numpy as np
-import numpy.typing as npt
 from numpy import ndarray
+from numpy.typing import NDArray
 
 from ...core_wrapper import CoreWrapper
 
@@ -66,7 +66,7 @@ class MockCoreWrapper(CoreWrapper):
 
     def yukarin_s_forward(
         self, length: int, phoneme_list: ndarray, style_id: ndarray
-    ) -> npt.NDArray[np.floating]:
+    ) -> NDArray[np.floating]:
         """音素系列サイズ・音素ID系列・スタイルIDから音素長系列を生成する"""
         result = []
         # mockとしての適当な処理、特に意味はない
@@ -84,7 +84,7 @@ class MockCoreWrapper(CoreWrapper):
         start_accent_phrase_list: ndarray,
         end_accent_phrase_list: ndarray,
         style_id: ndarray,
-    ) -> npt.NDArray[np.floating]:
+    ) -> NDArray[np.floating]:
         """モーラ系列サイズ・母音系列・子音系列・アクセント位置・アクセント句区切り・スタイルIDからモーラ音高系列を生成する"""
         assert length > 1, "前後無音を必ず付与しなければならない"
 
@@ -117,7 +117,7 @@ class MockCoreWrapper(CoreWrapper):
         f0: ndarray,
         phoneme: ndarray,
         style_id: ndarray,
-    ) -> npt.NDArray[np.floating]:
+    ) -> NDArray[np.floating]:
         """フレーム長・音素種類数・フレーム音高・フレーム音素onehot・スタイルIDからダミー音声波形を生成する"""
         # 入力値を反映し、長さが 256 倍であるダミー配列を出力する
         result: list[ndarray] = []

--- a/voicevox_engine/dev/tts_engine/mock.py
+++ b/voicevox_engine/dev/tts_engine/mock.py
@@ -1,8 +1,9 @@
 import copy
 from logging import getLogger
-from typing import Any, Dict
+from typing import Any
 
 import numpy as np
+import numpy.typing as npt
 from pyopenjtalk import tts
 from soxr import resample
 
@@ -24,7 +25,7 @@ class MockTTSEngine(TTSEngine):
         query: AudioQuery,
         style_id: StyleId,
         enable_interrogative_upspeak: bool = True,
-    ) -> np.ndarray:
+    ) -> npt.NDArray[np.float64]:
         """音声合成用のクエリに含まれる読み仮名に基づいてOpenJTalkで音声波形を生成する"""
         # モーフィング時などに同一参照のqueryで複数回呼ばれる可能性があるので、元の引数のqueryに破壊的変更を行わない
         query = copy.deepcopy(query)
@@ -38,9 +39,9 @@ class MockTTSEngine(TTSEngine):
         # volume
         wave *= query.volumeScale
 
-        return wave.astype("int16")
+        return wave
 
-    def forward(self, text: str, **kwargs: Dict[str, Any]) -> np.ndarray:
+    def forward(self, text: str, **kwargs: dict[str, Any]) -> npt.NDArray[np.float64]:
         """
         forward tts via pyopenjtalk.tts()
         参照→TTSEngine のdocstring [Mock]
@@ -52,7 +53,7 @@ class MockTTSEngine(TTSEngine):
 
         Returns
         -------
-        wave [npt.NDArray[np.int16]]
+        wave [npt.NDArray[np.float64]]
             音声波形データをNumPy配列で返します
 
         Note

--- a/voicevox_engine/dev/tts_engine/mock.py
+++ b/voicevox_engine/dev/tts_engine/mock.py
@@ -3,7 +3,7 @@ from logging import getLogger
 from typing import Any
 
 import numpy as np
-import numpy.typing as npt
+from numpy.typing import NDArray
 from pyopenjtalk import tts
 from soxr import resample
 
@@ -25,7 +25,7 @@ class MockTTSEngine(TTSEngine):
         query: AudioQuery,
         style_id: StyleId,
         enable_interrogative_upspeak: bool = True,
-    ) -> npt.NDArray[np.float32]:
+    ) -> NDArray[np.float32]:
         """音声合成用のクエリに含まれる読み仮名に基づいてOpenJTalkで音声波形を生成する"""
         # モーフィング時などに同一参照のqueryで複数回呼ばれる可能性があるので、元の引数のqueryに破壊的変更を行わない
         query = copy.deepcopy(query)
@@ -41,7 +41,7 @@ class MockTTSEngine(TTSEngine):
 
         return wave
 
-    def forward(self, text: str, **kwargs: dict[str, Any]) -> npt.NDArray[np.float32]:
+    def forward(self, text: str, **kwargs: dict[str, Any]) -> NDArray[np.float32]:
         """
         forward tts via pyopenjtalk.tts()
         参照→TTSEngine のdocstring [Mock]
@@ -53,7 +53,7 @@ class MockTTSEngine(TTSEngine):
 
         Returns
         -------
-        wave [npt.NDArray[np.float64]]
+        wave [NDArray[np.float64]]
             音声波形データをNumPy配列で返します
 
         Note

--- a/voicevox_engine/morphing.py
+++ b/voicevox_engine/morphing.py
@@ -19,7 +19,6 @@ from .model import AudioQuery, MorphableTargetInfo, StyleIdNotFoundError
 from .tts_pipeline import TTSEngine
 
 
-# FIXME: ndarray type hint, https://github.com/JeremyCCHsu/Python-Wrapper-for-World-Vocoder/blob/2b64f86197573497c685c785c6e0e743f407b63e/pyworld/pyworld.pyx#L398  # noqa
 @dataclass(frozen=True)
 class MorphingParameter:
     fs: int

--- a/voicevox_engine/morphing.py
+++ b/voicevox_engine/morphing.py
@@ -1,9 +1,9 @@
 from copy import deepcopy
 from dataclasses import dataclass
 from itertools import chain
-from typing import Dict, List, Tuple
 
 import numpy as np
+import numpy.typing as npt
 import pyworld as pw
 from soxr import resample
 
@@ -24,15 +24,15 @@ from .tts_pipeline import TTSEngine
 class MorphingParameter:
     fs: int
     frame_period: float
-    base_f0: np.ndarray
-    base_aperiodicity: np.ndarray
-    base_spectrogram: np.ndarray
-    target_spectrogram: np.ndarray
+    base_f0: npt.NDArray[np.double]
+    base_aperiodicity: npt.NDArray[np.double]
+    base_spectrogram: npt.NDArray[np.double]
+    target_spectrogram: npt.NDArray[np.double]
 
 
 def create_morphing_parameter(
-    base_wave: np.ndarray,
-    target_wave: np.ndarray,
+    base_wave: npt.NDArray[np.double],
+    target_wave: npt.NDArray[np.double],
     fs: int,
 ) -> MorphingParameter:
     frame_period = 1.0
@@ -55,9 +55,9 @@ def create_morphing_parameter(
 
 
 def get_morphable_targets(
-    speakers: List[Speaker],
-    base_style_ids: List[StyleId],
-) -> List[Dict[StyleId, MorphableTargetInfo]]:
+    speakers: list[Speaker],
+    base_style_ids: list[StyleId],
+) -> list[dict[StyleId, MorphableTargetInfo]]:
     """
     speakers: 全話者の情報
     base_speakers: モーフィング可能か判定したいベースのスタイルIDリスト
@@ -81,7 +81,7 @@ def get_morphable_targets(
 
 
 def is_synthesis_morphing_permitted(
-    speaker_lookup: Dict[StyleId, Tuple[Speaker, SpeakerStyle]],
+    speaker_lookup: dict[StyleId, tuple[Speaker, SpeakerStyle]],
     base_style_id: StyleId,
     target_style_id: StyleId,
 ) -> bool:
@@ -163,7 +163,7 @@ def synthesis_morphing(
     morph_rate: float,
     output_fs: int,
     output_stereo: bool = False,
-) -> np.ndarray:
+) -> npt.NDArray[np.float64]:
     """
     指定した割合で、パラメータをもとにモーフィングした音声を生成します。
 
@@ -178,7 +178,7 @@ def synthesis_morphing(
 
     Returns
     -------
-    generated : np.ndarray
+    generated : npt.NDArray[np.float64]
         モーフィングした音声
 
     Raises

--- a/voicevox_engine/morphing.py
+++ b/voicevox_engine/morphing.py
@@ -3,8 +3,8 @@ from dataclasses import dataclass
 from itertools import chain
 
 import numpy as np
-import numpy.typing as npt
 import pyworld as pw
+from numpy.typing import NDArray
 from soxr import resample
 
 from .core_adapter import CoreAdapter
@@ -24,15 +24,15 @@ from .tts_pipeline import TTSEngine
 class MorphingParameter:
     fs: int
     frame_period: float
-    base_f0: npt.NDArray[np.double]
-    base_aperiodicity: npt.NDArray[np.double]
-    base_spectrogram: npt.NDArray[np.double]
-    target_spectrogram: npt.NDArray[np.double]
+    base_f0: NDArray[np.double]
+    base_aperiodicity: NDArray[np.double]
+    base_spectrogram: NDArray[np.double]
+    target_spectrogram: NDArray[np.double]
 
 
 def create_morphing_parameter(
-    base_wave: npt.NDArray[np.double],
-    target_wave: npt.NDArray[np.double],
+    base_wave: NDArray[np.double],
+    target_wave: NDArray[np.double],
     fs: int,
 ) -> MorphingParameter:
     frame_period = 1.0
@@ -163,7 +163,7 @@ def synthesis_morphing(
     morph_rate: float,
     output_fs: int,
     output_stereo: bool = False,
-) -> npt.NDArray[np.float64]:
+) -> NDArray[np.float64]:
     """
     指定した割合で、パラメータをもとにモーフィングした音声を生成します。
 
@@ -178,7 +178,7 @@ def synthesis_morphing(
 
     Returns
     -------
-    generated : npt.NDArray[np.float64]
+    generated : NDArray[np.float64]
         モーフィングした音声
 
     Raises

--- a/voicevox_engine/tts_pipeline/acoustic_feature_extractor.py
+++ b/voicevox_engine/tts_pipeline/acoustic_feature_extractor.py
@@ -1,7 +1,7 @@
 from typing import Literal
 
 import numpy as np
-import numpy.typing as npt
+from numpy.typing import NDArray
 
 # NOTE: `Vowel` は母音 (a/i/u/e/o の有声・無声) + 無音 pau + 撥音 N ("ん") + 促音 cl ("っ")
 # NOTE: 型の名称は暫定的
@@ -122,7 +122,7 @@ class Phoneme:
         return self._PHONEME_LIST.index(self.phoneme)
 
     @property
-    def onehot(self) -> npt.NDArray[np.float32]:
+    def onehot(self) -> NDArray[np.float32]:
         """音素onehotベクトルを取得する"""
         vec = np.zeros(self._NUM_PHONEME, dtype=np.float32)
         vec[self.phoneme_id] = 1.0

--- a/voicevox_engine/tts_pipeline/acoustic_feature_extractor.py
+++ b/voicevox_engine/tts_pipeline/acoustic_feature_extractor.py
@@ -1,6 +1,7 @@
 from typing import Literal
 
-import numpy
+import numpy as np
+import numpy.typing as npt
 
 # NOTE: `Vowel` は母音 (a/i/u/e/o の有声・無声) + 無音 pau + 撥音 N ("ん") + 促音 cl ("っ")
 # NOTE: 型の名称は暫定的
@@ -121,8 +122,8 @@ class Phoneme:
         return self._PHONEME_LIST.index(self.phoneme)
 
     @property
-    def onehot(self):
+    def onehot(self) -> npt.NDArray[np.float32]:
         """音素onehotベクトルを取得する"""
-        vec = numpy.zeros(self._NUM_PHONEME, dtype=numpy.float32)
+        vec = np.zeros(self._NUM_PHONEME, dtype=np.float32)
         vec[self.phoneme_id] = 1.0
         return vec

--- a/voicevox_engine/tts_pipeline/tts_engine.py
+++ b/voicevox_engine/tts_pipeline/tts_engine.py
@@ -3,7 +3,7 @@ import math
 from typing import TypeVar
 
 import numpy as np
-import numpy.typing as npt
+from numpy.typing import NDArray
 from soxr import resample
 
 from ..core_adapter import CoreAdapter
@@ -134,7 +134,7 @@ def apply_speed_scale(moras: list[Mora], query: AudioQuery) -> list[Mora]:
 
 def count_frame_per_unit(
     moras: list[Mora],
-) -> tuple[npt.NDArray[np.integer], npt.NDArray[np.integer]]:
+) -> tuple[NDArray[np.integer], NDArray[np.integer]]:
     """
     音素あたり・モーラあたりのフレーム長を算出する
     Parameters
@@ -143,9 +143,9 @@ def count_frame_per_unit(
         モーラ系列
     Returns
     -------
-    frame_per_phoneme : npt.NDArray[np.integer]
+    frame_per_phoneme : NDArray[np.integer]
         音素あたりのフレーム長。端数丸め。shape = (Phoneme,)
-    frame_per_mora : npt.NDArray[np.integer]
+    frame_per_mora : NDArray[np.integer]
         モーラあたりのフレーム長。端数丸め。shape = (Mora,)
     """
     frame_per_phoneme: list[int] = []
@@ -189,7 +189,7 @@ def apply_intonation_scale(moras: list[Mora], query: AudioQuery) -> list[Mora]:
     return moras
 
 
-def apply_volume_scale(wave: np.ndarray, query: AudioQuery) -> npt.NDArray[np.floating]:
+def apply_volume_scale(wave: np.ndarray, query: AudioQuery) -> NDArray[np.floating]:
     """音声波形へ音声合成用のクエリがもつ音量スケール（`volumeScale`）を適用する"""
     return wave * query.volumeScale
 
@@ -198,8 +198,8 @@ _SoxrType = TypeVar("_SoxrType", np.float32, np.float64, np.int16, np.int32)
 
 
 def apply_output_sampling_rate(
-    wave: npt.NDArray[_SoxrType], sr_wave: float, query: AudioQuery
-) -> npt.NDArray[_SoxrType]:
+    wave: NDArray[_SoxrType], sr_wave: float, query: AudioQuery
+) -> NDArray[_SoxrType]:
     """音声波形へ音声合成用のクエリがもつ出力サンプリングレート（`outputSamplingRate`）を適用する"""
     # サンプリングレート一致のときはスルー
     if sr_wave == query.outputSamplingRate:
@@ -211,7 +211,7 @@ def apply_output_sampling_rate(
 T = TypeVar("T", bound=np.generic)
 
 
-def apply_output_stereo(wave: npt.NDArray[T], query: AudioQuery) -> npt.NDArray[T]:
+def apply_output_stereo(wave: NDArray[T], query: AudioQuery) -> NDArray[T]:
     """音声波形へ音声合成用のクエリがもつステレオ出力設定（`outputStereo`）を適用する"""
     if query.outputStereo:
         wave = np.array([wave, wave]).T
@@ -220,7 +220,7 @@ def apply_output_stereo(wave: npt.NDArray[T], query: AudioQuery) -> npt.NDArray[
 
 def query_to_decoder_feature(
     query: AudioQuery,
-) -> tuple[npt.NDArray[np.float32], npt.NDArray[np.float32]]:
+) -> tuple[NDArray[np.float32], NDArray[np.float32]]:
     """音声合成用のクエリからフレームごとの音素 (shape=(フレーム長, 音素数)) と音高 (shape=(フレーム長,)) を得る"""
     moras = to_flatten_moras(query.accent_phrases)
 
@@ -244,7 +244,7 @@ def query_to_decoder_feature(
 
 def raw_wave_to_output_wave(
     query: AudioQuery, wave: np.ndarray, sr_wave: int
-) -> npt.NDArray[np.floating]:
+) -> NDArray[np.floating]:
     """生音声波形に音声合成用のクエリを適用して出力音声波形を生成する"""
     wave = apply_volume_scale(wave, query)
     wave = apply_output_sampling_rate(wave, sr_wave, query)
@@ -301,7 +301,7 @@ class TTSEngine:
         # accent
         def _create_one_hot(
             accent_phrase: AccentPhrase, position: int
-        ) -> npt.NDArray[np.floating]:
+        ) -> NDArray[np.floating]:
             """
             単位行列(np.eye)を応用し、accent_phrase内でone hotな配列(リスト)を作る
             例えば、accent_phraseのmorasの長さが12、positionが1なら
@@ -318,7 +318,7 @@ class TTSEngine:
                 one hotにするindex
             Returns
             -------
-            one_hot : npt.NDArray[np.floating]
+            one_hot : NDArray[np.floating]
                 one hotな配列(リスト)
             """
             return np.r_[
@@ -423,7 +423,7 @@ class TTSEngine:
         query: AudioQuery,
         style_id: StyleId,
         enable_interrogative_upspeak: bool = True,
-    ) -> npt.NDArray[np.floating]:
+    ) -> NDArray[np.floating]:
         """音声合成用のクエリ・スタイルID・疑問文語尾自動調整フラグに基づいて音声波形を生成する"""
         # モーフィング時などに同一参照のqueryで複数回呼ばれる可能性があるので、元の引数のqueryに破壊的変更を行わない
         query = copy.deepcopy(query)

--- a/voicevox_engine/tts_pipeline/tts_engine.py
+++ b/voicevox_engine/tts_pipeline/tts_engine.py
@@ -194,12 +194,9 @@ def apply_volume_scale(wave: np.ndarray, query: AudioQuery) -> NDArray[np.floati
     return wave * query.volumeScale
 
 
-_SoxrType = TypeVar("_SoxrType", np.float32, np.float64, np.int16, np.int32)
-
-
 def apply_output_sampling_rate(
-    wave: NDArray[_SoxrType], sr_wave: float, query: AudioQuery
-) -> NDArray[_SoxrType]:
+    wave: NDArray[np.floating], sr_wave: float, query: AudioQuery
+) -> NDArray[np.floating]:
     """音声波形へ音声合成用のクエリがもつ出力サンプリングレート（`outputSamplingRate`）を適用する"""
     # サンプリングレート一致のときはスルー
     if sr_wave == query.outputSamplingRate:
@@ -208,10 +205,9 @@ def apply_output_sampling_rate(
     return wave
 
 
-T = TypeVar("T", bound=np.generic)
-
-
-def apply_output_stereo(wave: NDArray[T], query: AudioQuery) -> NDArray[T]:
+def apply_output_stereo(
+    wave: NDArray[np.floating], query: AudioQuery
+) -> NDArray[np.floating]:
     """音声波形へ音声合成用のクエリがもつステレオ出力設定（`outputStereo`）を適用する"""
     if query.outputStereo:
         wave = np.array([wave, wave]).T

--- a/voicevox_engine/tts_pipeline/tts_engine.py
+++ b/voicevox_engine/tts_pipeline/tts_engine.py
@@ -1,6 +1,5 @@
 import copy
 import math
-from typing import TypeVar
 
 import numpy as np
 from numpy.typing import NDArray

--- a/voicevox_engine/utility/connect_base64_waves.py
+++ b/voicevox_engine/utility/connect_base64_waves.py
@@ -2,8 +2,8 @@ import base64
 import io
 
 import numpy as np
-import numpy.typing as npt
 import soundfile
+from numpy.typing import NDArray
 from soxr import resample
 
 
@@ -12,7 +12,7 @@ class ConnectBase64WavesException(Exception):
         self.message = message
 
 
-def decode_base64_waves(waves: list[str]) -> list[tuple[npt.NDArray[np.float64], int]]:
+def decode_base64_waves(waves: list[str]) -> list[tuple[NDArray[np.float64], int]]:
     """
     base64エンコードされた複数のwavデータをデコードする
     Parameters
@@ -21,7 +21,7 @@ def decode_base64_waves(waves: list[str]) -> list[tuple[npt.NDArray[np.float64],
         base64エンコードされたwavデータのリスト
     Returns
     -------
-    waves_nparray_sr: List[Tuple[npt.NDArray[np.float64], int]]
+    waves_nparray_sr: List[Tuple[NDArray[np.float64], int]]
         (NumPy配列の音声波形データ, サンプリングレート) 形式のタプルのリスト
     """
     if len(waves) == 0:
@@ -42,7 +42,7 @@ def decode_base64_waves(waves: list[str]) -> list[tuple[npt.NDArray[np.float64],
     return waves_nparray_sr
 
 
-def connect_base64_waves(waves: list[str]) -> tuple[npt.NDArray[np.float64], int]:
+def connect_base64_waves(waves: list[str]) -> tuple[NDArray[np.float64], int]:
     waves_nparray_sr = decode_base64_waves(waves)
 
     max_sampling_rate = max([sr for _, sr in waves_nparray_sr])

--- a/voicevox_engine/utility/connect_base64_waves.py
+++ b/voicevox_engine/utility/connect_base64_waves.py
@@ -1,8 +1,8 @@
 import base64
 import io
-from typing import List, Tuple
 
 import numpy as np
+import numpy.typing as npt
 import soundfile
 from soxr import resample
 
@@ -12,7 +12,7 @@ class ConnectBase64WavesException(Exception):
         self.message = message
 
 
-def decode_base64_waves(waves: List[str]) -> List[Tuple[np.ndarray, int]]:
+def decode_base64_waves(waves: list[str]) -> list[tuple[npt.NDArray[np.float64], int]]:
     """
     base64エンコードされた複数のwavデータをデコードする
     Parameters
@@ -21,7 +21,7 @@ def decode_base64_waves(waves: List[str]) -> List[Tuple[np.ndarray, int]]:
         base64エンコードされたwavデータのリスト
     Returns
     -------
-    waves_nparray_sr: List[Tuple[np.ndarray, int]]
+    waves_nparray_sr: List[Tuple[npt.NDArray[np.float64], int]]
         (NumPy配列の音声波形データ, サンプリングレート) 形式のタプルのリスト
     """
     if len(waves) == 0:
@@ -42,7 +42,7 @@ def decode_base64_waves(waves: List[str]) -> List[Tuple[np.ndarray, int]]:
     return waves_nparray_sr
 
 
-def connect_base64_waves(waves: List[str]) -> Tuple[np.ndarray, int]:
+def connect_base64_waves(waves: list[str]) -> tuple[npt.NDArray[np.float64], int]:
     waves_nparray_sr = decode_base64_waves(waves)
 
     max_sampling_rate = max([sr for _, sr in waves_nparray_sr])


### PR DESCRIPTION
## 内容

numpyのdtypeの型情報を追加してみました。

## その他

かなり緩く付けたためあまり恩恵がないかもしれない。

`import numpy`の多くを`import numpy as np`に置き換えた。