### PR TITLE
整理: length 無音付加の`CoreAdapter` 移植

### DIFF
--- a/voicevox_engine/core_adapter.py
+++ b/voicevox_engine/core_adapter.py
@@ -69,7 +69,7 @@ class CoreAdapter:
     def safe_yukarin_s_forward(
         self, phoneme_list_s: NDArray[np.int64], style_id: StyleId
     ) -> NDArray[np.float32]:
-        # 「指定スタイルを初期化」「mutexによる安全性」「コア仕様に従う無音自動付加」「系列長・データ型に関するアダプター」を提供する
+        # 「指定スタイルを初期化」「mutexによる安全性」「コア仕様に従う無音付加」「系列長・データ型に関するアダプター」を提供する
         self.initialize_style_id_synthesis(style_id, skip_reinit=True)
 
         # 前後無音を付加する（詳細: voicevox_engine#924）
@@ -97,7 +97,7 @@ class CoreAdapter:
         end_accent_phrase_list: NDArray[np.int64],
         style_id: StyleId,
     ) -> NDArray[np.float32]:
-        # 「指定スタイルを初期化」「mutexによる安全性」「コア仕様に従う無音自動付加」「系列長・データ型に関するアダプター」を提供する
+        # 「指定スタイルを初期化」「mutexによる安全性」「コア仕様に従う無音付加」「系列長・データ型に関するアダプター」を提供する
         self.initialize_style_id_synthesis(style_id, skip_reinit=True)
 
         # 前後無音を付加する（詳細: voicevox_engine#924）

--- a/voicevox_engine/core_adapter.py
+++ b/voicevox_engine/core_adapter.py
@@ -69,14 +69,22 @@ class CoreAdapter:
     def safe_yukarin_s_forward(
         self, phoneme_list_s: NDArray[np.int64], style_id: StyleId
     ) -> NDArray[np.float32]:
-        # 「指定スタイルを初期化」「mutexによる安全性」「系列長・データ型に関するアダプター」を提供する
+        # 「指定スタイルを初期化」「mutexによる安全性」「コア仕様に従う無音自動付加」「系列長・データ型に関するアダプター」を提供する
         self.initialize_style_id_synthesis(style_id, skip_reinit=True)
+
+        # 前後無音を付加する（詳細: voicevox_engine#924）
+        phoneme_list_s = np.r_[0, phoneme_list_s, 0]
+
         with self.mutex:
             phoneme_length = self.core.yukarin_s_forward(
                 length=len(phoneme_list_s),
                 phoneme_list=phoneme_list_s,
                 style_id=np.array(style_id, dtype=np.int64).reshape(-1),
             )
+
+        # 前後無音に相当する領域を破棄する
+        phoneme_length = phoneme_length[1:-1]
+
         return phoneme_length
 
     def safe_yukarin_sa_forward(

--- a/voicevox_engine/tts_pipeline/tts_engine.py
+++ b/voicevox_engine/tts_pipeline/tts_engine.py
@@ -262,9 +262,8 @@ class TTSEngine:
         # モーラ系列を抽出する
         moras = to_flatten_moras(accent_phrases)
 
-        # 音素系列を抽出し前後無音を付加する
+        # 音素系列を抽出する
         phonemes = to_flatten_phonemes(moras)
-        phonemes = [Phoneme("pau")] + phonemes + [Phoneme("pau")]
 
         # 音素クラスから音素IDスカラへ表現を変換する
         phoneme_ids = np.array([p.phoneme_id for p in phonemes], dtype=np.int64)
@@ -278,8 +277,8 @@ class TTSEngine:
             if mora.consonant is None:
                 mora.consonant_length = None
             else:
-                mora.consonant_length = phoneme_lengths[vowel_indexes[i + 1] - 1]
-            mora.vowel_length = phoneme_lengths[vowel_indexes[i + 1]]
+                mora.consonant_length = phoneme_lengths[vowel_indexes[i] - 1]
+            mora.vowel_length = phoneme_lengths[vowel_indexes[i]]
 
         return accent_phrases
 


### PR DESCRIPTION
## 内容
音素長合成の無音付加`CoreAdapter` 移植によるリファクタリング  

#999 同様の移植を音素長合成（`update_length()`）でもおこなった。

## 関連 Issue
#999