### PR TITLE
整理: `.phoneme` プライベート化

### DIFF
--- a/test/tts_pipeline/test_acoustic_feature_extractor.py
+++ b/test/tts_pipeline/test_acoustic_feature_extractor.py
@@ -34,7 +34,7 @@ class TestPhoneme(TestCase):
 
     def test_convert(self):
         sil_phoneme = Phoneme("sil")
-        self.assertEqual(sil_phoneme.phoneme, "pau")
+        self.assertEqual(sil_phoneme._phoneme, "pau")
 
     def test_phoneme_id(self):
         ojt_str_hello_hiho = " ".join([str(p.id) for p in self.ojt_hello_hiho])

--- a/test/tts_pipeline/test_tts_engine.py
+++ b/test/tts_pipeline/test_tts_engine.py
@@ -132,7 +132,7 @@ def test_to_flatten_phonemes():
     true_phonemes = ["pau", "h", "i", "pau"]
 
     # Outputs
-    phonemes = list(map(lambda p: p.phoneme, to_flatten_phonemes(moras)))
+    phonemes = list(map(lambda p: p._phoneme, to_flatten_phonemes(moras)))
 
     assert true_phonemes == phonemes
 

--- a/voicevox_engine/tts_pipeline/acoustic_feature_extractor.py
+++ b/voicevox_engine/tts_pipeline/acoustic_feature_extractor.py
@@ -115,14 +115,14 @@ class Phoneme:
         if "sil" in phoneme:
             phoneme = "pau"
 
-        self.phoneme = phoneme
+        self._phoneme = phoneme
         # TODO: `phoneme` で受け入れ可能な文字列を型で保証
         # self.phoneme: Vowel | Consonant = phoneme
 
     @property
     def id(self) -> int:
         """音素ID (音素リスト内でのindex) を取得する"""
-        return self._PHONEME_LIST.index(self.phoneme)
+        return self._PHONEME_LIST.index(self._phoneme)
 
     @property
     def onehot(self) -> NDArray[np.float32]:
@@ -133,8 +133,8 @@ class Phoneme:
 
     def is_mora_tail(self) -> bool:
         """この音素はモーラ末尾音素（母音・撥音・促音・無音）である"""
-        return self.phoneme in MORA_TAIL_PHONEMES
+        return self._phoneme in MORA_TAIL_PHONEMES
 
     def is_unvoiced_mora_tail(self) -> bool:
         """この音素は無声のモーラ末尾音素（無声母音・促音・無音）である"""
-        return self.phoneme in UNVOICED_MORA_TAIL_PHONEMES
+        return self._phoneme in UNVOICED_MORA_TAIL_PHONEMES


### PR DESCRIPTION
## 内容
`Phoneme.phoneme` プライベート化によるリファクタリング  

音素クラスの判別メソッド追加により、`Phoneme` クラスの `.phoneme` 属性（音素文字）を直接操作するコードがテスト以外で消滅した。  
このような背景から、`Phoneme.phoneme` プライベート化によるリファクタリングを提案します。  

## 関連 Issue
無し