### PR TITLE
openapi-generatorに合わせてopenapiのバージョンを下げたりする

### DIFF
--- a/run.py
+++ b/run.py
@@ -23,7 +23,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.openapi.utils import get_openapi
 from fastapi.responses import JSONResponse
 from fastapi.templating import Jinja2Templates
-from pydantic import ValidationError, schema_json_of
+from pydantic import ValidationError
 from starlette.background import BackgroundTask
 from starlette.middleware.errors import ServerErrorMiddleware
 from starlette.responses import FileResponse
@@ -1334,7 +1334,7 @@ def generate_app(
         dependencies=[Depends(check_disabled_mutable_api)],
     )
     def setting_post(
-        cors_policy_mode: CorsPolicyMode = Form(),  # noqa
+        cors_policy_mode: str = Form(),  # noqa  # FIXME: CorsPolicyModeにするとopenapi-generatorがエラーになる
         allow_origin: str | None = Form(default=None),  # noqa
     ) -> Response:
         """
@@ -1366,9 +1366,6 @@ def generate_app(
             terms_of_service=app.terms_of_service,
             contact=app.contact,
             license_info=app.license_info,
-        )
-        openapi_schema["components"]["schemas"]["CorsPolicyMode"] = schema_json_of(
-            CorsPolicyMode
         )
         openapi_schema["components"]["schemas"][
             "VvlibManifest"

--- a/run.py
+++ b/run.py
@@ -23,7 +23,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.openapi.utils import get_openapi
 from fastapi.responses import JSONResponse
 from fastapi.templating import Jinja2Templates
-from pydantic import ValidationError
+from pydantic import ValidationError, schema_json_of
 from starlette.background import BackgroundTask
 from starlette.middleware.errors import ServerErrorMiddleware
 from starlette.responses import FileResponse
@@ -1334,7 +1334,7 @@ def generate_app(
         dependencies=[Depends(check_disabled_mutable_api)],
     )
     def setting_post(
-        cors_policy_mode: str = Form(),  # noqa  # FIXME: CorsPolicyModeにするとopenapi-generatorがうまく行かない
+        cors_policy_mode: CorsPolicyMode = Form(),  # noqa
         allow_origin: str | None = Form(default=None),  # noqa
     ) -> Response:
         """
@@ -1366,6 +1366,9 @@ def generate_app(
             terms_of_service=app.terms_of_service,
             contact=app.contact,
             license_info=app.license_info,
+        )
+        openapi_schema["components"]["schemas"]["CorsPolicyMode"] = schema_json_of(
+            CorsPolicyMode
         )
         openapi_schema["components"]["schemas"][
             "VvlibManifest"

--- a/run.py
+++ b/run.py
@@ -1358,7 +1358,7 @@ def generate_app(
         openapi_schema = get_openapi(
             title=app.title,
             version=app.version,
-            openapi_version="3.0.0",  # openapi-generatorがデフォルトの3.1.0に未対応なため
+            openapi_version="3.0.0",  # openapi-generatorが対応するバージョン
             description=app.description,
             routes=app.routes,
             tags=app.openapi_tags,

--- a/run.py
+++ b/run.py
@@ -1358,6 +1358,7 @@ def generate_app(
         openapi_schema = get_openapi(
             title=app.title,
             version=app.version,
+            openapi_version="3.0.0",  # openapi-generatorがデフォルトの3.1.0に未対応なため
             description=app.description,
             routes=app.routes,
             tags=app.openapi_tags,

--- a/run.py
+++ b/run.py
@@ -1334,7 +1334,7 @@ def generate_app(
         dependencies=[Depends(check_disabled_mutable_api)],
     )
     def setting_post(
-        cors_policy_mode: CorsPolicyMode = Form(),  # noqa
+        cors_policy_mode: str = Form(),  # noqa  # FIXME: CorsPolicyModeにするとopenapi-generatorがうまく行かない
         allow_origin: str | None = Form(default=None),  # noqa
     ) -> Response:
         """


### PR DESCRIPTION
## 内容

最新の3.1.0はopenapi-generatorが対応してないっぽいので、ちょっと下げて3.0.0にしてみました。
あと`CorsPolicyMode`がなぜかうまくいかなかったのでワークアラウンドをはさみます。


## その他

`VvlibManifest`と同様にスキーマを`openapi_schema["components"]["schemas"]`に入れようといろいろ試してみたのですが、なんかちゃんとしたEnumっぽいものが生成されなかったので、諦めてワークアラウンドを適用しています。。

ちなみに`= Form()`をやめて普通のクエリにする形でもうまくいきました。
が、APIの変更になってしまうので、こっちにしとこうかなと。。