### PR TITLE
旧来のonedir layoutと同様のレイアウトに変更し、実行ファイルと同じディレクトリにPython runtimeを含める

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -464,10 +464,17 @@ jobs:
             LIBONNXRUNTIME_PATH=download/onnxruntime/lib/libonnxruntime.so
           fi
 
-          pyinstaller --noconfirm run.spec -- \
-            --libcore_path="$LIBCORE_PATH" \
-            --libonnxruntime_path="$LIBONNXRUNTIME_PATH" \
-            --core_model_dir_path="download/core/model"
+          if [[ ${{ matrix.os }} == macos-* ]]; then
+            pyinstaller --noconfirm run_macos.spec -- \
+              --libcore_path="$LIBCORE_PATH" \
+              --libonnxruntime_path="$LIBONNXRUNTIME_PATH" \
+              --core_model_dir_path="download/core/model"
+          else
+            pyinstaller --noconfirm run.spec -- \
+              --libcore_path="$LIBCORE_PATH" \
+              --libonnxruntime_path="$LIBONNXRUNTIME_PATH" \
+              --core_model_dir_path="download/core/model"
+          fi
 
       - name: Gather DLL dependencies to dist/run/ (Windows)
         if: startsWith(matrix.os, 'windows-')
@@ -539,7 +546,7 @@ jobs:
       - name: Set @rpath to @executable_path
         if: startsWith(matrix.os, 'macos-')
         run: |
-          install_name_tool -add_rpath @executable_path/. dist/run/run
+          install_name_tool -add_rpath @executable_path/. dist/run.app/MacOS/run
 
       - name: Code signing
         if: github.event.inputs.code_signing == 'true' && startsWith(matrix.os, 'windows-')
@@ -551,8 +558,13 @@ jobs:
           ESIGNERCKA_TOTP_SECRET: ${{ secrets.ESIGNERCKA_TOTP_SECRET }}
 
       - name: Rename artifact directory to archive
+        if: startsWith(matrix.os, 'macos-') != true
         run: |
           mv dist/run/ "${{ matrix.target }}/"
+      - name: Rename artifact directory to archive
+        if: startsWith(matrix.os, 'macos-')
+        run: |
+          mv dist/run.app "${{ matrix.target }}/"
 
       # 7z archives
       - name: Create 7z archives

--- a/run.spec
+++ b/run.spec
@@ -69,7 +69,7 @@ exe = EXE(
     target_arch=None,
     codesign_identity=None,
     entitlements_file=None,
-    contents_directory="engine_internal",
+    contents_directory=".",
 )
 
 coll = COLLECT(

--- a/run.spec
+++ b/run.spec
@@ -69,7 +69,7 @@ exe = EXE(
     target_arch=None,
     codesign_identity=None,
     entitlements_file=None,
-    contents_directory=".",
+    contents_directory="engine_internal",
 )
 
 coll = COLLECT(

--- a/run_macos.spec
+++ b/run_macos.spec
@@ -1,0 +1,112 @@
+# -*- mode: python ; coding: utf-8 -*-
+# このファイルはPyInstallerによって自動生成されたもので、それをカスタマイズして使用しています。
+# pyinstaller --onedir --windowed run.py で生成されたコードをベースとしています
+from argparse import ArgumentParser
+from pathlib import Path
+from shutil import copy2, copytree
+
+from PyInstaller.utils.hooks import collect_data_files
+
+parser = ArgumentParser()
+parser.add_argument("--libcore_path", type=Path)
+parser.add_argument("--libonnxruntime_path", type=Path)
+parser.add_argument("--core_model_dir_path", type=Path)
+options = parser.parse_args()
+
+libonnxruntime_path: Path | None = options.libonnxruntime_path
+if libonnxruntime_path is not None and not libonnxruntime_path.is_file():
+    raise Exception(f"libonnxruntime_path: {libonnxruntime_path} is not file")
+
+libcore_path: Path | None = options.libcore_path
+if libcore_path is not None and not libcore_path.is_file():
+    raise Exception(f"libcore_path: {libcore_path} is not file")
+
+core_model_dir_path: Path | None = options.core_model_dir_path
+if core_model_dir_path is not None and not core_model_dir_path.is_dir():
+    raise Exception(f"core_model_dir_path: {core_model_dir_path} is not dir")
+
+datas = [
+    ("default.csv", "."),
+    ("presets.yaml", "."),
+    ("ui_template", "ui_template"),
+]
+datas += collect_data_files("pyopenjtalk")
+
+
+block_cipher = None
+
+
+a = Analysis(
+    ["run.py"],
+    pathex=[],
+    binaries=[],
+    datas=datas,
+    hiddenimports=[],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name="run",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)
+
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name="run",
+)
+app = BUNDLE(
+    coll,
+    name="run.app",
+    icon=None,
+    bundle_identifier=None,
+)
+
+# 実行ファイル作成後の処理
+
+# 実行ファイルと同じrootディレクトリ
+target_dir = Path(DISTPATH) / "run.app" / "Contents" / "MacOS"
+
+# 動的ライブラリをコピー
+if libonnxruntime_path is not None:
+    copy2(libonnxruntime_path, target_dir)
+if libcore_path is not None:
+    copy2(libcore_path, target_dir)
+if core_model_dir_path is not None:
+    copytree(core_model_dir_path, target_dir / "model")
+
+# 互換性維持のために必要なファイルをコピー
+license_file_path = Path("licenses.json")
+if license_file_path.is_file():
+    copy2("licenses.json", target_dir)
+
+copytree("speaker_info", target_dir / "speaker_info")
+copy2("engine_manifest.json", target_dir)
+copytree("engine_manifest_assets", target_dir / "engine_manifest_assets")


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->

PyInstaller v6へのアップデートにより、動的ライブラリの配置箇所の変更などが行われた。
engine単体での実行に関しては問題が生じなかったが、ElectronのBuilderと組み合わせパッケージングを行うと、macOS環境でPython runtimeを見つけられない事象が発生している。

根本解決には至らないが、まずはElectronとの組み合わせの場合でも実行できるようにする。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

ref: https://discord.com/channels/879570910208733277/893889888208977960/1198352832311599305
ref: https://github.com/VOICEVOX/voicevox_engine/pull/857

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他

ファイルの配置状況は以下の通り

0.15.0

```
(.venv) # ~/Projects/github.com/VOICEVOX/voicevox_engine/dist_0.15.0/run $
 find . -maxdepth 2
.
./speaker_info
./speaker_info/b1a81618-b27b-40d2-b0ea-27a9ad408c4b
./speaker_info/35b2c544-660e-401e-b503-0e14c635303a
./speaker_info/7ffcb7ce-00ec-4bdc-82cd-45a8889e43ff
./speaker_info/388f246b-8c41-4ac1-8e2d-5d79f3ff56d9
./engine_manifest.json
./engine_internal
./engine_internal/lib-dynload
./engine_internal/_cffi_backend.cpython-311-darwin.so
./engine_internal/markupsafe
./engine_internal/soxr
./engine_internal/default.csv
./engine_internal/libpython3.11.dylib
./engine_internal/pyworld-0.3.4.dist-info
./engine_internal/libssl.1.1.dylib
./engine_internal/_soundfile_data
./engine_internal/numpy
./engine_internal/presets.yaml
./engine_internal/base_library.zip
./engine_internal/libgfortran.5.dylib
./engine_internal/libintl.8.dylib
./engine_internal/ui_template
./engine_internal/yaml
./engine_internal/liblzma.5.dylib
./engine_internal/libreadline.8.dylib
./engine_internal/pyworld
./engine_internal/libcrypto.1.1.dylib
./engine_internal/pydantic
./engine_internal/libquadmath.0.dylib
./engine_internal/libgcc_s.1.1.dylib
./engine_internal/libb2.1.dylib
./engine_internal/pyopenjtalk
./engine_internal/libopenblas64_.0.dylib
./engine_internal/importlib_metadata-6.8.0.dist-info
./licenses.json
./run
./engine_manifest_assets
./engine_manifest_assets/icon.png
./engine_manifest_assets/update_infos.json
./engine_manifest_assets/terms_of_service.md
./engine_manifest_assets/downloadable_libraries.json
./engine_manifest_assets/dependency_licenses.json
```

0.15.0-patch

```
# ~/Projects/github.com/VOICEVOX/voicevox_engine/dist_0.15.0-patch/run $
  find . -maxdepth 1
.
./lib-dynload
./_cffi_backend.cpython-311-darwin.so
./speaker_info
./markupsafe
./soxr
./default.csv
./engine_manifest.json
./libpython3.11.dylib
./pyworld-0.3.4.dist-info
./libssl.1.1.dylib
./_soundfile_data
./numpy
./presets.yaml
./base_library.zip
./libgfortran.5.dylib
./licenses.json
./libintl.8.dylib
./ui_template
./yaml
./liblzma.5.dylib
./libreadline.8.dylib
./run
./pyworld
./libcrypto.1.1.dylib
./engine_manifest_assets
./pydantic
./libquadmath.0.dylib
./libgcc_s.1.1.dylib
./libb2.1.dylib
./pyopenjtalk
./libopenblas64_.0.dylib
./importlib_metadata-6.8.0.dist-info
```

0.14.7

```
# ~/Downloads/voicevox_engine_0.14.7/macos-x64 $
 find . -maxdepth 1
.
./lib-dynload
./libvoicevox_core.dylib
./speaker_info
./markupsafe
./default_setting.yml
./default.csv
./importlib_metadata-4.13.0.dist-info
./engine_manifest.json
./libssl.1.1.dylib
./_soundfile_data
./numpy
./presets.yaml
./base_library.zip
./licenses.json
./certifi
./libintl.8.dylib
./libgfortran.3.dylib
./_cffi_backend.cpython-38-darwin.so
./ui_template
./model
./yaml
./liblzma.5.dylib
./setuptools-65.6.3.dist-info
./run
./pyworld
./libcrypto.1.1.dylib
./engine_manifest_assets
./pydantic
./libquadmath.0.dylib
./libonnxruntime.dylib
./scipy
./pyopenjtalk
./libgcc_s.1.dylib
./libpython3.8.dylib
./pyworld-0.3.0.dist-info
./libopenblas.0.dylib
```

この様に旧来の配置になる
