### PR TITLE
[release-0.15] 0.15.1用の更新情報を更新

### DIFF
--- a/engine_manifest_assets/update_infos.json
+++ b/engine_manifest_assets/update_infos.json
@@ -1,7 +1,7 @@
 [
   {
     "version": "0.15.1",
-    "descriptions": ["Mac版エディタが起動しない問題の解決"],
+    "descriptions": ["ビルド成果物のディレクトリ構造を元に戻した"],
     "contributors": []
   },
   {

--- a/engine_manifest_assets/update_infos.json
+++ b/engine_manifest_assets/update_infos.json
@@ -1,7 +1,7 @@
 [
   {
     "version": "0.15.1",
-    "descriptions": ["mac版エディタが起動しない問題の解決"],
+    "descriptions": ["Mac版エディタが起動しない問題の解決"],
     "contributors": []
   },
   {

--- a/engine_manifest_assets/update_infos.json
+++ b/engine_manifest_assets/update_infos.json
@@ -1,5 +1,10 @@
 [
   {
+    "version": "0.15.1",
+    "descriptions": ["mac版エディタが起動しない問題の解決"],
+    "contributors": []
+  },
+  {
     "version": "0.15.0",
     "descriptions": [
       "/validate_kana APIを追加",


### PR DESCRIPTION
## 内容

0.15.1用のupdate_infoの更新です。

これを足し忘れて0.15.1をビルドしてしまいました。
･･･このまま進みたいと思います。次のビルドから更新内容に追加される予定です。


## その他
