### PR TITLE
整理: jsonスナップショットのdiffをgithub上で展開しないように

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,5 @@
+test/**/__snapshots__/**/*.json linguist-generated=true
+
 * text=auto
 *.png -text
 *.wav -text

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -10,7 +10,7 @@ def snapshot_json(snapshot: SnapshotAssertion) -> SnapshotAssertion:
 
     Examples
     --------
-    >>> def test_foo(snapshot_json: JSONSnapshotExtension):
+    >>> def test_foo(snapshot_json: SnapshotAssertion):
     >>>     assert snapshot_json == {"key": "value"}
     """
     return snapshot.use_extension(JSONSnapshotExtension)

--- a/test/e2e/__snapshots__/test_preset/test_プリセット一覧を取得できる.json
+++ b/test/e2e/__snapshots__/test_preset/test_プリセット一覧を取得できる.json
@@ -1,0 +1,14 @@
+[
+  {
+    "id": 1,
+    "intonationScale": 1.0,
+    "name": "サンプルプリセット",
+    "pitchScale": 0.0,
+    "postPhonemeLength": 0.1,
+    "prePhonemeLength": 0.1,
+    "speaker_uuid": "7ffcb7ce-00ec-4bdc-82cd-45a8889e43ff",
+    "speedScale": 1.0,
+    "style_id": 0,
+    "volumeScale": 1.0
+  }
+]

--- a/test/e2e/test_audio_query.py
+++ b/test/e2e/test_audio_query.py
@@ -5,11 +5,11 @@ AudioQuery APIのテスト
 from test.utility import round_floats
 
 from fastapi.testclient import TestClient
-from syrupy.extensions.json import JSONSnapshotExtension
+from syrupy.assertion import SnapshotAssertion
 
 
 def test_speakerを指定して音声合成クエリが取得できる(
-    client: TestClient, snapshot_json: JSONSnapshotExtension
+    client: TestClient, snapshot_json: SnapshotAssertion
 ) -> None:
     response = client.post("/audio_query", params={"text": "テストです", "speaker": 0})
     assert response.status_code == 200

--- a/test/e2e/test_openapi.py
+++ b/test/e2e/test_openapi.py
@@ -1,12 +1,10 @@
 from typing import Any
 
 from fastapi import FastAPI
-from syrupy.extensions.json import JSONSnapshotExtension
+from syrupy.assertion import SnapshotAssertion
 
 
-def test_OpenAPIの形が変わっていないことを確認(
-    app: FastAPI, snapshot_json: JSONSnapshotExtension
-) -> None:
+def test_OpenAPIの形が変わっていないことを確認(app: FastAPI, snapshot_json: SnapshotAssertion) -> None:
     # 変更があった場合はREADMEの「スナップショットの更新」の手順で更新可能
     openapi: Any = app.openapi()  # snapshot_jsonがmypyに対応していないのでワークアラウンド
     assert snapshot_json == openapi

--- a/test/e2e/test_preset.py
+++ b/test/e2e/test_preset.py
@@ -1,0 +1,12 @@
+"""
+プリセットAPIのテスト
+"""
+
+from fastapi.testclient import TestClient
+from syrupy.assertion import SnapshotAssertion
+
+
+def test_プリセット一覧を取得できる(client: TestClient, snapshot_json: SnapshotAssertion) -> None:
+    response = client.get("/presets")
+    assert response.status_code == 200
+    assert snapshot_json == response.json()

--- a/test/e2e/test_validate_speakers.py
+++ b/test/e2e/test_validate_speakers.py
@@ -1,9 +1,9 @@
 from fastapi.testclient import TestClient
-from syrupy.extensions.json import JSONSnapshotExtension
+from syrupy.assertion import SnapshotAssertion
 
 
 def test_fetch_speakers_success(
-    client: TestClient, snapshot_json: JSONSnapshotExtension
+    client: TestClient, snapshot_json: SnapshotAssertion
 ) -> None:
     response = client.get("/speakers")
     assert response.status_code == 200

--- a/test/tts_pipeline/test_tts_engine.py
+++ b/test/tts_pipeline/test_tts_engine.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock
 import numpy as np
 import pytest
 from numpy.typing import NDArray
-from syrupy.extensions.json import JSONSnapshotExtension
+from syrupy.assertion import SnapshotAssertion
 
 from voicevox_engine.dev.core.mock import MockCoreWrapper
 from voicevox_engine.metas.Metas import StyleId
@@ -345,7 +345,7 @@ def test_create_accent_phrases_toward_unknown():
     assert str(e.value) == "tuple.index(x): x not in tuple"
 
 
-def test_mocked_update_length_output(snapshot_json: JSONSnapshotExtension) -> None:
+def test_mocked_update_length_output(snapshot_json: SnapshotAssertion) -> None:
     """モックされた `TTSEngine.update_length()` の出力スナップショットが一定である"""
     # Inputs
     tts_engine = TTSEngine(MockCoreWrapper())
@@ -356,7 +356,7 @@ def test_mocked_update_length_output(snapshot_json: JSONSnapshotExtension) -> No
     assert snapshot_json == round_floats(pydantic_to_native_type(result), round_value=2)
 
 
-def test_mocked_update_pitch_output(snapshot_json: JSONSnapshotExtension) -> None:
+def test_mocked_update_pitch_output(snapshot_json: SnapshotAssertion) -> None:
     """モックされた `TTSEngine.update_pitch()` の出力スナップショットが一定である"""
     # Inputs
     tts_engine = TTSEngine(MockCoreWrapper())
@@ -368,7 +368,7 @@ def test_mocked_update_pitch_output(snapshot_json: JSONSnapshotExtension) -> Non
 
 
 def test_mocked_update_length_and_pitch_output(
-    snapshot_json: JSONSnapshotExtension,
+    snapshot_json: SnapshotAssertion,
 ) -> None:
     """モックされた `TTSEngine.update_length_and_pitch()` の出力スナップショットが一定である"""
     # Inputs
@@ -381,7 +381,7 @@ def test_mocked_update_length_and_pitch_output(
 
 
 def test_mocked_create_accent_phrases_output(
-    snapshot_json: JSONSnapshotExtension,
+    snapshot_json: SnapshotAssertion,
 ) -> None:
     """モックされた `TTSEngine.create_accent_phrases()` の出力スナップショットが一定である"""
     # Inputs
@@ -394,7 +394,7 @@ def test_mocked_create_accent_phrases_output(
 
 
 def test_mocked_create_accent_phrases_from_kana_output(
-    snapshot_json: JSONSnapshotExtension,
+    snapshot_json: SnapshotAssertion,
 ) -> None:
     """モックされた `TTSEngine.create_accent_phrases_from_kana()` の出力スナップショットが一定である"""
     # Inputs
@@ -406,7 +406,7 @@ def test_mocked_create_accent_phrases_from_kana_output(
     assert snapshot_json == round_floats(pydantic_to_native_type(result), round_value=2)
 
 
-def test_mocked_synthesize_wave_output(snapshot_json: JSONSnapshotExtension) -> None:
+def test_mocked_synthesize_wave_output(snapshot_json: SnapshotAssertion) -> None:
     """モックされた `TTSEngine.synthesize_wave()` の出力スナップショットが一定である"""
     # Inputs
     tts_engine = TTSEngine(MockCoreWrapper())


### PR DESCRIPTION
## 内容

.gitattributeを使って、jsonスナップショットのdiffをgithub上で展開しないようにしました。
サンプルとしてプリセットAPIの実行結果のe2eテストを書きました。

あとsnapshot_jsonの型は`SnapshotAssertion`としておかないとcallするときにmypyエラーになることがわかったので書き換えました。

## その他
