### PR TITLE
整理: 巨大なバイナリファイルがあってもsnapshotが良い感じに取れるように

### DIFF
--- a/test/e2e/__snapshots__/test_speakers/test_歌手の情報を取得できる[388f246b-8c41-4ac1-8e2d-5d79f3ff56d9].json
+++ b/test/e2e/__snapshots__/test_speakers/test_歌手の情報を取得できる[388f246b-8c41-4ac1-8e2d-5d79f3ff56d9].json
@@ -1,11 +1,26 @@
 {
   "policy": "dummy2 policy\n\nhttps://voicevox.hiroshiba.jp/\n",
+  "portrait": "MD5:72ceb00f20b2a1e449f0b45973cc8b24",
   "style_infos": [
     {
-      "id": 5
+      "icon": "MD5:5f2211c3144b8dee613056bef5893d60",
+      "id": 5,
+      "portrait": null,
+      "voice_samples": [
+        "MD5:2b7f17f6751b9f0c76950ad3bcc1a619",
+        "MD5:4bc9f14cda818955cba931b1532e18fd",
+        "MD5:9ebfc3cf3fba47513a60c464fc57c705"
+      ]
     },
     {
-      "id": 7
+      "icon": "MD5:375ecba26764b7c71ce61731b52f71f8",
+      "id": 7,
+      "portrait": null,
+      "voice_samples": [
+        "MD5:fc93b361293ce128afd8f48d4cd89bc5",
+        "MD5:b74ee50cb135ccf29c0a1be2711f8cca",
+        "MD5:08c325d1cfe72209949a77c327b60302"
+      ]
     }
   ]
 }

--- a/test/e2e/__snapshots__/test_speakers/test_歌手の情報を取得できる[7ffcb7ce-00ec-4bdc-82cd-45a8889e43ff].json
+++ b/test/e2e/__snapshots__/test_speakers/test_歌手の情報を取得できる[7ffcb7ce-00ec-4bdc-82cd-45a8889e43ff].json
@@ -1,11 +1,26 @@
 {
   "policy": "dummy1 policy\n\nhttps://voicevox.hiroshiba.jp/\n",
+  "portrait": "MD5:cab33c9fdf563682108666a012dc9853",
   "style_infos": [
     {
-      "id": 4
+      "icon": "MD5:9dfc8b32d4afc3c933388ba85a8d8d12",
+      "id": 4,
+      "portrait": "MD5:2aba7f7037d00903dada4401582bf31a",
+      "voice_samples": [
+        "MD5:49c763de77c5c6be4967900b08b561a9",
+        "MD5:d9736740e3735bbf45efd792f8af7383",
+        "MD5:58bda86215149663b605d0ba0db59bde"
+      ]
     },
     {
-      "id": 6
+      "icon": "MD5:53b0f8ce874e450fc8cc5758d6ed2b03",
+      "id": 6,
+      "portrait": "MD5:6a79f7e6d8ca9087be9a0e39eac67e7b",
+      "voice_samples": [
+        "MD5:e9fbdc80f22d91a1ad96612ea60391b4",
+        "MD5:8c403062ffc5fca5605aca46778ed512",
+        "MD5:95a626ec8a36a3a550d7ba4188937cb3"
+      ]
     }
   ]
 }

--- a/test/e2e/__snapshots__/test_speakers/test_歌手の情報を取得できる[b1a81618-b27b-40d2-b0ea-27a9ad408c4b].json
+++ b/test/e2e/__snapshots__/test_speakers/test_歌手の情報を取得できる[b1a81618-b27b-40d2-b0ea-27a9ad408c4b].json
@@ -1,8 +1,16 @@
 {
   "policy": "dummy4 policy\n\nhttps://voicevox.hiroshiba.jp/\n",
+  "portrait": "MD5:70cb4a361935084f00f6956a4e8e4f32",
   "style_infos": [
     {
-      "id": 9
+      "icon": "MD5:e1e2fab676912fc0796a5b23320a0b67",
+      "id": 9,
+      "portrait": null,
+      "voice_samples": [
+        "MD5:fa1230e97dec17b814ec05da1709be19",
+        "MD5:714f4c4f2d3c51a1d9597a6960b8367c",
+        "MD5:bc47fd0d1ea9083c2f4621461ae072b8"
+      ]
     }
   ]
 }

--- a/test/e2e/__snapshots__/test_speakers/test_話者の情報を取得できる[35b2c544-660e-401e-b503-0e14c635303a].json
+++ b/test/e2e/__snapshots__/test_speakers/test_話者の情報を取得できる[35b2c544-660e-401e-b503-0e14c635303a].json
@@ -1,8 +1,16 @@
 {
   "policy": "dummy3 policy\n\nhttps://voicevox.hiroshiba.jp/\n",
+  "portrait": "MD5:90b250e0976f792e2fda2b1ad2643c7b",
   "style_infos": [
     {
-      "id": 8
+      "icon": "MD5:541aeccd87319c0af159cfa13baf26cb",
+      "id": 8,
+      "portrait": "MD5:1bb8b584e8499d601a3f3bf0c3216391",
+      "voice_samples": [
+        "MD5:148c72905d47a308cbdf9858c99ef9d7",
+        "MD5:46fda5f38dec0df94445066eee9ed128",
+        "MD5:61e7d2d3180c2c891cf096f50b98e317"
+      ]
     }
   ]
 }

--- a/test/e2e/__snapshots__/test_speakers/test_話者の情報を取得できる[388f246b-8c41-4ac1-8e2d-5d79f3ff56d9].json
+++ b/test/e2e/__snapshots__/test_speakers/test_話者の情報を取得できる[388f246b-8c41-4ac1-8e2d-5d79f3ff56d9].json
@@ -1,11 +1,26 @@
 {
   "policy": "dummy2 policy\n\nhttps://voicevox.hiroshiba.jp/\n",
+  "portrait": "MD5:72ceb00f20b2a1e449f0b45973cc8b24",
   "style_infos": [
     {
-      "id": 1
+      "icon": "MD5:3248458ae11d28ec1eb482db7f1927d9",
+      "id": 1,
+      "portrait": null,
+      "voice_samples": [
+        "MD5:2cdd82264a8b0ad508ff3f5a84d5c920",
+        "MD5:14b4a96141c6b9e86ce4f38adaac1fcb",
+        "MD5:4494752eec42b718ff3b9a3fb934596a"
+      ]
     },
     {
-      "id": 3
+      "icon": "MD5:3e32a4a66bd2505cb75f91c8028d061c",
+      "id": 3,
+      "portrait": "MD5:1dd8a513f11c204c1449172b7a812be8",
+      "voice_samples": [
+        "MD5:2bd7d3be714fdfdda2e96aa98888a9bd",
+        "MD5:10a9d6d4bcd02a6fa37d13c3f7335df1",
+        "MD5:6a21d1007f8957fca45843fde1e2d1c2"
+      ]
     }
   ]
 }

--- a/test/e2e/__snapshots__/test_speakers/test_話者の情報を取得できる[7ffcb7ce-00ec-4bdc-82cd-45a8889e43ff].json
+++ b/test/e2e/__snapshots__/test_speakers/test_話者の情報を取得できる[7ffcb7ce-00ec-4bdc-82cd-45a8889e43ff].json
@@ -1,11 +1,26 @@
 {
   "policy": "dummy1 policy\n\nhttps://voicevox.hiroshiba.jp/\n",
+  "portrait": "MD5:cab33c9fdf563682108666a012dc9853",
   "style_infos": [
     {
-      "id": 0
+      "icon": "MD5:529b1750562ca339ba05c1b00f4b2854",
+      "id": 0,
+      "portrait": "MD5:6c1c461e54ba4f57d0c17171d17e1d80",
+      "voice_samples": [
+        "MD5:85acb767ac22b1d17915c666cc5cee90",
+        "MD5:ad9e64177d28f960fb9ce40162cd82c2",
+        "MD5:16bf0d95c463fff08353a3452bdb8d7c"
+      ]
     },
     {
-      "id": 2
+      "icon": "MD5:04cce28c375949935497ec3d5d015be9",
+      "id": 2,
+      "portrait": "MD5:0a4e78369adc266672d571f4c0663697",
+      "voice_samples": [
+        "MD5:f508aca632a8f1cfd9eee7ed29cff96c",
+        "MD5:09984e27d23eee8af13809a0f621f7fd",
+        "MD5:e3f9a4df3f537bfb9d63d1791eda73e6"
+      ]
     }
   ]
 }

--- a/test/e2e/test_speakers.py
+++ b/test/e2e/test_speakers.py
@@ -3,9 +3,10 @@
 TODO: 話者と歌手の両ドメイン共通のドメイン用語を定め、このテストファイル名を変更する。
 """
 
+from test.utility import hash_long_string
+
 from fastapi.testclient import TestClient
 from pydantic import parse_obj_as
-from syrupy import filters
 from syrupy.assertion import SnapshotAssertion
 
 from voicevox_engine.metas.Metas import Speaker
@@ -23,15 +24,9 @@ def test_話者の情報を取得できる(client: TestClient, snapshot_json: Sn
         response = client.get(
             "/speaker_info", params={"speaker_uuid": speaker.speaker_uuid}
         )
-        assert (
-            snapshot_json(
-                name=speaker.speaker_uuid,
-                exclude=filters.props(
-                    "portrait", "icon", "voice_samples"
-                ),  # バイナリファイル系は除外  FIXME: 除外せずにハッシュ化する
-            )
-            == response.json()
-        )
+        assert snapshot_json(
+            name=speaker.speaker_uuid,
+        ) == hash_long_string(response.json())
 
 
 def test_歌手一覧が取得できる(client: TestClient, snapshot_json: SnapshotAssertion) -> None:
@@ -46,12 +41,6 @@ def test_歌手の情報を取得できる(client: TestClient, snapshot_json: Sn
         response = client.get(
             "/singer_info", params={"speaker_uuid": singer.speaker_uuid}
         )
-        assert (
-            snapshot_json(
-                name=singer.speaker_uuid,
-                exclude=filters.props(
-                    "portrait", "icon", "voice_samples"
-                ),  # バイナリファイル系は除外  FIXME: 除外せずにハッシュ化する
-            )
-            == response.json()
-        )
+        assert snapshot_json(
+            name=singer.speaker_uuid,
+        ) == hash_long_string(response.json())

--- a/test/utility.py
+++ b/test/utility.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 from typing import Any
 
@@ -19,3 +20,19 @@ def round_floats(value: Any, round_value: int) -> Any:
 def pydantic_to_native_type(value: Any) -> Any:
     """pydanticの型をnativeな型に変換する"""
     return json.loads(json.dumps(value, default=pydantic_encoder))
+
+
+def hash_long_string(value: Any) -> Any:
+    """文字数が1000文字を超えるものはハッシュ化する"""
+
+    def to_hash(value: str) -> str:
+        return "MD5:" + hashlib.md5(value.encode()).hexdigest()
+
+    if isinstance(value, str):
+        return value if len(value) <= 1000 else to_hash(value)
+    elif isinstance(value, list):
+        return [hash_long_string(v) for v in value]
+    elif isinstance(value, dict):
+        return {k: hash_long_string(v) for k, v in value.items()}
+    else:
+        return value


### PR DESCRIPTION
## 内容

json snapshotを作るとき、画像ファイルなどをbase64したものが含まれていた場合に良い感じにhash化するようにしてみました。

objを再帰的に見ていき、大きなstringがあったばあいにmd5に置き換えるようにしています。
ちょっと行儀悪い気もしますが、まあこれで現状十分かなと･･･。

## その他

ちなみに最新版のPydanticには[Base64Str](https://docs.pydantic.dev/latest/api/types/#pydantic.types.Base64Str)なる型があるので、これがあれば更に良い感じに書けるかもです。

- https://github.com/VOICEVOX/voicevox_engine/issues/995
