### PR TITLE
修正: 暗示的 `UserDictWord.mora_count=None`

### DIFF
--- a/test/user_dict/test_user_dict.py
+++ b/test/user_dict/test_user_dict.py
@@ -59,6 +59,7 @@ import_word = UserDictWord(
     yomi="テストツー",
     pronunciation="テストツー",
     accent_type=1,
+    mora_count=None,
     accent_associative_rule="*",
 )
 
@@ -106,6 +107,7 @@ class TestUserDict(TestCase):
                 yomi="テスト",
                 pronunciation="テスト",
                 accent_type=1,
+                mora_count=None,
                 accent_associative_rule="*",
             ),
         )

--- a/test/user_dict/test_user_dict_model.py
+++ b/test/user_dict/test_user_dict_model.py
@@ -1,4 +1,3 @@
-from copy import deepcopy
 from typing import TypedDict
 from unittest import TestCase
 
@@ -27,21 +26,22 @@ class TestModel(TypedDict):
 
 def generate_model() -> TestModel:
     return {
-            "surface": "テスト",
-            "priority": 0,
-            "part_of_speech": "名詞",
-            "part_of_speech_detail_1": "固有名詞",
-            "part_of_speech_detail_2": "一般",
-            "part_of_speech_detail_3": "*",
-            "inflectional_type": "*",
-            "inflectional_form": "*",
-            "stem": "*",
-            "yomi": "テスト",
-            "pronunciation": "テスト",
-            "accent_type": 0,
-            "mora_count": None,
-            "accent_associative_rule": "*",
-        }
+        "surface": "テスト",
+        "priority": 0,
+        "part_of_speech": "名詞",
+        "part_of_speech_detail_1": "固有名詞",
+        "part_of_speech_detail_2": "一般",
+        "part_of_speech_detail_3": "*",
+        "inflectional_type": "*",
+        "inflectional_form": "*",
+        "stem": "*",
+        "yomi": "テスト",
+        "pronunciation": "テスト",
+        "accent_type": 0,
+        "mora_count": None,
+        "accent_associative_rule": "*",
+    }
+
 
 class TestUserDictWords(TestCase):
     def setUp(self):

--- a/test/user_dict/test_user_dict_model.py
+++ b/test/user_dict/test_user_dict_model.py
@@ -21,12 +21,12 @@ class TestModel(TypedDict):
     yomi: str
     pronunciation: str
     accent_type: int
+    mora_count: int | None
     accent_associative_rule: str
 
 
-class TestUserDictWords(TestCase):
-    def setUp(self):
-        self.test_model: TestModel = {
+def generate_model() -> TestModel:
+    return {
             "surface": "テスト",
             "priority": 0,
             "part_of_speech": "名詞",
@@ -39,27 +39,32 @@ class TestUserDictWords(TestCase):
             "yomi": "テスト",
             "pronunciation": "テスト",
             "accent_type": 0,
+            "mora_count": None,
             "accent_associative_rule": "*",
         }
 
+class TestUserDictWords(TestCase):
+    def setUp(self):
+        pass
+
     def test_valid_word(self):
-        test_value = deepcopy(self.test_model)
+        test_value = generate_model()
         try:
             UserDictWord(**test_value)
         except ValidationError as e:
             self.fail(f"Unexpected Validation Error\n{str(e)}")
 
     def test_convert_to_zenkaku(self):
-        test_value = deepcopy(self.test_model)
+        test_value = generate_model()
         test_value["surface"] = "test"
         self.assertEqual(UserDictWord(**test_value).surface, "ｔｅｓｔ")
 
     def test_count_mora(self):
-        test_value = deepcopy(self.test_model)
+        test_value = generate_model()
         self.assertEqual(UserDictWord(**test_value).mora_count, 3)
 
     def test_count_mora_x(self):
-        test_value = deepcopy(self.test_model)
+        test_value = generate_model()
         for s in [chr(i) for i in range(12449, 12533)]:
             if s in ["ァ", "ィ", "ゥ", "ェ", "ォ", "ッ", "ャ", "ュ", "ョ", "ヮ"]:
                 continue
@@ -77,7 +82,7 @@ class TestUserDictWords(TestCase):
                     )
 
     def test_count_mora_xwa(self):
-        test_value = deepcopy(self.test_model)
+        test_value = generate_model()
         test_value["pronunciation"] = "クヮンセイ"
         expected_count = 0
         for accent_phrase in parse_kana(
@@ -90,36 +95,36 @@ class TestUserDictWords(TestCase):
         )
 
     def test_invalid_pronunciation_not_katakana(self):
-        test_value = deepcopy(self.test_model)
+        test_value = generate_model()
         test_value["pronunciation"] = "ぼいぼ"
         with self.assertRaises(ValidationError):
             UserDictWord(**test_value)
 
     def test_invalid_pronunciation_invalid_sutegana(self):
-        test_value = deepcopy(self.test_model)
+        test_value = generate_model()
         test_value["pronunciation"] = "アィウェォ"
         with self.assertRaises(ValidationError):
             UserDictWord(**test_value)
 
     def test_invalid_pronunciation_invalid_xwa(self):
-        test_value = deepcopy(self.test_model)
+        test_value = generate_model()
         test_value["pronunciation"] = "アヮ"
         with self.assertRaises(ValidationError):
             UserDictWord(**test_value)
 
     def test_count_mora_voiced_sound(self):
-        test_value = deepcopy(self.test_model)
+        test_value = generate_model()
         test_value["pronunciation"] = "ボイボ"
         self.assertEqual(UserDictWord(**test_value).mora_count, 3)
 
     def test_invalid_accent_type(self):
-        test_value = deepcopy(self.test_model)
+        test_value = generate_model()
         test_value["accent_type"] = 4
         with self.assertRaises(ValidationError):
             UserDictWord(**test_value)
 
     def test_invalid_accent_type_2(self):
-        test_value = deepcopy(self.test_model)
+        test_value = generate_model()
         test_value["accent_type"] = -1
         with self.assertRaises(ValidationError):
             UserDictWord(**test_value)

--- a/voicevox_engine/user_dict/user_dict.py
+++ b/voicevox_engine/user_dict/user_dict.py
@@ -232,6 +232,7 @@ def _create_word(
         yomi=pronunciation,
         pronunciation=pronunciation,
         accent_type=accent_type,
+        mora_count=None,
         accent_associative_rule="*",
     )
 


### PR DESCRIPTION
## 内容
ユーザー辞書関連の暗示的 `UserDictWord.mora_count = None` を明示化

ユーザー辞書テストで `deepcopy()` による型情報欠落が起きていたため、テストオブジェクト生成関数で置き換えた。  
その結果、`UserDictWord` インスタンス生成時にしばしば引数 `mora_count: int | None` が忘れられていることが判明した。  
`**` による展開時に暗示的な `None` 渡しがおこなわれていた、のかもしれない。  

このような背景から、ユーザー辞書関連の暗示的 `mora_count=None` を明示化することを提案します。

## 関連 Issue
無し