### PR TITLE
整理: fastapiの依存パッケージに意図コメント追加

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,12 +46,12 @@ authors = ["Hiroshiba <hihokaruta@gmail.com>"]
 python = "~3.11"
 numpy = "^1.20.0"
 fastapi = "^0.103.2"
-python-multipart = "^0.0.5"
+python-multipart = "^0.0.5" # NOTE: required by fastapi
 uvicorn = "^0.15.0"
 soundfile = "^0.12.1"
 pyyaml = "^6.0"
 pyworld = "^0.3.0"
-jinja2 = "^3.1.2"
+jinja2 = "^3.1.2" # NOTE: required by fastapi
 pyopenjtalk = { git = "https://github.com/VOICEVOX/pyopenjtalk", rev = "b35fc89fe42948a28e33aed886ea145a51113f88" }
 semver = "^3.0.0"
 platformdirs = "^3.10.0"


### PR DESCRIPTION
## 内容
概要: 依存パッケージ意図を追加してリファクタリング

`pyproject.toml` には依存パッケージが記録されているが、その一部は VOICEVOX ENGINE コード内に一切登場しない（見た目上の依存性がない）。これらのうち 3 つが FastAPI に暗示的に依存するものであるが、そのうち 1 つのみに FastAPI 依存に関する記述/コメントがある。他の2つにも同様のコメントを付与することでパッケージの依存関係を理解しやすくできる。  

このような背景から、依存パッケージ意図の追加によるリファクタリングを提案します。  

## 関連 Issue
- #1077