### PR TITLE
追加: `poetry` バージョン固定

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ soxr = "^0.3.6"
 [tool.poetry.group.dev.dependencies]
 pyinstaller = "^5.13"
 pre-commit = "^2.16.0"
-poetry = "^1.3.1"
+poetry = "1.6.1"
 
 [tool.poetry.group.test.dependencies]
 pysen = "~0.10.5"
@@ -71,7 +71,7 @@ isort = "^5.12.0"
 mypy = "^1.8.0"
 pytest = "^7.4.3"
 coveralls = "^3.2.0"
-poetry = "^1.3.1"
+poetry = "1.6.1"
 httpx = "^0.25.0"          # NOTE: required by fastapi.testclient.TestClient
 syrupy = "^4.6.0"
 types-pyyaml = "^6.0"


### PR DESCRIPTION
## 内容
`poetry` のバージョンを固定する。  

lockファイル内で元々 `poetry==1.6.1` となっているため、lockファイルに更新はない。  
その結果、この lock ファイルに依存する pip 用ファイルでも更新はない。  

## 関連 Issue
resolve #1075