### PR TITLE
整理: e2e 合成系 single API テスト

### DIFF
--- a/test/e2e/single_api/test_accent_phrases.py
+++ b/test/e2e/single_api/test_accent_phrases.py
@@ -6,5 +6,7 @@ from fastapi.testclient import TestClient
 
 
 def test_post_accent_phrases_200(client: TestClient) -> None:
-    response = client.post("/accent_phrases", params={"text": "テストです", "speaker": 0})
+    response = client.post(
+        "/accent_phrases", params={"text": "テストです", "speaker": 0}
+    )
     assert response.status_code == 200

--- a/test/e2e/single_api/test_accent_phrases.py
+++ b/test/e2e/single_api/test_accent_phrases.py
@@ -1,0 +1,10 @@
+"""
+/accent_phrases API のテスト
+"""
+
+from fastapi.testclient import TestClient
+
+
+def test_post_accent_phrases_200(client: TestClient) -> None:
+    response = client.post("/accent_phrases", params={"text": "テストです", "speaker": 0})
+    assert response.status_code == 200

--- a/test/e2e/single_api/test_audio_query_from_preset.py
+++ b/test/e2e/single_api/test_audio_query_from_preset.py
@@ -2,12 +2,16 @@
 /audio_query_from_preset API のテスト
 """
 
+import pytest
 from fastapi.testclient import TestClient
 
-# def test_post_audio_query_from_preset_200(client: TestClient) -> None:
-#     query_params = {"text": "テストです", "preset_id": 0}
-#     response = client.post("/audio_query_from_preset", params=query_params)
-#     assert response.status_code == 200
+
+@pytest.mark.skip(reason="200の前提として別APIを要するプリセット登録が必要だから")
+def test_post_audio_query_from_preset_200(client: TestClient) -> None:
+    response = client.post(
+        "/audio_query_from_preset", params={"text": "テストです", "preset_id": 0}
+    )
+    assert response.status_code == 200
 
 
 def test_post_audio_query_from_preset_422(client: TestClient) -> None:

--- a/test/e2e/single_api/test_audio_query_from_preset.py
+++ b/test/e2e/single_api/test_audio_query_from_preset.py
@@ -1,0 +1,15 @@
+"""
+/audio_query_from_preset API のテスト
+"""
+
+from fastapi.testclient import TestClient
+
+
+# def test_post_audio_query_from_preset_200(client: TestClient) -> None:
+#     response = client.post("/audio_query_from_preset", params={"text": "テストです", "preset_id": 0})
+#     assert response.status_code == 200
+
+
+def test_post_audio_query_from_preset_422(client: TestClient) -> None:
+    response = client.post("/audio_query_from_preset", params={"text": "テストです", "preset_id": 404})
+    assert response.status_code == 422

--- a/test/e2e/single_api/test_audio_query_from_preset.py
+++ b/test/e2e/single_api/test_audio_query_from_preset.py
@@ -4,12 +4,13 @@
 
 from fastapi.testclient import TestClient
 
-
 # def test_post_audio_query_from_preset_200(client: TestClient) -> None:
 #     response = client.post("/audio_query_from_preset", params={"text": "テストです", "preset_id": 0})
 #     assert response.status_code == 200
 
 
 def test_post_audio_query_from_preset_422(client: TestClient) -> None:
-    response = client.post("/audio_query_from_preset", params={"text": "テストです", "preset_id": 404})
+    response = client.post(
+        "/audio_query_from_preset", params={"text": "テストです", "preset_id": 404}
+    )
     assert response.status_code == 422

--- a/test/e2e/single_api/test_audio_query_from_preset.py
+++ b/test/e2e/single_api/test_audio_query_from_preset.py
@@ -5,7 +5,8 @@
 from fastapi.testclient import TestClient
 
 # def test_post_audio_query_from_preset_200(client: TestClient) -> None:
-#     response = client.post("/audio_query_from_preset", params={"text": "テストです", "preset_id": 0})
+#     query_params = {"text": "テストです", "preset_id": 0}
+#     response = client.post("/audio_query_from_preset", params=query_params)
 #     assert response.status_code == 200
 
 

--- a/test/e2e/single_api/test_mora_data.py
+++ b/test/e2e/single_api/test_mora_data.py
@@ -2,9 +2,9 @@
 /mora_data API のテスト
 """
 
-from fastapi.testclient import TestClient
-
 from test.e2e.single_api.utils import gen_mora
+
+from fastapi.testclient import TestClient
 
 
 def test_post_mora_data_200(client: TestClient) -> None:

--- a/test/e2e/single_api/test_mora_data.py
+++ b/test/e2e/single_api/test_mora_data.py
@@ -4,7 +4,7 @@
 
 from fastapi.testclient import TestClient
 
-from .utils import gen_mora
+from test.e2e.single_api.utils import gen_mora
 
 
 def test_post_mora_data_200(client: TestClient) -> None:

--- a/test/e2e/single_api/test_mora_data.py
+++ b/test/e2e/single_api/test_mora_data.py
@@ -4,15 +4,21 @@
 
 from fastapi.testclient import TestClient
 
+from .utils import gen_mora
+
 
 def test_post_mora_data_200(client: TestClient) -> None:
     accent_phrases = [
-        {'moras': [
-            {'text': 'テ', 'consonant': 't', 'consonant_length': 2.3, 'vowel': 'e', 'vowel_length': 0.8, 'pitch': 3.3},
-            {'text': 'ス', 'consonant': 's', 'consonant_length': 2.1, 'vowel': 'U', 'vowel_length': 0.3, 'pitch': 0.0},
-            {'text': 'ト', 'consonant': 't', 'consonant_length': 2.3, 'vowel': 'o', 'vowel_length': 1.8, 'pitch': 4.1},
-        ], 'accent': 1, 'pause_mora': None, 'is_interrogative': False}
+        {
+            "moras": [
+                gen_mora("テ", "t", 2.3, "e", 0.8, 3.3),
+                gen_mora("ス", "s", 2.1, "U", 0.3, 0.0),
+                gen_mora("ト", "t", 2.3, "o", 1.8, 4.1),
+            ],
+            "accent": 1,
+            "pause_mora": None,
+            "is_interrogative": False,
+        }
     ]
     response = client.post("/mora_data", params={"speaker": 0}, json=accent_phrases)
     assert response.status_code == 200
-

--- a/test/e2e/single_api/test_mora_data.py
+++ b/test/e2e/single_api/test_mora_data.py
@@ -1,0 +1,18 @@
+"""
+/mora_data API のテスト
+"""
+
+from fastapi.testclient import TestClient
+
+
+def test_post_mora_data_200(client: TestClient) -> None:
+    accent_phrases = [
+        {'moras': [
+            {'text': 'テ', 'consonant': 't', 'consonant_length': 2.3, 'vowel': 'e', 'vowel_length': 0.8, 'pitch': 3.3},
+            {'text': 'ス', 'consonant': 's', 'consonant_length': 2.1, 'vowel': 'U', 'vowel_length': 0.3, 'pitch': 0.0},
+            {'text': 'ト', 'consonant': 't', 'consonant_length': 2.3, 'vowel': 'o', 'vowel_length': 1.8, 'pitch': 4.1},
+        ], 'accent': 1, 'pause_mora': None, 'is_interrogative': False}
+    ]
+    response = client.post("/mora_data", params={"speaker": 0}, json=accent_phrases)
+    assert response.status_code == 200
+

--- a/test/e2e/single_api/test_mora_length.py
+++ b/test/e2e/single_api/test_mora_length.py
@@ -4,15 +4,21 @@
 
 from fastapi.testclient import TestClient
 
+from .utils import gen_mora
+
 
 def test_post_mora_length_200(client: TestClient) -> None:
     accent_phrases = [
-        {'moras': [
-            {'text': 'テ', 'consonant': 't', 'consonant_length': 2.3, 'vowel': 'e', 'vowel_length': 0.8, 'pitch': 3.3},
-            {'text': 'ス', 'consonant': 's', 'consonant_length': 2.1, 'vowel': 'U', 'vowel_length': 0.3, 'pitch': 0.0},
-            {'text': 'ト', 'consonant': 't', 'consonant_length': 2.3, 'vowel': 'o', 'vowel_length': 1.8, 'pitch': 4.1},
-        ], 'accent': 1, 'pause_mora': None, 'is_interrogative': False}
+        {
+            "moras": [
+                gen_mora("テ", "t", 2.3, "e", 0.8, 3.3),
+                gen_mora("ス", "s", 2.1, "U", 0.3, 0.0),
+                gen_mora("ト", "t", 2.3, "o", 1.8, 4.1),
+            ],
+            "accent": 1,
+            "pause_mora": None,
+            "is_interrogative": False,
+        }
     ]
     response = client.post("/mora_length", params={"speaker": 0}, json=accent_phrases)
     assert response.status_code == 200
-

--- a/test/e2e/single_api/test_mora_length.py
+++ b/test/e2e/single_api/test_mora_length.py
@@ -1,0 +1,18 @@
+"""
+/mora_length API のテスト
+"""
+
+from fastapi.testclient import TestClient
+
+
+def test_post_mora_length_200(client: TestClient) -> None:
+    accent_phrases = [
+        {'moras': [
+            {'text': 'テ', 'consonant': 't', 'consonant_length': 2.3, 'vowel': 'e', 'vowel_length': 0.8, 'pitch': 3.3},
+            {'text': 'ス', 'consonant': 's', 'consonant_length': 2.1, 'vowel': 'U', 'vowel_length': 0.3, 'pitch': 0.0},
+            {'text': 'ト', 'consonant': 't', 'consonant_length': 2.3, 'vowel': 'o', 'vowel_length': 1.8, 'pitch': 4.1},
+        ], 'accent': 1, 'pause_mora': None, 'is_interrogative': False}
+    ]
+    response = client.post("/mora_length", params={"speaker": 0}, json=accent_phrases)
+    assert response.status_code == 200
+

--- a/test/e2e/single_api/test_mora_length.py
+++ b/test/e2e/single_api/test_mora_length.py
@@ -4,7 +4,7 @@
 
 from fastapi.testclient import TestClient
 
-from .utils import gen_mora
+from test.e2e.single_api.utils import gen_mora
 
 
 def test_post_mora_length_200(client: TestClient) -> None:

--- a/test/e2e/single_api/test_mora_length.py
+++ b/test/e2e/single_api/test_mora_length.py
@@ -2,9 +2,9 @@
 /mora_length API のテスト
 """
 
-from fastapi.testclient import TestClient
-
 from test.e2e.single_api.utils import gen_mora
+
+from fastapi.testclient import TestClient
 
 
 def test_post_mora_length_200(client: TestClient) -> None:

--- a/test/e2e/single_api/test_mora_pitch.py
+++ b/test/e2e/single_api/test_mora_pitch.py
@@ -4,7 +4,7 @@
 
 from fastapi.testclient import TestClient
 
-from .utils import gen_mora
+from test.e2e.single_api.utils import gen_mora
 
 
 def test_post_mora_pitch_200(client: TestClient) -> None:

--- a/test/e2e/single_api/test_mora_pitch.py
+++ b/test/e2e/single_api/test_mora_pitch.py
@@ -1,0 +1,18 @@
+"""
+/mora_pitch API のテスト
+"""
+
+from fastapi.testclient import TestClient
+
+
+def test_post_mora_pitch_200(client: TestClient) -> None:
+    accent_phrases = [
+        {'moras': [
+            {'text': 'テ', 'consonant': 't', 'consonant_length': 2.3, 'vowel': 'e', 'vowel_length': 0.8, 'pitch': 3.3},
+            {'text': 'ス', 'consonant': 's', 'consonant_length': 2.1, 'vowel': 'U', 'vowel_length': 0.3, 'pitch': 0.0},
+            {'text': 'ト', 'consonant': 't', 'consonant_length': 2.3, 'vowel': 'o', 'vowel_length': 1.8, 'pitch': 4.1},
+        ], 'accent': 1, 'pause_mora': None, 'is_interrogative': False}
+    ]
+    response = client.post("/mora_pitch", params={"speaker": 0}, json=accent_phrases)
+    assert response.status_code == 200
+

--- a/test/e2e/single_api/test_mora_pitch.py
+++ b/test/e2e/single_api/test_mora_pitch.py
@@ -4,15 +4,21 @@
 
 from fastapi.testclient import TestClient
 
+from .utils import gen_mora
+
 
 def test_post_mora_pitch_200(client: TestClient) -> None:
     accent_phrases = [
-        {'moras': [
-            {'text': 'テ', 'consonant': 't', 'consonant_length': 2.3, 'vowel': 'e', 'vowel_length': 0.8, 'pitch': 3.3},
-            {'text': 'ス', 'consonant': 's', 'consonant_length': 2.1, 'vowel': 'U', 'vowel_length': 0.3, 'pitch': 0.0},
-            {'text': 'ト', 'consonant': 't', 'consonant_length': 2.3, 'vowel': 'o', 'vowel_length': 1.8, 'pitch': 4.1},
-        ], 'accent': 1, 'pause_mora': None, 'is_interrogative': False}
+        {
+            "moras": [
+                gen_mora("テ", "t", 2.3, "e", 0.8, 3.3),
+                gen_mora("ス", "s", 2.1, "U", 0.3, 0.0),
+                gen_mora("ト", "t", 2.3, "o", 1.8, 4.1),
+            ],
+            "accent": 1,
+            "pause_mora": None,
+            "is_interrogative": False,
+        }
     ]
     response = client.post("/mora_pitch", params={"speaker": 0}, json=accent_phrases)
     assert response.status_code == 200
-

--- a/test/e2e/single_api/test_mora_pitch.py
+++ b/test/e2e/single_api/test_mora_pitch.py
@@ -2,9 +2,9 @@
 /mora_pitch API のテスト
 """
 
-from fastapi.testclient import TestClient
-
 from test.e2e.single_api.utils import gen_mora
+
+from fastapi.testclient import TestClient
 
 
 def test_post_mora_pitch_200(client: TestClient) -> None:

--- a/test/e2e/single_api/test_synthesis.py
+++ b/test/e2e/single_api/test_synthesis.py
@@ -4,7 +4,7 @@
 
 from fastapi.testclient import TestClient
 
-from .utils import gen_mora
+from test.e2e.single_api.utils import gen_mora
 
 
 def test_post_synthesis_200(client: TestClient) -> None:

--- a/test/e2e/single_api/test_synthesis.py
+++ b/test/e2e/single_api/test_synthesis.py
@@ -1,0 +1,29 @@
+"""
+/synthesis API のテスト
+"""
+
+from fastapi.testclient import TestClient
+
+
+def test_post_synthesis_200(client: TestClient) -> None:
+    query = {
+        'accent_phrases': [
+            {'moras': [
+                {'text': 'テ', 'consonant': 't', 'consonant_length': 2.3, 'vowel': 'e', 'vowel_length': 0.8, 'pitch': 3.3},
+                {'text': 'ス', 'consonant': 's', 'consonant_length': 2.1, 'vowel': 'U', 'vowel_length': 0.3, 'pitch': 0.0},
+                {'text': 'ト', 'consonant': 't', 'consonant_length': 2.3, 'vowel': 'o', 'vowel_length': 1.8, 'pitch': 4.1},
+            ], 'accent': 1, 'pause_mora': None, 'is_interrogative': False}
+        ],
+       'speedScale': 1.0,
+       'pitchScale': 1.0,
+       'intonationScale': 1.0,
+       'volumeScale': 1.0,
+       'prePhonemeLength': 0.1,
+       'postPhonemeLength': 0.1,
+       'outputSamplingRate': 24000,
+       'outputStereo': False,
+       'kana': "テ'_スト"
+    }
+    response = client.post("/synthesis", params={"speaker": 0}, json=query)
+    assert response.status_code == 200
+

--- a/test/e2e/single_api/test_synthesis.py
+++ b/test/e2e/single_api/test_synthesis.py
@@ -2,9 +2,9 @@
 /synthesis API のテスト
 """
 
-from fastapi.testclient import TestClient
-
 from test.e2e.single_api.utils import gen_mora
+
+from fastapi.testclient import TestClient
 
 
 def test_post_synthesis_200(client: TestClient) -> None:

--- a/test/e2e/single_api/test_synthesis.py
+++ b/test/e2e/single_api/test_synthesis.py
@@ -4,26 +4,32 @@
 
 from fastapi.testclient import TestClient
 
+from .utils import gen_mora
+
 
 def test_post_synthesis_200(client: TestClient) -> None:
     query = {
-        'accent_phrases': [
-            {'moras': [
-                {'text': 'テ', 'consonant': 't', 'consonant_length': 2.3, 'vowel': 'e', 'vowel_length': 0.8, 'pitch': 3.3},
-                {'text': 'ス', 'consonant': 's', 'consonant_length': 2.1, 'vowel': 'U', 'vowel_length': 0.3, 'pitch': 0.0},
-                {'text': 'ト', 'consonant': 't', 'consonant_length': 2.3, 'vowel': 'o', 'vowel_length': 1.8, 'pitch': 4.1},
-            ], 'accent': 1, 'pause_mora': None, 'is_interrogative': False}
+        "accent_phrases": [
+            {
+                "moras": [
+                    gen_mora("テ", "t", 2.3, "e", 0.8, 3.3),
+                    gen_mora("ス", "s", 2.1, "U", 0.3, 0.0),
+                    gen_mora("ト", "t", 2.3, "o", 1.8, 4.1),
+                ],
+                "accent": 1,
+                "pause_mora": None,
+                "is_interrogative": False,
+            }
         ],
-       'speedScale': 1.0,
-       'pitchScale': 1.0,
-       'intonationScale': 1.0,
-       'volumeScale': 1.0,
-       'prePhonemeLength': 0.1,
-       'postPhonemeLength': 0.1,
-       'outputSamplingRate': 24000,
-       'outputStereo': False,
-       'kana': "テ'_スト"
+        "speedScale": 1.0,
+        "pitchScale": 1.0,
+        "intonationScale": 1.0,
+        "volumeScale": 1.0,
+        "prePhonemeLength": 0.1,
+        "postPhonemeLength": 0.1,
+        "outputSamplingRate": 24000,
+        "outputStereo": False,
+        "kana": "テ'_スト",
     }
     response = client.post("/synthesis", params={"speaker": 0}, json=query)
     assert response.status_code == 200
-

--- a/test/e2e/single_api/utils.py
+++ b/test/e2e/single_api/utils.py
@@ -1,0 +1,28 @@
+from typing import TypedDict
+
+
+class MoraForTest(TypedDict):
+    text: str
+    consonant: str
+    consonant_length: float
+    vowel: str
+    vowel_length: float
+    pitch: float
+
+
+def gen_mora(
+    text: str,
+    consonant: str,
+    consonant_length: float,
+    vowel: str,
+    vowel_length: float,
+    pitch: float,
+) -> MoraForTest:
+    return {
+        "text": text,
+        "consonant": consonant,
+        "consonant_length": consonant_length,
+        "vowel": vowel,
+        "vowel_length": vowel_length,
+        "pitch": pitch,
+    }


### PR DESCRIPTION
## 内容
e2e 合成系 single API テストを追加  

次のAPIに対し、status code チェック（#1065 における A の簡易版）を追加した。


- [x] `POST /audio_query_from_preset`
  - [ ] `200`
  - [x] `422`
- [x] `POST /accent_phrases`
  - [x] `200`
- [x] `POST /mora_data`
  - [x] `200`
- [x] `POST /mora_length`
  - [x] `200`
- [x] `POST /mora_pitch`
  - [x] `200`
- [x] `POST /synthesis`
  - [x] `200`

## 関連 Issue
part of #1065