### PR TITLE
追加: `poetry-plugin-export`

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2374,4 +2374,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.11"
-content-hash = "288bc863ee0de8532980f44207a3e87f1ec9c0ecfe790247649275bfbeb2beb6"
+content-hash = "dd531f8d707d026b99b62be8b8eb5e8bae09a971b0df699aa9f5fe30f0bcdb6e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ soxr = "^0.3.6"
 pyinstaller = "^5.13"
 pre-commit = "^2.16.0"
 poetry = "1.8.1"
+poetry-plugin-export = "^1.6.0"
 
 [tool.poetry.group.test.dependencies]
 pysen = "~0.10.5"
@@ -72,6 +73,7 @@ mypy = "^1.8.0"
 pytest = "^8.0.0"
 coveralls = "^3.2.0"
 poetry = "1.8.1"
+poetry-plugin-export = "^1.6.0"
 httpx = "^0.25.0"          # NOTE: required by fastapi.testclient.TestClient
 syrupy = "^4.6.1"
 types-pyyaml = "^6.0"


### PR DESCRIPTION
## 内容
`poetry-plugin-export` 追加による `poetry export` コマンドの維持 

`poetry==1.8.1` が `poetry-plugin-export` をデフォルトインストールしているため、lockファイルのパッケージ部分には現時点で変更無し（将来的にこのデフォルトインストールが無くなるとのこと）。  

## 関連 Issue
resolve #1083