### PR TITLE
修正: キャンセル可能生成の `500` プロセスエラー

### DIFF
--- a/voicevox_engine/cancellable_engine.py
+++ b/voicevox_engine/cancellable_engine.py
@@ -172,7 +172,7 @@ class CancellableEngine:
             f_name = sub_proc_con1.recv()
         except EOFError:
             raise HTTPException(
-                status_code=422, detail="既にサブプロセスは終了されています"
+                status_code=500, detail="既にサブプロセスは終了されています"
             )
         except Exception:
             self.finalize_con(request, proc, sub_proc_con1)


### PR DESCRIPTION
## 内容
`CancellableEngine` の「既にサブプロセスは終了されています」エラーをサーバーで起因の `500` エラーへ修正

## 関連 Issue
ref https://github.com/VOICEVOX/voicevox_engine/issues/944#issuecomment-1961739822