### PR TITLE
追加: `poetry check` フック

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,12 @@ repos:
         types: [file, python]
         stages: [push]
         pass_filenames: false
+      - id: poetry-check # `pyproject.toml` と `poetry.lock` が整合する
+        name: poetry-check
+        entry: poetry check
+        language: python
+        stages: [push]
+        pass_filenames: false
       - id: poetry-export
         name: poetry-export
         entry: poetry export --without-hashes -o requirements.txt


### PR DESCRIPTION
## 内容
`content-hash` 未更新を `poetry check` pre-commit により予防する

## 関連 Issue
resolve #1091