### PR TITLE
修正: Settingクラスのcors_policy_modeの型をCorsPolicyModeのみに制限

### DIFF
--- a/run.py
+++ b/run.py
@@ -1348,7 +1348,7 @@ def generate_app(
         settings = setting_loader.load()
 
         brand_name = engine_manifest_data.brand_name
-        cors_policy_mode = settings.cors_policy_mode
+        cors_policy_mode = settings.cors_policy_mode.value
         allow_origin = settings.allow_origin
 
         if allow_origin is None:

--- a/run.py
+++ b/run.py
@@ -1348,7 +1348,7 @@ def generate_app(
         settings = setting_loader.load()
 
         brand_name = engine_manifest_data.brand_name
-        cors_policy_mode = settings.cors_policy_mode.value
+        cors_policy_mode = settings.cors_policy_mode
         allow_origin = settings.allow_origin
 
         if allow_origin is None:
@@ -1359,7 +1359,7 @@ def generate_app(
             {
                 "request": request,
                 "brand_name": brand_name,
-                "cors_policy_mode": cors_policy_mode,
+                "cors_policy_mode": cors_policy_mode.value,
                 "allow_origin": allow_origin,
             },
         )

--- a/test/setting/test_setting.py
+++ b/test/setting/test_setting.py
@@ -69,5 +69,17 @@ class TestSettingLoader(TestCase):
             {"allow_origin": None, "cors_policy_mode": CorsPolicyMode.localapps},
         )
 
+    def test_cors_policy_mode_type(self) -> None:
+        setting_loader = SettingHandler(
+            setting_file_path=Path("test/setting/setting-test-load-1.yaml")
+        )
+        settings = setting_loader.load()
+
+        self.assertIsInstance(settings.cors_policy_mode, CorsPolicyMode)
+
+    def test_invalid_cors_policy_mode_type(self):
+        with self.assertRaises(ValueError):
+            Setting(cors_policy_mode="invalid_value", allow_origin="*")
+
     def tearDown(self) -> None:
         self.tmp_dir.cleanup()

--- a/test/setting/test_setting.py
+++ b/test/setting/test_setting.py
@@ -2,6 +2,8 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import TestCase
 
+from pydantic import ValidationError
+
 from voicevox_engine.setting.Setting import CorsPolicyMode, Setting
 from voicevox_engine.setting.SettingLoader import SettingHandler
 
@@ -78,7 +80,7 @@ class TestSettingLoader(TestCase):
         self.assertIsInstance(settings.cors_policy_mode, CorsPolicyMode)
 
     def test_invalid_cors_policy_mode_type(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ValidationError):
             Setting(cors_policy_mode="invalid_value", allow_origin="*")
 
     def tearDown(self) -> None:

--- a/voicevox_engine/setting/Setting.py
+++ b/voicevox_engine/setting/Setting.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, validator
 
 
 class CorsPolicyMode(str, Enum):
@@ -21,5 +21,8 @@ class Setting(BaseModel):
     cors_policy_mode: CorsPolicyMode = Field(title="リソース共有ポリシー")
     allow_origin: Optional[str] = Field(title="許可するオリジン")
 
-    class Config:
-        use_enum_values = True
+    @validator("cors_policy_mode", pre=True)
+    def convert_cors_policy_mode(cls, value):
+        if isinstance(value, str):
+            CorsPolicyMode(value)
+        return value

--- a/voicevox_engine/setting/Setting.py
+++ b/voicevox_engine/setting/Setting.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import Optional
 
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, Field
 
 
 class CorsPolicyMode(str, Enum):
@@ -20,9 +20,3 @@ class Setting(BaseModel):
 
     cors_policy_mode: CorsPolicyMode = Field(title="リソース共有ポリシー")
     allow_origin: Optional[str] = Field(title="許可するオリジン")
-
-    @validator("cors_policy_mode", pre=True)
-    def convert_cors_policy_mode(cls, value):
-        if isinstance(value, str):
-            CorsPolicyMode(value)
-        return value

--- a/voicevox_engine/setting/SettingLoader.py
+++ b/voicevox_engine/setting/SettingLoader.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from pathlib import Path
 
 import yaml
@@ -37,6 +38,9 @@ class SettingHandler:
     def save(self, settings: Setting) -> None:
         """設定値をファイルへ書き込む。"""
         settings_dict = settings.dict()
+
+        if isinstance(settings_dict["cors_policy_mode"], Enum):
+            settings_dict["cors_policy_mode"] = settings_dict["cors_policy_mode"].value
 
         with open(self.setting_file_path, mode="w", encoding="utf-8") as f:
             yaml.safe_dump(settings_dict, f)


### PR DESCRIPTION
## 内容

* Settingクラスにvalidatorを追加し、`str`型が`cors_policy_mode`に使用された時に、`CorsPolicyMode`に変更する
  * これにより、設定ファイルからロードした際も型が`CorsPolicyMode`になる(`test_cors_policy_mode_type`にてテスト)
* `SettingLoader.py`において、設定ファイルに書き込む際は`str`型に戻す必要があり、そのためのコードを追加
  * 既存の`test_dump`にてテスト
* Settingクラスの`cors_policy_mode`に`all`, `localapps`以外で初期化する時にエラー処理を追加
  * `test_invalid_cors_policy_mode_type`にてテスト

## 関連 Issue
close #1102
<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #1102
-->



<!--
## スクリーンショット・動画など
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

<!--
## その他
-->
