### PR TITLE
整理: e2e single API テスト vol 3

### DIFF
--- a/test/e2e/single_api/test_core_versions.py
+++ b/test/e2e/single_api/test_core_versions.py
@@ -1,0 +1,10 @@
+"""
+/core_versions API のテスト
+"""
+
+from fastapi.testclient import TestClient
+
+
+def test_get_core_versions_200(client: TestClient) -> None:
+    response = client.get("/core_versions", params={})
+    assert response.status_code == 200

--- a/test/e2e/single_api/test_initialize_speaker.py
+++ b/test/e2e/single_api/test_initialize_speaker.py
@@ -1,0 +1,10 @@
+"""
+/initialize_speaker API のテスト
+"""
+
+from fastapi.testclient import TestClient
+
+
+def test_post_initialize_speaker_204(client: TestClient) -> None:
+    response = client.post("/initialize_speaker", params={"speaker": 0})
+    assert response.status_code == 204

--- a/test/e2e/single_api/test_is_initialized_speaker.py
+++ b/test/e2e/single_api/test_is_initialized_speaker.py
@@ -1,0 +1,10 @@
+"""
+/is_initialized_speaker API のテスト
+"""
+
+from fastapi.testclient import TestClient
+
+
+def test_get_is_initialized_speaker_200(client: TestClient) -> None:
+    response = client.get("/is_initialized_speaker", params={"speaker": 0})
+    assert response.status_code == 200

--- a/test/e2e/single_api/test_singer_info.py
+++ b/test/e2e/single_api/test_singer_info.py
@@ -1,0 +1,10 @@
+"""
+/singer_info API のテスト
+"""
+
+from fastapi.testclient import TestClient
+
+
+def test_get_singer_info_200(client: TestClient) -> None:
+    response = client.get("/singer_info", params={"speaker_uuid": "b1a81618-b27b-40d2-b0ea-27a9ad408c4b"})
+    assert response.status_code == 200

--- a/test/e2e/single_api/test_singer_info.py
+++ b/test/e2e/single_api/test_singer_info.py
@@ -6,5 +6,7 @@ from fastapi.testclient import TestClient
 
 
 def test_get_singer_info_200(client: TestClient) -> None:
-    response = client.get("/singer_info", params={"speaker_uuid": "b1a81618-b27b-40d2-b0ea-27a9ad408c4b"})
+    response = client.get(
+        "/singer_info", params={"speaker_uuid": "b1a81618-b27b-40d2-b0ea-27a9ad408c4b"}
+    )
     assert response.status_code == 200

--- a/test/e2e/single_api/test_singers.py
+++ b/test/e2e/single_api/test_singers.py
@@ -1,0 +1,10 @@
+"""
+/singers API のテスト
+"""
+
+from fastapi.testclient import TestClient
+
+
+def test_get_singers_200(client: TestClient) -> None:
+    response = client.get("/singers", params={})
+    assert response.status_code == 200

--- a/test/e2e/single_api/test_speaker_info.py
+++ b/test/e2e/single_api/test_speaker_info.py
@@ -6,5 +6,7 @@ from fastapi.testclient import TestClient
 
 
 def test_get_speaker_info_200(client: TestClient) -> None:
-    response = client.get("/speaker_info", params={"speaker_uuid": "388f246b-8c41-4ac1-8e2d-5d79f3ff56d9"})
+    response = client.get(
+        "/speaker_info", params={"speaker_uuid": "388f246b-8c41-4ac1-8e2d-5d79f3ff56d9"}
+    )
     assert response.status_code == 200

--- a/test/e2e/single_api/test_speaker_info.py
+++ b/test/e2e/single_api/test_speaker_info.py
@@ -1,0 +1,10 @@
+"""
+/speaker_info API のテスト
+"""
+
+from fastapi.testclient import TestClient
+
+
+def test_get_speaker_info_200(client: TestClient) -> None:
+    response = client.get("/speaker_info", params={"speaker_uuid": "388f246b-8c41-4ac1-8e2d-5d79f3ff56d9"})
+    assert response.status_code == 200

--- a/test/e2e/single_api/test_speakers.py
+++ b/test/e2e/single_api/test_speakers.py
@@ -1,0 +1,10 @@
+"""
+/speakers API のテスト
+"""
+
+from fastapi.testclient import TestClient
+
+
+def test_get_speakers_200(client: TestClient) -> None:
+    response = client.get("/speakers", params={})
+    assert response.status_code == 200

--- a/test/e2e/single_api/test_supported_devices.py
+++ b/test/e2e/single_api/test_supported_devices.py
@@ -1,0 +1,10 @@
+"""
+/supported_devices API のテスト
+"""
+
+from fastapi.testclient import TestClient
+
+
+def test_get_supported_devices_200(client: TestClient) -> None:
+    response = client.get("/supported_devices", params={})
+    assert response.status_code == 200

--- a/test/e2e/single_api/test_validate_version.py
+++ b/test/e2e/single_api/test_validate_version.py
@@ -1,9 +1,0 @@
-from fastapi.testclient import TestClient
-
-from voicevox_engine import __version__
-
-
-def test_fetch_version_success(client: TestClient) -> None:
-    response = client.get("/version")
-    assert response.status_code == 200
-    assert response.json() == __version__

--- a/test/e2e/single_api/test_version.py
+++ b/test/e2e/single_api/test_version.py
@@ -4,7 +4,10 @@
 
 from fastapi.testclient import TestClient
 
+from voicevox_engine import __version__
+
 
 def test_get_version_200(client: TestClient) -> None:
     response = client.get("/version", params={})
     assert response.status_code == 200
+    assert response.json() == __version__

--- a/test/e2e/single_api/test_version.py
+++ b/test/e2e/single_api/test_version.py
@@ -1,0 +1,10 @@
+"""
+/version API のテスト
+"""
+
+from fastapi.testclient import TestClient
+
+
+def test_get_version_200(client: TestClient) -> None:
+    response = client.get("/version", params={})
+    assert response.status_code == 200


### PR DESCRIPTION
## 内容
e2e single API テストを追加 vol.3

次のAPIに対し、status code チェック（#1065 における A の簡易版）を追加した。

- [ ] `GET /version`
  - [x] `200`
- [ ] `GET /core_versions`
  - [x] `200`
- [ ] `GET /speakers`
  - [x] `200`
- [ ] `GET /speaker_info`
  - [x] `200`
- [ ] `GET /singers`
  - [x] `200`
- [ ] `GET /singer_info`
  - [x] `200`
- [ ] `POST /initialize_speaker`
  - [x] `204`
- [ ] `GET /is_initialized_speaker`
  - [x] `200`
- [ ] `GET /supported_devices`
  - [x] `200`

## 関連 Issue
part of #1065