### PR TITLE
[docs] ソングAPIのREADMEを追記

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,43 @@ curl -s -X GET "127.0.0.1:50021/speaker_info?speaker_uuid=7ffcb7ce-00ec-4bdc-82c
 この API は実験的機能であり、エンジン起動時に引数で`--enable_cancellable_synthesis`を指定しないと有効化されません。  
 音声合成に必要なパラメータは`/synthesis`と同様です。
 
+### HTTP リクエストで歌声合成するサンプルコード
+
+```bash
+echo -n '{
+  "notes": [
+    { "key": null, "frame_length": 15, "lyric": "" },
+    { "key": 60, "frame_length": 45, "lyric": "ド" },
+    { "key": 62, "frame_length": 45, "lyric": "レ" },
+    { "key": 64, "frame_length": 45, "lyric": "ミ" },
+    { "key": null, "frame_length": 15, "lyric": "" }
+  ]
+}' > score.json
+
+curl -s \
+    -H "Content-Type: application/json" \
+    -X POST \
+    -d @score.json \
+    "127.0.0.1:50021/sing_frame_audio_query?speaker=6000" \
+    > query.json
+
+curl -s \
+    -H "Content-Type: application/json" \
+    -X POST \
+    -d @query.json \
+    "127.0.0.1:50021/frame_synthesis?speaker=3001" \
+    > audio.wav
+```
+
+スコアの`key`は MIDI 番号です。  
+`lyric`は歌詞で、任意の文字列を指定できますが、エンジンによってはひらがな・カタカナ１モーラ以外の文字列はエラーになることがあります。  
+フレームレートはデフォルトが 93.75Hz で、エンジンマニフェストの`frame_rate`で取得できます。  
+１つ目のノートは無音である必要があります。
+
+`/sing_frame_audio_query`で指定できる`speaker`は、`/singers`で取得できるスタイルの内、種類が`sing`か`singing_teacher`なスタイルの`style_id`です。  
+`/frame_synthesis`で指定できる`speaker`は、`/singers`で取得できるスタイルの内、種類が`frame_decode`の`style_id`です。  
+引数が `speaker` という名前になっているのは、他の API と一貫性をもたせるためです。
+
 ### CORS 設定
 
 VOICEVOX ではセキュリティ保護のため`localhost`・`127.0.0.1`・`app://`・Origin なし以外の Origin からリクエストを受け入れないようになっています。

--- a/README.md
+++ b/README.md
@@ -344,6 +344,8 @@ curl -s \
 `/frame_synthesis`で指定できる`speaker`は、`/singers`で取得できるスタイルの内、種類が`frame_decode`の`style_id`です。  
 引数が `speaker` という名前になっているのは、他の API と一貫性をもたせるためです。
 
+`/sing_frame_audio_query`と`/frame_synthesis`に異なるスタイルを指定することも可能です。
+
 ### CORS 設定
 
 VOICEVOX ではセキュリティ保護のため`localhost`・`127.0.0.1`・`app://`・Origin なし以外の Origin からリクエストを受け入れないようになっています。

--- a/test/e2e/__snapshots__/test_openapi/test_OpenAPIの形が変わっていないことを確認.json
+++ b/test/e2e/__snapshots__/test_openapi/test_OpenAPIの形が変わっていないことを確認.json
@@ -732,7 +732,7 @@
               "frame_decode",
               "sing"
             ],
-            "title": "モデルの種類。talk:音声合成クエリの作成と音声合成が可能。singing_teacher:歌唱音声合成用のクエリの作成が可能。frame_decode:歌唱音声合成が可能。sing:歌唱音声合成用のクエリの作成と歌唱音声合成が可能。",
+            "title": "スタイルの種類。talk:音声合成クエリの作成と音声合成が可能。singing_teacher:歌唱音声合成用のクエリの作成が可能。frame_decode:歌唱音声合成が可能。sing:歌唱音声合成用のクエリの作成と歌唱音声合成が可能。",
             "type": "string"
           }
         },

--- a/voicevox_engine/metas/Metas.py
+++ b/voicevox_engine/metas/Metas.py
@@ -19,7 +19,7 @@ class SpeakerStyle(BaseModel):
     type: Optional[StyleType] = Field(
         default="talk",
         title=(
-            "モデルの種類。"
+            "スタイルの種類。"
             "talk:音声合成クエリの作成と音声合成が可能。"
             "singing_teacher:歌唱音声合成用のクエリの作成が可能。"
             "frame_decode:歌唱音声合成が可能。"


### PR DESCRIPTION
## 内容

READMEにソング API の使い方を簡単に書きました。

- https://github.com/VOICEVOX/voicevox_engine/issues/1038

の解決プルリクエストです。

トーク側の説明の流れと合わせています。
ちょっと曖昧性が高いですが、まあ色々試したらできると思うので一旦これでいいかなと･･･。


## 関連 Issue

close #1038

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他

書こうと思ったけどやめたこと：

ハミングの定義。
一応製品版VOICEVOXの方では、「トーク音声を用いて作成したframe_decodeと、ソング音声を用いて作成した`singing_teacher`の2つのスタイルを使って歌声合成すること」をハミングと呼ぶ感じなんですが、「トーク音声を用いて作成した」というメタデータがどこにも存在せず、説明したくてもできなかったのでやめました。
書くならVOICEVOX製品の説明ページのどこかかなと。

音域や声量の調整方法。
歌手によって得意音域や声量が違うため、そこをうまいこと調整した方がうまいこと歌えるのですが、じゃあどこに調整すればいいんだとかのメタデータがなくこちらも説明しづらかったので書くのをやめました。
音域や声量のメタデータが書かれるようになったら説明可能になると思います。
ちなみにリソース側にそのような取り組みがあります。 https://github.com/VOICEVOX/voicevox_resource/pull/60
