### PR TITLE
最適な話者ピッチ範囲を送れるように

### DIFF
--- a/speaker_info/35b2c544-660e-401e-b503-0e14c635303a/metas.json
+++ b/speaker_info/35b2c544-660e-401e-b503-0e14c635303a/metas.json
@@ -1,3 +1,10 @@
 {
-  "supported_features": { "permitted_synthesis_morphing": "NOTHING" }
+    "supported_features": {},
+    "range": [
+        {
+            "style_id": 8,
+            "low": 5.07,
+            "high": 6.5
+        }
+    ]
 }

--- a/speaker_info/388f246b-8c41-4ac1-8e2d-5d79f3ff56d9/metas.json
+++ b/speaker_info/388f246b-8c41-4ac1-8e2d-5d79f3ff56d9/metas.json
@@ -1,3 +1,17 @@
 {
-  "supported_features": { "permitted_synthesis_morphing": "SELF_ONLY" }
+    "supported_features": {
+        "permitted_synthesis_morphing": "SELF_ONLY"
+    },
+    "range": [
+        {
+            "style_id": 1,
+            "low": 5.38,
+            "high": 6.44
+        },
+        {
+            "style_id": 3,
+            "low": 5.11,
+            "high": 6.5
+        }
+    ]
 }

--- a/speaker_info/7ffcb7ce-00ec-4bdc-82cd-45a8889e43ff/metas.json
+++ b/speaker_info/7ffcb7ce-00ec-4bdc-82cd-45a8889e43ff/metas.json
@@ -1,1 +1,17 @@
-{}
+{
+    "supported_features": {
+        "permitted_synthesis_morphing": "SELF_ONLY"
+    },
+    "range": [
+        {
+            "style_id": 2,
+            "low": 5.16,
+            "high": 6.2
+        },
+        {
+            "style_id": 0,
+            "low": 5.21,
+            "high": 6.13
+        }
+    ]
+}

--- a/speaker_info/b1a81618-b27b-40d2-b0ea-27a9ad408c4b/metas.json
+++ b/speaker_info/b1a81618-b27b-40d2-b0ea-27a9ad408c4b/metas.json
@@ -1,3 +1,4 @@
 {
-  "supported_features": { "permitted_synthesis_morphing": "ALL" }
+    "supported_features": {},
+    "range": []
 }

--- a/voicevox_engine/metas/Metas.py
+++ b/voicevox_engine/metas/Metas.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel, Field
 # NOTE: 循環importを防ぐためにとりあえずここに書いている
 # FIXME: 他のmodelに依存せず、全modelから参照できる場所に配置する
 StyleId = NewType("StyleId", int)
+PitchRange = NewType("PitchRange", float)
 StyleType = Literal["talk", "singing_teacher", "frame_decode", "sing"]
 
 
@@ -27,6 +28,11 @@ class SpeakerStyle(BaseModel):
         ),
     )
 
+
+class SpeakerOptimalPitchRangeItem(BaseModel):
+    style_id: StyleId
+    high: PitchRange
+    low: PitchRange
 
 class SpeakerSupportPermittedSynthesisMorphing(str, Enum):
     ALL = "ALL"  # 全て許可
@@ -66,6 +72,9 @@ class EngineSpeaker(BaseModel):
 
     supported_features: SpeakerSupportedFeatures = Field(
         title="話者の対応機能", default_factory=SpeakerSupportedFeatures
+    )
+    range: List[SpeakerOptimalPitchRangeItem] = Field(
+        title="話者の最適ピッチ範囲", default_factory=list[SpeakerOptimalPitchRangeItem]
     )
 
 


### PR DESCRIPTION
> 恐れてはならない、わたしはこれから日本語を話す。

[ここ](https://github.com/VOICEVOX/voicevox_resource/pull/60)の続きとして、`metas.json`に追加された`range`をAPIで送れるようにしました。`supported_features`と同じく、`speaker_infos`で取得できます。

後ほどGUIの方にもPR出します。