### PR TITLE
FIX: 非推奨の`startup`イベントを`lifespan`に置き換え

### DIFF
--- a/run.py
+++ b/run.py
@@ -8,7 +8,8 @@ import re
 import sys
 import traceback
 import zipfile
-from collections.abc import Awaitable, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable
+from contextlib import asynccontextmanager
 from functools import lru_cache
 from io import BytesIO, TextIOWrapper
 from pathlib import Path
@@ -146,10 +147,16 @@ def generate_app(
     if root_dir is None:
         root_dir = engine_root()
 
+    @asynccontextmanager
+    async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+        update_dict()
+        yield
+
     app = FastAPI(
         title="VOICEVOX Engine",
         description="VOICEVOXの音声合成エンジンです。",
         version=__version__,
+        lifespan=lifespan,
     )
 
     # 未処理の例外が発生するとCORSMiddlewareが適用されない問題に対するワークアラウンド
@@ -247,10 +254,6 @@ def generate_app(
     #     if cancellable_engine is not None:
     #         loop = asyncio.get_event_loop()
     #         _ = loop.create_task(cancellable_engine.catch_disconnection())
-
-    @app.on_event("startup")
-    def apply_user_dict() -> None:
-        update_dict()
 
     def get_engine(core_version: Optional[str]) -> TTSEngine:
         if core_version is None:


### PR DESCRIPTION
## 内容

以下のコードが原因で`DeprecationWarning`が発生していたので更新します。
https://github.com/VOICEVOX/voicevox_engine/blob/c75b657a5c53feafaba418aa99ed4d9359991ffb/run.py#L251-L253

## 関連 Issue

- #1128 
- #1072 

## その他

動作上は全く変わらないと思います。

---

ref : [Lifespan Events - FastAPI](https://fastapi.tiangolo.com/advanced/events/)
ref : [Lifespan - Starlette](https://www.starlette.io/lifespan/)

ドキュメントを見て思ったのですが本来は`lifespan`で使用するオブジェクト(VOICEVOXでは`tts_engines`や`cores`)を初期化することが想定されている？