### PR TITLE
整理: ライセンス生成の重複処理を共通化

### DIFF
--- a/build_util/generate_licenses.py
+++ b/build_util/generate_licenses.py
@@ -41,25 +41,25 @@ def generate_licenses() -> list[License]:
         ("remote", "Python",                    python_ver, "Python Software Foundation License",       f"https://raw.githubusercontent.com/python/cpython/v{python_ver}/LICENSE"),                                    # noqa: B950
     ]
 
-    for l in license_infos:
+    for info in license_infos:
         # ローカルに事前保存されたライセンス情報を登録する
-        if l[0] == "local":
+        if info[0] == "local":
             licenses.append(
                 License(
-                    name=l[1],
-                    version=l[2],
-                    license=l[3],
-                    text=Path(l[4]).read_text(),
+                    name=info[1],
+                    version=info[2],
+                    license=info[3],
+                    text=Path(info[4]).read_text(),
                 )
             )
         # リモートに存在するライセンス情報を登録する
-        elif l[0] == "remote":
-            with urllib.request.urlopen(l[4]) as res:
+        elif info[0] == "remote":
+            with urllib.request.urlopen(info[4]) as res:
                 licenses.append(
                     License(
-                        name=l[1],
-                        version=l[2],
-                        license=l[3],
+                        name=info[1],
+                        version=info[2],
+                        license=info[3],
                         text=res.read().decode(),
                     )
                 )
@@ -182,25 +182,25 @@ def generate_licenses() -> list[License]:
         ("local",  "cuDNN",               "8.9.2",  None,                          "docs/licenses/cudnn/LICENSE"),                                                                                    # noqa: B950
     ]
 
-    for l in license_infos:
+    for info in license_infos:
         # ローカルに事前保存されたライセンス情報を登録する
-        if l[0] == "local":
+        if info[0] == "local":
             licenses.append(
                 License(
-                    name=l[1],
-                    version=l[2],
-                    license=l[3],
-                    text=Path(l[4]).read_text(),
+                    name=info[1],
+                    version=info[2],
+                    license=info[3],
+                    text=Path(info[4]).read_text(),
                 )
             )
         # リモートに存在するライセンス情報を登録する
-        elif l[0] == "remote":
-            with urllib.request.urlopen(l[4]) as res:
+        elif info[0] == "remote":
+            with urllib.request.urlopen(info[4]) as res:
                 licenses.append(
                     License(
-                        name=l[1],
-                        version=l[2],
-                        license=l[3],
+                        name=info[1],
+                        version=info[2],
+                        license=info[3],
                         text=res.read().decode(),
                     )
                 )

--- a/build_util/generate_licenses.py
+++ b/build_util/generate_licenses.py
@@ -16,8 +16,11 @@ class License:
     license: Optional[str]
     text: str
 
+
 # ライセンス情報: (place_type, name, version, license_type, place)
-LicenseInfo: TypeAlias = tuple[Literal["local", "remote"], str, str | None, str | None, str]
+LicenseInfo: TypeAlias = tuple[
+    Literal["local", "remote"], str, str | None, str | None, str
+]
 
 
 def generate_licenses() -> list[License]:
@@ -27,19 +30,21 @@ def generate_licenses() -> list[License]:
 
     python_ver = "3.11.3"
 
+    # fmt: off
     license_infos: list[LicenseInfo] = [
         # https://sourceforge.net/projects/open-jtalk/files/Open%20JTalk/open_jtalk-1.11/
-        ("local",  "Open JTalk",                "1.11",     "Modified BSD license",                     "docs/licenses/open_jtalk/COPYING"),                                                                           # noqa: B950
-        ("local",  "MeCab",                     None,       "Modified BSD license",                     "docs/licenses/open_jtalk/mecab/COPYING"),                                                                     # noqa: B950
-        ("local",  "NAIST Japanese Dictionary", None,       "Modified BSD license",                     "docs/licenses//open_jtalk/mecab-naist-jdic/COPYING"),                                                         # noqa: B950
-        ("remote", 'HTS Voice "Mei"',           None,       "Creative Commons Attribution 3.0 license", "https://raw.githubusercontent.com/r9y9/pyopenjtalk/master/pyopenjtalk/htsvoice/LICENSE_mei_normal.htsvoice"), # noqa: B950
-        ("remote", "VOICEVOX CORE",             None,       "MIT license",                              "https://raw.githubusercontent.com/VOICEVOX/voicevox_core/main/LICENSE"),                                      # noqa: B950
-        ("remote", "VOICEVOX ENGINE",           None,       "LGPL license",                             "https://raw.githubusercontent.com/VOICEVOX/voicevox_engine/master/LGPL_LICENSE"),                             # noqa: B950
-        ("remote", "world",                     None,       "Modified BSD license",                     "https://raw.githubusercontent.com/mmorise/World/master/LICENSE.txt"),                                         # noqa: B950
-        ("remote", "PyTorch",                   "1.9.0",    "BSD-style license",                        "https://raw.githubusercontent.com/pytorch/pytorch/master/LICENSE"),                                           # noqa: B950
-        ("remote", "ONNX Runtime",              "1.13.1",   "MIT license",                              "https://raw.githubusercontent.com/microsoft/onnxruntime/master/LICENSE"),                                     # noqa: B950
-        ("remote", "Python",                    python_ver, "Python Software Foundation License",       f"https://raw.githubusercontent.com/python/cpython/v{python_ver}/LICENSE"),                                    # noqa: B950
+        ("local",  "Open JTalk",                "1.11",     "Modified BSD license",                     "docs/licenses/open_jtalk/COPYING"),                                                                            # noqa: B950,E241
+        ("local",  "MeCab",                     None,       "Modified BSD license",                     "docs/licenses/open_jtalk/mecab/COPYING"),                                                                      # noqa: B950,E241
+        ("local",  "NAIST Japanese Dictionary", None,       "Modified BSD license",                     "docs/licenses//open_jtalk/mecab-naist-jdic/COPYING"),                                                          # noqa: B950,E241
+        ("remote", 'HTS Voice "Mei"',           None,       "Creative Commons Attribution 3.0 license", "https://raw.githubusercontent.com/r9y9/pyopenjtalk/master/pyopenjtalk/htsvoice/LICENSE_mei_normal.htsvoice"),  # noqa: B950,E241
+        ("remote", "VOICEVOX CORE",             None,       "MIT license",                              "https://raw.githubusercontent.com/VOICEVOX/voicevox_core/main/LICENSE"),                                       # noqa: B950,E241
+        ("remote", "VOICEVOX ENGINE",           None,       "LGPL license",                             "https://raw.githubusercontent.com/VOICEVOX/voicevox_engine/master/LGPL_LICENSE"),                              # noqa: B950,E241
+        ("remote", "world",                     None,       "Modified BSD license",                     "https://raw.githubusercontent.com/mmorise/World/master/LICENSE.txt"),                                          # noqa: B950,E241
+        ("remote", "PyTorch",                   "1.9.0",    "BSD-style license",                        "https://raw.githubusercontent.com/pytorch/pytorch/master/LICENSE"),                                            # noqa: B950,E241
+        ("remote", "ONNX Runtime",              "1.13.1",   "MIT license",                              "https://raw.githubusercontent.com/microsoft/onnxruntime/master/LICENSE"),                                      # noqa: B950,E241
+        ("remote", "Python",                    python_ver, "Python Software Foundation License",       f"https://raw.githubusercontent.com/python/cpython/v{python_ver}/LICENSE"),                                     # noqa: B950,E241
     ]
+    # fmt: on
 
     for info in license_infos:
         # ローカルに事前保存されたライセンス情報を登録する
@@ -160,27 +165,29 @@ def generate_licenses() -> list[License]:
         licenses.append(license)
     # /pip
 
+    # fmt: off
     license_infos = [
-        ("remote", "OpenBLAS",            None,     "BSD 3-clause license",        "https://raw.githubusercontent.com/xianyi/OpenBLAS/develop/LICENSE"),                                              # noqa: B950
-        ("remote", "libsndfile-binaries", "1.2.0",  "LGPL-2.1 license",            "https://raw.githubusercontent.com/bastibe/libsndfile-binaries/d9887ef926bb11cf1a2526be4ab6f9dc690234c0/COPYING"), # noqa: B950
-        ("remote", "libogg",              "1.3.5",  "BSD 3-clause license",        "https://raw.githubusercontent.com/xiph/ogg/v1.3.5/COPYING"),                                                      # noqa: B950
-        ("remote", "libvorbis",           "1.3.7",  "BSD 3-clause license",        "https://raw.githubusercontent.com/xiph/vorbis/v1.3.7/COPYING"),                                                   # noqa: B950
-        ("remote", "FLAC",                "1.4.2",  "Xiph.org's BSD-like license", "https://raw.githubusercontent.com/xiph/flac/1.4.2/COPYING.Xiph"),                                                 # noqa: B950
-        ("remote", "Opus",                "1.3.1",  "BSD 3-clause license",        "https://raw.githubusercontent.com/xiph/opus/v1.3.1/COPYING"),                                                     # noqa: B950
-        # https://sourceforge.net/projects/mpg123/files/mpg123/1.30.2/
-        ("local",  "mpg123",              "1.30.2", "LGPL-2.1 license",            "docs/licenses/mpg123/COPYING"),                                                                                   # noqa: B950
-        # https://sourceforge.net/projects/lame/files/lame/3.100/
-        ("remote", "lame",                "3.100",  "LGPL-2.0 license",            "https://svn.code.sf.net/p/lame/svn/tags/RELEASE__3_100/lame/COPYING"),                                            # noqa: B950
-        # https://developer.nvidia.com/cuda-11-8-0-download-archive?target_os=Windows&target_arch=x86_64&target_version=10&target_type=exe_local # noqa: B950
-        # https://developer.download.nvidia.com/compute/cuda/11.8.0/local_installers/cuda_11.8.0_522.06_windows.exe # noqa: B950
-        # cuda_11.8.0_522.06_windows.exe (cuda_documentation/Doc/EULA.txt)
-        ("local",  "CUDA Toolkit",        "11.8.0", None,                          "docs/licenses/cuda/EULA.txt"),                                                                                    # noqa: B950
-        # cuDNN v8.9.2 (June 1st, 2023), for CUDA 11.x, cuDNN Library for Windows
-        # https://developer.nvidia.com/rdp/cudnn-archive # noqa: B950
-        # https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/windows-x86_64/cudnn-windows-x86_64-8.9.2.26_cuda11-archive.zip # noqa: B950
-        # cudnn-windows-x86_64-8.9.2.26_cuda11-archive.zip (cudnn-windows-x86_64-8.9.2.26_cuda11-archive/LICENSE)                                                                                     # noqa: B950
-        ("local",  "cuDNN",               "8.9.2",  None,                          "docs/licenses/cudnn/LICENSE"),                                                                                    # noqa: B950
+        ("remote", "OpenBLAS",            None,     "BSD 3-clause license",        "https://raw.githubusercontent.com/xianyi/OpenBLAS/develop/LICENSE"),                                               # noqa: B950,E241
+        ("remote", "libsndfile-binaries", "1.2.0",  "LGPL-2.1 license",            "https://raw.githubusercontent.com/bastibe/libsndfile-binaries/d9887ef926bb11cf1a2526be4ab6f9dc690234c0/COPYING"),  # noqa: B950,E241
+        ("remote", "libogg",              "1.3.5",  "BSD 3-clause license",        "https://raw.githubusercontent.com/xiph/ogg/v1.3.5/COPYING"),                                                       # noqa: B950,E241
+        ("remote", "libvorbis",           "1.3.7",  "BSD 3-clause license",        "https://raw.githubusercontent.com/xiph/vorbis/v1.3.7/COPYING"),                                                    # noqa: B950,E241
+        ("remote", "FLAC",                "1.4.2",  "Xiph.org's BSD-like license", "https://raw.githubusercontent.com/xiph/flac/1.4.2/COPYING.Xiph"),                                                  # noqa: B950,E241
+        ("remote", "Opus",                "1.3.1",  "BSD 3-clause license",        "https://raw.githubusercontent.com/xiph/opus/v1.3.1/COPYING"),                                                      # noqa: B950,E241
+        # https://sourceforge.net/projects/mpg123/files/mpg123/1.30.2/                                                                                                                                 # noqa: B950,E241
+        ("local",  "mpg123",              "1.30.2", "LGPL-2.1 license",            "docs/licenses/mpg123/COPYING"),                                                                                    # noqa: B950,E241
+        # https://sourceforge.net/projects/lame/files/lame/3.100/                                                                                                                                      # noqa: B950,E241
+        ("remote", "lame",                "3.100",  "LGPL-2.0 license",            "https://svn.code.sf.net/p/lame/svn/tags/RELEASE__3_100/lame/COPYING"),                                             # noqa: B950,E241
+        # https://developer.nvidia.com/cuda-11-8-0-download-archive?target_os=Windows&target_arch=x86_64&target_version=10&target_type=exe_local                                                       # noqa: B950,E241
+        # https://developer.download.nvidia.com/compute/cuda/11.8.0/local_installers/cuda_11.8.0_522.06_windows.exe                                                                                    # noqa: B950,E241
+        # cuda_11.8.0_522.06_windows.exe (cuda_documentation/Doc/EULA.txt)                                                                                                                             # noqa: B950,E241
+        ("local",  "CUDA Toolkit",        "11.8.0", None,                          "docs/licenses/cuda/EULA.txt"),                                                                                     # noqa: B950,E241
+        # cuDNN v8.9.2 (June 1st, 2023), for CUDA 11.x, cuDNN Library for Windows                                                                                                                      # noqa: B950,E241
+        # https://developer.nvidia.com/rdp/cudnn-archive                                                                                                                                               # noqa: B950,E241
+        # https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/windows-x86_64/cudnn-windows-x86_64-8.9.2.26_cuda11-archive.zip                                                             # noqa: B950,E241
+        # cudnn-windows-x86_64-8.9.2.26_cuda11-archive.zip (cudnn-windows-x86_64-8.9.2.26_cuda11-archive/LICENSE)                                                                                      # noqa: B950,E241
+        ("local",  "cuDNN",               "8.9.2",  None,                          "docs/licenses/cudnn/LICENSE"),                                                                                     # noqa: B950,E241
     ]
+    # fmt: on
 
     for info in license_infos:
         # ローカルに事前保存されたライセンス情報を登録する

--- a/build_util/generate_licenses.py
+++ b/build_util/generate_licenses.py
@@ -17,7 +17,7 @@ class License:
     text: str
 
 # ライセンス情報: (place_type, name, version, license_type, place)
-LicenseInfo: TypeAlias = tuple[Literal["local", "remote"], str, str | None, str, str]
+LicenseInfo: TypeAlias = tuple[Literal["local", "remote"], str, str | None, str | None, str]
 
 
 def generate_licenses() -> list[License]:

--- a/build_util/generate_licenses.py
+++ b/build_util/generate_licenses.py
@@ -6,7 +6,7 @@ import subprocess
 import urllib.request
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import List, Literal, Optional, TypeAlias
+from typing import Literal, Optional, TypeAlias
 
 
 @dataclass

--- a/build_util/generate_licenses.py
+++ b/build_util/generate_licenses.py
@@ -160,7 +160,7 @@ def generate_licenses() -> list[License]:
         licenses.append(license)
     # /pip
 
-    license_infos: list[LicenseInfo] = [
+    license_infos = [
         ("remote", "OpenBLAS",            None,     "BSD 3-clause license",        "https://raw.githubusercontent.com/xianyi/OpenBLAS/develop/LICENSE"),                                              # noqa: B950
         ("remote", "libsndfile-binaries", "1.2.0",  "LGPL-2.1 license",            "https://raw.githubusercontent.com/bastibe/libsndfile-binaries/d9887ef926bb11cf1a2526be4ab6f9dc690234c0/COPYING"), # noqa: B950
         ("remote", "libogg",              "1.3.5",  "BSD 3-clause license",        "https://raw.githubusercontent.com/xiph/ogg/v1.3.5/COPYING"),                                                      # noqa: B950

--- a/build_util/generate_licenses.py
+++ b/build_util/generate_licenses.py
@@ -54,7 +54,7 @@ def generate_licenses() -> list[License]:
                     name=info[1],
                     version=info[2],
                     license=info[3],
-                    text=Path(info[4]).read_text(),
+                    text=Path(info[4]).read_text(encoding="utf8"),
                 )
             )
         # リモートに存在するライセンス情報を登録する
@@ -197,7 +197,7 @@ def generate_licenses() -> list[License]:
                     name=info[1],
                     version=info[2],
                     license=info[3],
-                    text=Path(info[4]).read_text(),
+                    text=Path(info[4]).read_text(encoding="utf8"),
                 )
             )
         # リモートに存在するライセンス情報を登録する


### PR DESCRIPTION
## 内容
概要: ライセンス生成の重複処理を共通化してリファクタリングした

従来の `generate_licenses.py` ではライセンス情報の生成時に「ライセンス文アクセス→`License` インスタンス化→`licenses` 登録」を約20個の個別ライセンスごとにベタ書きしており、一切の共通化がなされていなかった。  
これら重複処理を for 文により共通化した。  
すなわち、以前の
```python
   licenses.append(
        License(
            name="Open JTalk",
            version="1.11",
            license="Modified BSD license",
            text=Path("docs/licenses/open_jtalk/COPYING").read_text(),
        )
    )
    licenses.append(
        License(
            name="MeCab",
            version=None,
            license="Modified BSD license",
            text=Path("docs/licenses/open_jtalk/mecab/COPYING").read_text(),
        )
    )
    with urllib.request.urlopen(
        "https://raw.githubusercontent.com/VOICEVOX/voicevox_core/main/LICENSE"
    ) as res:
        licenses.append(
            License(
                name="VOICEVOX CORE",
                version=None,
                license="MIT license",
                text=res.read().decode(),
            )
        )
```
を次のように共通化した：  
```python
    license_infos: list[LicenseInfo] = [
        ("local",   "Open JTalk",    "1.11", "Modified BSD license", "docs/licenses/open_jtalk/COPYING"),
        ("local",   "MeCab",         None,   "Modified BSD license", "docs/licenses/open_jtalk/mecab/COPYING"),
        ("remote",  "VOICEVOX CORE", None,   "MIT license",          "https://raw.githubusercontent.com/VOICEVOX/voicevox_core/main/LICENSE"),
    ]

    for info in license_infos:
        if info[0] == "local":
            licenses.append(
                License(
                    name=info[1],
                    version=info[2],
                    license=info[3],
                    text=Path(info[4]).read_text(),
                )
            )
        elif info[0] == "remote":
            with urllib.request.urlopen(info[4]) as res:
                licenses.append(
                    License(
                        name=info[1],
                        version=info[2],
                        license=info[3],
                        text=res.read().decode(),
                    )
                )
```

`license_infos` の可読性を上げるためにこの箇所における linter をオフにし、space 挿入による整形をおこなっている。  
折り返し無効化により GitHub PR UI 上での可読性が下がっているため、エディタでチェックして頂ければ幸いです。

## 関連 Issue
無し

## Notes
`python build_util/generate_licenses.py -o ./opt.json` の出力がリファクタリング前後で完全一致することを確認済み
