### PR TITLE
廃止: fixture セッションスコープを削除して廃止

### DIFF
--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -13,7 +13,7 @@ from voicevox_engine.tts_pipeline.tts_engine import make_tts_engines_from_cores
 from voicevox_engine.utility.core_version_utility import get_latest_core_version
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture()
 def app_params() -> dict[str, Any]:
     cores = initialize_cores(use_gpu=False, enable_mock=True)
     tts_engines = make_tts_engines_from_cores(cores)
@@ -31,11 +31,11 @@ def app_params() -> dict[str, Any]:
     }
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture()
 def app(app_params: dict) -> FastAPI:
     return generate_app(**app_params)
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture()
 def client(app: FastAPI) -> TestClient:
     return TestClient(app)


### PR DESCRIPTION
## 内容
概要: `pytest` fixture セッションスコープを廃止

現在の ENGINE は e2e テストでの `app` 等の生成に `pytest` fixture セッションスコープを利用している。  
これはテスト実行時間の削減に寄与している。  
以下のように、実測値 (n=5/5) として、全テスト実行時間を計 1.0 秒削減している。  

- セッションスコープ ON: 3.7 [sec/session]
- セッションスコープ OFF: 2.7 [sec/session]

一方でスコープによる値の再利用により、テスト間で状態が引き継がれるかなど、テスト設計上の考慮事項が増えている。  
例えば https://github.com/VOICEVOX/voicevox_engine/pull/1149#discussion_r1544874790 で提案された teardown の実行タイミングを理解するのにコストが発生している。  
テストが充実する中、このコストの総量は日に日に増している。  

メリット・デメリットを天秤に掛けたとき、1.0 秒のテスト実行時間削減に見合ったコストではなくなったと考える。  

このような背景から、`pytest` fixture セッションスコープ廃止を提案します。  

## 関連 Issue
ref https://github.com/VOICEVOX/voicevox_engine/pull/1149#discussion_r1544874790