### PR TITLE
整理: プリセットの public メソッド呼び出しによる内部更新を private へ変更

### DIFF
--- a/run.py
+++ b/run.py
@@ -319,7 +319,7 @@ def generate_app(
         engine = get_engine(core_version)
         core = get_core(core_version)
         try:
-            presets = preset_manager.load_presets()
+            presets = preset_manager.read_all()
         except PresetError as err:
             raise HTTPException(status_code=422, detail=str(err))
         for preset in presets:
@@ -765,7 +765,7 @@ def generate_app(
         エンジンが保持しているプリセットの設定を返します
         """
         try:
-            presets = preset_manager.load_presets()
+            presets = preset_manager.read_all()
         except PresetError as err:
             raise HTTPException(status_code=422, detail=str(err))
         return presets
@@ -789,7 +789,7 @@ def generate_app(
         新しいプリセットを追加します
         """
         try:
-            id = preset_manager.add_preset(preset)
+            id = preset_manager.create(preset)
         except PresetError as err:
             raise HTTPException(status_code=422, detail=str(err))
         return id
@@ -813,7 +813,7 @@ def generate_app(
         既存のプリセットを更新します
         """
         try:
-            id = preset_manager.update_preset(preset)
+            id = preset_manager.update(preset)
         except PresetError as err:
             raise HTTPException(status_code=422, detail=str(err))
         return id
@@ -831,7 +831,7 @@ def generate_app(
         既存のプリセットを削除します
         """
         try:
-            preset_manager.delete_preset(id)
+            preset_manager.delete(id)
         except PresetError as err:
             raise HTTPException(status_code=422, detail=str(err))
         return Response(status_code=204)

--- a/run.py
+++ b/run.py
@@ -319,7 +319,7 @@ def generate_app(
         engine = get_engine(core_version)
         core = get_core(core_version)
         try:
-            presets = preset_manager.read_all()
+            presets = preset_manager.load_presets()
         except PresetError as err:
             raise HTTPException(status_code=422, detail=str(err))
         for preset in presets:
@@ -765,7 +765,7 @@ def generate_app(
         エンジンが保持しているプリセットの設定を返します
         """
         try:
-            presets = preset_manager.read_all()
+            presets = preset_manager.load_presets()
         except PresetError as err:
             raise HTTPException(status_code=422, detail=str(err))
         return presets
@@ -789,7 +789,7 @@ def generate_app(
         新しいプリセットを追加します
         """
         try:
-            id = preset_manager.create(preset)
+            id = preset_manager.add_preset(preset)
         except PresetError as err:
             raise HTTPException(status_code=422, detail=str(err))
         return id
@@ -813,7 +813,7 @@ def generate_app(
         既存のプリセットを更新します
         """
         try:
-            id = preset_manager.update(preset)
+            id = preset_manager.update_preset(preset)
         except PresetError as err:
             raise HTTPException(status_code=422, detail=str(err))
         return id
@@ -831,7 +831,7 @@ def generate_app(
         既存のプリセットを削除します
         """
         try:
-            preset_manager.delete(id)
+            preset_manager.delete_preset(id)
         except PresetError as err:
             raise HTTPException(status_code=422, detail=str(err))
         return Response(status_code=204)

--- a/test/preset/test_preset.py
+++ b/test/preset/test_preset.py
@@ -24,13 +24,13 @@ class TestPresetManager(TestCase):
 
     def test_validation(self) -> None:
         preset_manager = PresetManager(preset_path=presets_test_1_yaml_path)
-        presets = preset_manager.read_all()
+        presets = preset_manager.load_presets()
         self.assertFalse(presets is None)
 
     def test_validation_same(self) -> None:
         preset_manager = PresetManager(preset_path=presets_test_1_yaml_path)
-        presets = preset_manager.read_all()
-        presets2 = preset_manager.read_all()
+        presets = preset_manager.load_presets()
+        presets2 = preset_manager.load_presets()
         self.assertFalse(presets is None)
         self.assertEqual(presets, presets2)
 
@@ -39,26 +39,26 @@ class TestPresetManager(TestCase):
         with self.assertRaises(
             PresetError, msg="プリセットの設定ファイルにミスがあります"
         ):
-            preset_manager.read_all()
+            preset_manager.load_presets()
 
     def test_preset_id(self) -> None:
         preset_manager = PresetManager(preset_path=presets_test_3_yaml_path)
         with self.assertRaises(PresetError, msg="プリセットのidに重複があります"):
-            preset_manager.read_all()
+            preset_manager.load_presets()
 
     def test_empty_file(self) -> None:
         preset_manager = PresetManager(preset_path=presets_test_4_yaml_path)
         with self.assertRaises(
             PresetError, msg="プリセットの設定ファイルが空の内容です"
         ):
-            preset_manager.read_all()
+            preset_manager.load_presets()
 
     def test_not_exist_file(self) -> None:
         preset_manager = PresetManager(preset_path=Path("test/presets-dummy.yaml"))
         with self.assertRaises(
             PresetError, msg="プリセットの設定ファイルが見つかりません"
         ):
-            preset_manager.read_all()
+            preset_manager.load_presets()
 
     def test_add_preset(self) -> None:
         temp_path = self.tmp_dir_path / "presets-test-temp.yaml"
@@ -78,7 +78,7 @@ class TestPresetManager(TestCase):
                 "postPhonemeLength": 0.1,
             }
         )
-        id = preset_manager.create(preset)
+        id = preset_manager.add_preset(preset)
         self.assertEqual(id, 10)
         self.assertEqual(len(preset_manager.presets), 3)
         for _preset in preset_manager.presets:
@@ -91,7 +91,7 @@ class TestPresetManager(TestCase):
         with self.assertRaises(
             PresetError, msg="プリセットの設定ファイルにミスがあります"
         ):
-            preset_manager.create(
+            preset_manager.add_preset(
                 Preset(
                     **{
                         "id": 1,
@@ -126,7 +126,7 @@ class TestPresetManager(TestCase):
                 "postPhonemeLength": 0.1,
             }
         )
-        id = preset_manager.create(preset)
+        id = preset_manager.add_preset(preset)
         self.assertEqual(id, 3)
         self.assertEqual(len(preset_manager.presets), 3)
         for _preset in preset_manager.presets:
@@ -152,7 +152,7 @@ class TestPresetManager(TestCase):
                 "postPhonemeLength": 0.1,
             }
         )
-        id = preset_manager.create(preset)
+        id = preset_manager.add_preset(preset)
         self.assertEqual(id, 3)
         self.assertEqual(len(preset_manager.presets), 3)
         for _preset in preset_manager.presets:
@@ -178,13 +178,13 @@ class TestPresetManager(TestCase):
                 "postPhonemeLength": 0.1,
             }
         )
-        preset_manager.read_all()
+        preset_manager.load_presets()
         preset_manager._refresh_cache = lambda: None  # type:ignore[method-assign]
         preset_manager.preset_path = ""  # type: ignore[assignment]
         with self.assertRaises(
             PresetError, msg="プリセットの設定ファイルに書き込み失敗しました"
         ):
-            preset_manager.create(preset)
+            preset_manager.add_preset(preset)
         self.assertEqual(len(preset_manager.presets), 2)
         remove(temp_path)
 
@@ -206,7 +206,7 @@ class TestPresetManager(TestCase):
                 "postPhonemeLength": 0.1,
             }
         )
-        id = preset_manager.update(preset)
+        id = preset_manager.update_preset(preset)
         self.assertEqual(id, 1)
         self.assertEqual(len(preset_manager.presets), 2)
         for _preset in preset_manager.presets:
@@ -219,7 +219,7 @@ class TestPresetManager(TestCase):
         with self.assertRaises(
             PresetError, msg="プリセットの設定ファイルにミスがあります"
         ):
-            preset_manager.update(
+            preset_manager.update_preset(
                 Preset(
                     **{
                         "id": 1,
@@ -255,7 +255,7 @@ class TestPresetManager(TestCase):
             }
         )
         with self.assertRaises(PresetError, msg="更新先のプリセットが存在しません"):
-            preset_manager.update(preset)
+            preset_manager.update_preset(preset)
         self.assertEqual(len(preset_manager.presets), 2)
         remove(temp_path)
 
@@ -277,13 +277,13 @@ class TestPresetManager(TestCase):
                 "postPhonemeLength": 0.1,
             }
         )
-        preset_manager.read_all()
+        preset_manager.load_presets()
         preset_manager._refresh_cache = lambda: None  # type:ignore[method-assign]
         preset_manager.preset_path = ""  # type: ignore[assignment]
         with self.assertRaises(
             PresetError, msg="プリセットの設定ファイルに書き込み失敗しました"
         ):
-            preset_manager.update(preset)
+            preset_manager.update_preset(preset)
         self.assertEqual(len(preset_manager.presets), 2)
         self.assertEqual(preset_manager.presets[0].name, "test")
         remove(temp_path)
@@ -292,7 +292,7 @@ class TestPresetManager(TestCase):
         temp_path = self.tmp_dir_path / "presets-test-temp.yaml"
         copyfile(presets_test_1_yaml_path, temp_path)
         preset_manager = PresetManager(preset_path=temp_path)
-        id = preset_manager.delete(1)
+        id = preset_manager.delete_preset(1)
         self.assertEqual(id, 1)
         self.assertEqual(len(preset_manager.presets), 1)
         remove(temp_path)
@@ -302,14 +302,14 @@ class TestPresetManager(TestCase):
         with self.assertRaises(
             PresetError, msg="プリセットの設定ファイルにミスがあります"
         ):
-            preset_manager.delete(10)
+            preset_manager.delete_preset(10)
 
     def test_delete_preset_not_found(self) -> None:
         temp_path = self.tmp_dir_path / "presets-test-temp.yaml"
         copyfile(presets_test_1_yaml_path, temp_path)
         preset_manager = PresetManager(preset_path=temp_path)
         with self.assertRaises(PresetError, msg="削除対象のプリセットが存在しません"):
-            preset_manager.delete(10)
+            preset_manager.delete_preset(10)
         self.assertEqual(len(preset_manager.presets), 2)
         remove(temp_path)
 
@@ -317,12 +317,12 @@ class TestPresetManager(TestCase):
         temp_path = self.tmp_dir_path / "presets-test-temp.yaml"
         copyfile(presets_test_1_yaml_path, temp_path)
         preset_manager = PresetManager(preset_path=temp_path)
-        preset_manager.read_all()
+        preset_manager.load_presets()
         preset_manager._refresh_cache = lambda: None  # type:ignore[method-assign]
         preset_manager.preset_path = ""  # type: ignore[assignment]
         with self.assertRaises(
             PresetError, msg="プリセットの設定ファイルに書き込み失敗しました"
         ):
-            preset_manager.delete(1)
+            preset_manager.delete_preset(1)
         self.assertEqual(len(preset_manager.presets), 2)
         remove(temp_path)

--- a/test/preset/test_preset.py
+++ b/test/preset/test_preset.py
@@ -24,13 +24,13 @@ class TestPresetManager(TestCase):
 
     def test_validation(self) -> None:
         preset_manager = PresetManager(preset_path=presets_test_1_yaml_path)
-        presets = preset_manager.load_presets()
+        presets = preset_manager.read_all()
         self.assertFalse(presets is None)
 
     def test_validation_same(self) -> None:
         preset_manager = PresetManager(preset_path=presets_test_1_yaml_path)
-        presets = preset_manager.load_presets()
-        presets2 = preset_manager.load_presets()
+        presets = preset_manager.read_all()
+        presets2 = preset_manager.read_all()
         self.assertFalse(presets is None)
         self.assertEqual(presets, presets2)
 
@@ -39,26 +39,26 @@ class TestPresetManager(TestCase):
         with self.assertRaises(
             PresetError, msg="プリセットの設定ファイルにミスがあります"
         ):
-            preset_manager.load_presets()
+            preset_manager.read_all()
 
     def test_preset_id(self) -> None:
         preset_manager = PresetManager(preset_path=presets_test_3_yaml_path)
         with self.assertRaises(PresetError, msg="プリセットのidに重複があります"):
-            preset_manager.load_presets()
+            preset_manager.read_all()
 
     def test_empty_file(self) -> None:
         preset_manager = PresetManager(preset_path=presets_test_4_yaml_path)
         with self.assertRaises(
             PresetError, msg="プリセットの設定ファイルが空の内容です"
         ):
-            preset_manager.load_presets()
+            preset_manager.read_all()
 
     def test_not_exist_file(self) -> None:
         preset_manager = PresetManager(preset_path=Path("test/presets-dummy.yaml"))
         with self.assertRaises(
             PresetError, msg="プリセットの設定ファイルが見つかりません"
         ):
-            preset_manager.load_presets()
+            preset_manager.read_all()
 
     def test_add_preset(self) -> None:
         temp_path = self.tmp_dir_path / "presets-test-temp.yaml"
@@ -78,7 +78,7 @@ class TestPresetManager(TestCase):
                 "postPhonemeLength": 0.1,
             }
         )
-        id = preset_manager.add_preset(preset)
+        id = preset_manager.create(preset)
         self.assertEqual(id, 10)
         self.assertEqual(len(preset_manager.presets), 3)
         for _preset in preset_manager.presets:
@@ -91,7 +91,7 @@ class TestPresetManager(TestCase):
         with self.assertRaises(
             PresetError, msg="プリセットの設定ファイルにミスがあります"
         ):
-            preset_manager.add_preset(
+            preset_manager.create(
                 Preset(
                     **{
                         "id": 1,
@@ -126,7 +126,7 @@ class TestPresetManager(TestCase):
                 "postPhonemeLength": 0.1,
             }
         )
-        id = preset_manager.add_preset(preset)
+        id = preset_manager.create(preset)
         self.assertEqual(id, 3)
         self.assertEqual(len(preset_manager.presets), 3)
         for _preset in preset_manager.presets:
@@ -152,7 +152,7 @@ class TestPresetManager(TestCase):
                 "postPhonemeLength": 0.1,
             }
         )
-        id = preset_manager.add_preset(preset)
+        id = preset_manager.create(preset)
         self.assertEqual(id, 3)
         self.assertEqual(len(preset_manager.presets), 3)
         for _preset in preset_manager.presets:
@@ -178,13 +178,13 @@ class TestPresetManager(TestCase):
                 "postPhonemeLength": 0.1,
             }
         )
-        preset_manager.load_presets()
-        preset_manager.load_presets = lambda: []  # type:ignore[method-assign]
+        preset_manager.read_all()
+        preset_manager._refresh_cache = lambda: []  # type:ignore[method-assign]
         preset_manager.preset_path = ""  # type: ignore[assignment]
         with self.assertRaises(
             PresetError, msg="プリセットの設定ファイルに書き込み失敗しました"
         ):
-            preset_manager.add_preset(preset)
+            preset_manager.create(preset)
         self.assertEqual(len(preset_manager.presets), 2)
         remove(temp_path)
 
@@ -206,7 +206,7 @@ class TestPresetManager(TestCase):
                 "postPhonemeLength": 0.1,
             }
         )
-        id = preset_manager.update_preset(preset)
+        id = preset_manager.update(preset)
         self.assertEqual(id, 1)
         self.assertEqual(len(preset_manager.presets), 2)
         for _preset in preset_manager.presets:
@@ -219,7 +219,7 @@ class TestPresetManager(TestCase):
         with self.assertRaises(
             PresetError, msg="プリセットの設定ファイルにミスがあります"
         ):
-            preset_manager.update_preset(
+            preset_manager.update(
                 Preset(
                     **{
                         "id": 1,
@@ -255,7 +255,7 @@ class TestPresetManager(TestCase):
             }
         )
         with self.assertRaises(PresetError, msg="更新先のプリセットが存在しません"):
-            preset_manager.update_preset(preset)
+            preset_manager.update(preset)
         self.assertEqual(len(preset_manager.presets), 2)
         remove(temp_path)
 
@@ -277,13 +277,13 @@ class TestPresetManager(TestCase):
                 "postPhonemeLength": 0.1,
             }
         )
-        preset_manager.load_presets()
-        preset_manager.load_presets = lambda: []  # type:ignore[method-assign]
+        preset_manager.read_all()
+        preset_manager._refresh_cache = lambda: []  # type:ignore[method-assign]
         preset_manager.preset_path = ""  # type: ignore[assignment]
         with self.assertRaises(
             PresetError, msg="プリセットの設定ファイルに書き込み失敗しました"
         ):
-            preset_manager.update_preset(preset)
+            preset_manager.update(preset)
         self.assertEqual(len(preset_manager.presets), 2)
         self.assertEqual(preset_manager.presets[0].name, "test")
         remove(temp_path)
@@ -292,7 +292,7 @@ class TestPresetManager(TestCase):
         temp_path = self.tmp_dir_path / "presets-test-temp.yaml"
         copyfile(presets_test_1_yaml_path, temp_path)
         preset_manager = PresetManager(preset_path=temp_path)
-        id = preset_manager.delete_preset(1)
+        id = preset_manager.delete(1)
         self.assertEqual(id, 1)
         self.assertEqual(len(preset_manager.presets), 1)
         remove(temp_path)
@@ -302,14 +302,14 @@ class TestPresetManager(TestCase):
         with self.assertRaises(
             PresetError, msg="プリセットの設定ファイルにミスがあります"
         ):
-            preset_manager.delete_preset(10)
+            preset_manager.delete(10)
 
     def test_delete_preset_not_found(self) -> None:
         temp_path = self.tmp_dir_path / "presets-test-temp.yaml"
         copyfile(presets_test_1_yaml_path, temp_path)
         preset_manager = PresetManager(preset_path=temp_path)
         with self.assertRaises(PresetError, msg="削除対象のプリセットが存在しません"):
-            preset_manager.delete_preset(10)
+            preset_manager.delete(10)
         self.assertEqual(len(preset_manager.presets), 2)
         remove(temp_path)
 
@@ -317,12 +317,12 @@ class TestPresetManager(TestCase):
         temp_path = self.tmp_dir_path / "presets-test-temp.yaml"
         copyfile(presets_test_1_yaml_path, temp_path)
         preset_manager = PresetManager(preset_path=temp_path)
-        preset_manager.load_presets()
-        preset_manager.load_presets = lambda: []  # type:ignore[method-assign]
+        preset_manager.read_all()
+        preset_manager._refresh_cache = lambda: []  # type:ignore[method-assign]
         preset_manager.preset_path = ""  # type: ignore[assignment]
         with self.assertRaises(
             PresetError, msg="プリセットの設定ファイルに書き込み失敗しました"
         ):
-            preset_manager.delete_preset(1)
+            preset_manager.delete(1)
         self.assertEqual(len(preset_manager.presets), 2)
         remove(temp_path)

--- a/test/preset/test_preset.py
+++ b/test/preset/test_preset.py
@@ -179,7 +179,7 @@ class TestPresetManager(TestCase):
             }
         )
         preset_manager.read_all()
-        preset_manager._refresh_cache = lambda: []  # type:ignore[method-assign]
+        preset_manager._refresh_cache = lambda: None  # type:ignore[method-assign]
         preset_manager.preset_path = ""  # type: ignore[assignment]
         with self.assertRaises(
             PresetError, msg="プリセットの設定ファイルに書き込み失敗しました"
@@ -278,7 +278,7 @@ class TestPresetManager(TestCase):
             }
         )
         preset_manager.read_all()
-        preset_manager._refresh_cache = lambda: []  # type:ignore[method-assign]
+        preset_manager._refresh_cache = lambda: None  # type:ignore[method-assign]
         preset_manager.preset_path = ""  # type: ignore[assignment]
         with self.assertRaises(
             PresetError, msg="プリセットの設定ファイルに書き込み失敗しました"
@@ -318,7 +318,7 @@ class TestPresetManager(TestCase):
         copyfile(presets_test_1_yaml_path, temp_path)
         preset_manager = PresetManager(preset_path=temp_path)
         preset_manager.read_all()
-        preset_manager._refresh_cache = lambda: []  # type:ignore[method-assign]
+        preset_manager._refresh_cache = lambda: None  # type:ignore[method-assign]
         preset_manager.preset_path = ""  # type: ignore[assignment]
         with self.assertRaises(
             PresetError, msg="プリセットの設定ファイルに書き込み失敗しました"

--- a/voicevox_engine/preset/PresetManager.py
+++ b/voicevox_engine/preset/PresetManager.py
@@ -54,7 +54,7 @@ class PresetManager:
         self.presets = _presets
         self.last_modified_time = _last_modified_time
 
-    def create(self, preset: Preset) -> int:
+    def add_preset(self, preset: Preset) -> int:
         """新規プリセットを追加し、その ID を取得する。"""
 
         # データベース更新の反映
@@ -78,7 +78,7 @@ class PresetManager:
 
         return preset.id
 
-    def read_all(self) -> list[Preset]:
+    def load_presets(self) -> list[Preset]:
         """全てのプリセットを取得する"""
 
         # データベース更新の反映
@@ -86,7 +86,7 @@ class PresetManager:
 
         return self.presets
 
-    def update(self, preset: Preset) -> int:
+    def update_preset(self, preset: Preset) -> int:
         """指定されたプリセットを更新し、その ID を取得する。"""
 
         # データベース更新の反映
@@ -114,7 +114,7 @@ class PresetManager:
 
         return preset.id
 
-    def delete(self, id: int) -> int:
+    def delete_preset(self, id: int) -> int:
         """ID で指定されたプリセットを削除し、その ID を取得する。"""
 
         # データベース更新の反映


### PR DESCRIPTION
## 内容
プリセットマネージャー<del>各メソッドの名称を明確 &</del> 実装を分割 & docstring を簡略化してリファクタリングした。  

<del>プリセットデータベース（マネージャー）へのアクセスを標準的な CRUD (create-read-update-delete) へ名称変更した。</del>  

内部更新と read が単一のメソッドに実装され、このメソッドが create/update/delete 内部で呼ばれていた。よって内部更新を private method へ切り出し、readと分離した。  

また docstring を簡略化した（コーディング規約No.4 (#799)）。

## 関連 Issue
無し