### PR TITLE
追加: issue 状態遷移図を作成

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -241,21 +241,19 @@ title: issue 状態遷移図 v1.0
 ---
 stateDiagram-v2
     [*]     --> 必要性議論 : issue open
-    state active {
+    state opened {
       必要性議論 --> 設計
       設計       --> 実装者募集
       実装者募集 --> 実装 : 着手宣言
     }
-    active      --> not_planned  : NoGo 判断
+    opened      --> not_planned  : NoGo 判断
     not_planned --> [*]          : issue close
-    実装        --> resolved     : PR merge
+    実装        --> resolved     : Pull request merge
     resolved    --> [*]          : issue close
-    ロードマップ --> active
-    実装        --> ロードマップ  : 停滞 180日 
-    実装者募集   --> ロードマップ  : 停滞 180日 
-    設計         --> ロードマップ : 停滞 180日
-    必要性議論   --> ロードマップ  : 停滞 30日
+    opened      --> ロードマップ : 停滞
+    ロードマップ --> opened
 ```
+NOTE: ロードマップ化すべきかの棚卸し判定は、issue が `必要性議論` で 30 日、`設計`・`実装者募集`・`実装` で 180 日停滞した場合におこなう。`実装` の停滞時にはサポートも検討する。
 
 ## ライセンス
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -246,15 +246,15 @@ stateDiagram-v2
       設計       --> 実装者募集
       実装者募集 --> 実装 : 着手宣言
     }
-    active      --> not_planned : NoGo 判断
-    not_planned --> [*]         : issue close
-    実装        --> resolved    : PR merge
-    resolved    --> [*]         : issue close
-    pending     --> active
-    実装        --> pending     : 停滞 180日 
-    実装者募集   --> pending     : 停滞 180日 
-    設計         --> pending    : 停滞 180日
-    必要性議論   --> pending     : 停滞 30日
+    active      --> not_planned  : NoGo 判断
+    not_planned --> [*]          : issue close
+    実装        --> resolved     : PR merge
+    resolved    --> [*]          : issue close
+    ロードマップ --> active
+    実装        --> ロードマップ  : 停滞 180日 
+    実装者募集   --> ロードマップ  : 停滞 180日 
+    設計         --> ロードマップ : 停滞 180日
+    必要性議論   --> ロードマップ  : 停滞 30日
 ```
 
 ## ライセンス

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -231,6 +231,32 @@ PYTHONPATH=. python build_util/make_docs.py
 ## Issue
 不具合の報告、機能要望、改善提案、質問は<a href="https://github.com/VOICEVOX/voicevox_engine/issues/new">Issue</a>の方に報告してください。
 
+### Issue の状態
+VOICEVOX ENGINE では issue の状態遷移を以下のように整理しています。  
+各状態は GitHub の `状態：〇〇` ラベルと対応しています（例： [`状態：実装者募集`](https://github.com/VOICEVOX/voicevox_engine/labels/%E7%8A%B6%E6%85%8B%EF%BC%9A%E5%AE%9F%E8%A3%85%E8%80%85%E5%8B%9F%E9%9B%86)）。  
+
+```mermaid
+---
+title: issue 状態遷移図 v1.0
+---
+stateDiagram-v2
+    [*]     --> 必要性議論 : issue open
+    state active {
+      必要性議論 --> 設計
+      設計       --> 実装者募集
+      実装者募集 --> 実装 : 着手宣言
+    }
+    active      --> not_planned : NoGo 判断
+    not_planned --> [*]         : issue close
+    実装        --> resolved    : PR merge
+    resolved    --> [*]         : issue close
+    pending     --> active
+    実装        --> pending     : 停滞 180日 
+    実装者募集   --> pending     : 停滞 180日 
+    設計         --> pending    : 停滞 180日
+    必要性議論   --> pending     : 停滞 30日
+```
+
 ## ライセンス
 
 LGPL v3 と、ソースコードの公開が不要な別ライセンスのデュアルライセンスです。


### PR DESCRIPTION
## 内容
概要: issue 状態遷移図を `CONTRIBUTING.md` へ明記した

#1112 で採択された issue 状態遷移図は「頂いた PR のメリットを慎重に判断したいので `必要性議論` に立ち戻って議論しましょう」といった形でコントリビュータ・レビュア間のコミュニケーションに資する。  
よって https://github.com/VOICEVOX/voicevox_engine/issues/1112#issuecomment-2019215904 にて明示的案内の必要性が示された。  
この図の恩恵は ENGINE コミッタにあるため、記載先は `CONTRIBUTING.md` とした。  

## 関連 Issue
part of #1112