### PR TITLE
FIX: Poetryの`package-mode`を`false`にする

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,10 +38,6 @@ use_parentheses = true
 
 [tool.poetry]
 package-mode = false
-name = "voicevox_engine"
-version = "0.0.0"
-description = ""
-authors = ["Hiroshiba <hihokaruta@gmail.com>"]
 
 [tool.poetry.dependencies]
 python = "~3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ multi_line_output = 3
 use_parentheses = true
 
 [tool.poetry]
+package-mode = false
 name = "voicevox_engine"
 version = "0.0.0"
 description = ""


### PR DESCRIPTION
## 内容

Poetryの`package-mode`を`false`に変更します。
VOICEVOXエンジンはライブラリとして動作させることを想定していない(そもそもできない？)ためこちらが適切な設定だと思います。

ref: https://python-poetry.org/docs/basic-usage/#operating-modes

## その他

これにより`poetry install`コマンドで`voicevox_engine`がパッケージとしてインストールされるという動作が起こらなくなります。