### PR TITLE
FIX: `localhost_regex`にIPv6のループバックアドレスを追加

### DIFF
--- a/run.py
+++ b/run.py
@@ -172,7 +172,7 @@ def generate_app(
     app.add_middleware(ServerErrorMiddleware, handler=global_execution_handler)
 
     # CORS用のヘッダを生成するミドルウェア
-    localhost_regex = "^https?://(localhost|127\\.0\\.0\\.1)(:[0-9]+)?$"
+    localhost_regex = "^https?://(localhost|127\\.0\\.0\\.1|\\[::1\\])(:[0-9]+)?$"
     compiled_localhost_regex = re.compile(localhost_regex)
     allowed_origins = ["*"]
     if cors_policy_mode == "localapps":


### PR DESCRIPTION
## 内容

`localhost_regex`にIPv6のループバックアドレスを追加します。
これにより特に何も設定しなくてもIPv4アドレスと同様にIPv6のローカールホストからのアクセスが許可されます。
