### PR TITLE
MAINT: FastAPIのパラメータを全て`Annotated`に移行する

### DIFF
--- a/run.py
+++ b/run.py
@@ -296,9 +296,9 @@ def generate_app(
     )
     def _synthesis_morphing(
         query: AudioQuery,
-        base_style_id: StyleId = Query(alias="base_speaker"),  # noqa: B008
-        target_style_id: StyleId = Query(alias="target_speaker"),  # noqa: B008
-        morph_rate: float = Query(..., ge=0.0, le=1.0),  # noqa: B008
+        base_style_id: Annotated[StyleId, Query(alias="base_speaker")],
+        target_style_id: Annotated[StyleId, Query(alias="target_speaker")],
+        morph_rate: Annotated[float, Query(ge=0.0, le=1.0)],
         core_version: str | None = None,
     ) -> FileResponse:
         """
@@ -450,11 +450,13 @@ def generate_app(
 
     @app.post("/initialize_speaker", status_code=204, tags=["その他"])
     def initialize_speaker(
-        style_id: StyleId = Query(alias="speaker"),  # noqa: B008
-        skip_reinit: bool = Query(  # noqa: B008
-            default=False,
-            description="既に初期化済みのスタイルの再初期化をスキップするかどうか",
-        ),
+        style_id: Annotated[StyleId, Query(alias="speaker")],
+        skip_reinit: Annotated[
+            bool,
+            Query(
+                description="既に初期化済みのスタイルの再初期化をスキップするかどうか",
+            ),
+        ] = False,
         core_version: str | None = None,
     ) -> Response:
         """
@@ -467,7 +469,7 @@ def generate_app(
 
     @app.get("/is_initialized_speaker", response_model=bool, tags=["その他"])
     def is_initialized_speaker(
-        style_id: StyleId = Query(alias="speaker"),  # noqa: B008
+        style_id: Annotated[StyleId, Query(alias="speaker")],
         core_version: str | None = None,
     ) -> bool:
         """

--- a/voicevox_engine/app/routers/setting.py
+++ b/voicevox_engine/app/routers/setting.py
@@ -1,5 +1,7 @@
 """設定機能を提供する API Router"""
 
+from typing import Annotated
+
 from fastapi import APIRouter, Depends, Form, Request, Response
 from fastapi.templating import Jinja2Templates
 
@@ -49,8 +51,8 @@ def generate_router(
         dependencies=[Depends(check_disabled_mutable_api)],
     )
     def setting_post(
-        cors_policy_mode: CorsPolicyMode = Form(),  # noqa
-        allow_origin: str | None = Form(default=None),  # noqa
+        cors_policy_mode: Annotated[CorsPolicyMode, Form()],
+        allow_origin: Annotated[str | None, Form()] = None,
     ) -> Response:
         """
         設定を更新します。

--- a/voicevox_engine/app/routers/tts_pipeline.py
+++ b/voicevox_engine/app/routers/tts_pipeline.py
@@ -48,7 +48,7 @@ def generate_router(
     )
     def audio_query(
         text: str,
-        style_id: StyleId = Query(alias="speaker"),  # noqa: B008
+        style_id: Annotated[StyleId, Query(alias="speaker")],
         core_version: str | None = None,
     ) -> AudioQuery:
         """
@@ -127,7 +127,7 @@ def generate_router(
     )
     def accent_phrases(
         text: str,
-        style_id: StyleId = Query(alias="speaker"),  # noqa: B008
+        style_id: Annotated[StyleId, Query(alias="speaker")],
         is_kana: bool = False,
         core_version: str | None = None,
     ) -> list[AccentPhrase]:
@@ -159,7 +159,7 @@ def generate_router(
     )
     def mora_data(
         accent_phrases: list[AccentPhrase],
-        style_id: StyleId = Query(alias="speaker"),  # noqa: B008
+        style_id: Annotated[StyleId, Query(alias="speaker")],
         core_version: str | None = None,
     ) -> list[AccentPhrase]:
         engine = get_engine(core_version)
@@ -173,7 +173,7 @@ def generate_router(
     )
     def mora_length(
         accent_phrases: list[AccentPhrase],
-        style_id: StyleId = Query(alias="speaker"),  # noqa: B008
+        style_id: Annotated[StyleId, Query(alias="speaker")],
         core_version: str | None = None,
     ) -> list[AccentPhrase]:
         engine = get_engine(core_version)
@@ -187,7 +187,7 @@ def generate_router(
     )
     def mora_pitch(
         accent_phrases: list[AccentPhrase],
-        style_id: StyleId = Query(alias="speaker"),  # noqa: B008
+        style_id: Annotated[StyleId, Query(alias="speaker")],
         core_version: str | None = None,
     ) -> list[AccentPhrase]:
         engine = get_engine(core_version)
@@ -208,11 +208,13 @@ def generate_router(
     )
     def synthesis(
         query: AudioQuery,
-        style_id: StyleId = Query(alias="speaker"),  # noqa: B008
-        enable_interrogative_upspeak: bool = Query(  # noqa: B008
-            default=True,
-            description="疑問系のテキストが与えられたら語尾を自動調整する",
-        ),
+        style_id: Annotated[StyleId, Query(alias="speaker")],
+        enable_interrogative_upspeak: Annotated[
+            bool,
+            Query(
+                description="疑問系のテキストが与えられたら語尾を自動調整する",
+            ),
+        ] = True,
         core_version: str | None = None,
     ) -> FileResponse:
         engine = get_engine(core_version)
@@ -247,7 +249,7 @@ def generate_router(
     def cancellable_synthesis(
         query: AudioQuery,
         request: Request,
-        style_id: StyleId = Query(alias="speaker"),  # noqa: B008
+        style_id: Annotated[StyleId, Query(alias="speaker")],
         core_version: str | None = None,
     ) -> FileResponse:
         if cancellable_engine is None:
@@ -284,7 +286,7 @@ def generate_router(
     )
     def multi_synthesis(
         queries: list[AudioQuery],
-        style_id: StyleId = Query(alias="speaker"),  # noqa: B008
+        style_id: Annotated[StyleId, Query(alias="speaker")],
         core_version: str | None = None,
     ) -> FileResponse:
         engine = get_engine(core_version)
@@ -324,7 +326,7 @@ def generate_router(
     )
     def sing_frame_audio_query(
         score: Score,
-        style_id: StyleId = Query(alias="speaker"),  # noqa: B008
+        style_id: Annotated[StyleId, Query(alias="speaker")],
         core_version: str | None = None,
     ) -> FrameAudioQuery:
         """
@@ -359,7 +361,7 @@ def generate_router(
     )
     def frame_synthesis(
         query: FrameAudioQuery,
-        style_id: StyleId = Query(alias="speaker"),  # noqa: B008
+        style_id: Annotated[StyleId, Query(alias="speaker")],
         core_version: str | None = None,
     ) -> FileResponse:
         """


### PR DESCRIPTION
## 内容

```Python
def func(arg: str = Query()): ...
```
を
```Python
def func(arg: Annotated[str, Query]): ...
```
の記法に統一します。

## その他

`# noqa: B008`が消せた
APIは変化していない。