### PR TITLE
整理: ライセンス生成の都度登録を一括化

### DIFF
--- a/build_util/generate_licenses.py
+++ b/build_util/generate_licenses.py
@@ -255,6 +255,7 @@ def generate_licenses() -> list[License]:
             text="https://raw.githubusercontent.com/xiph/vorbis/v1.3.7/COPYING",
             license_text_type="remote_address",
         ),
+        # libflac
         License(
             name="FLAC",
             version="1.4.2",
@@ -262,6 +263,7 @@ def generate_licenses() -> list[License]:
             text="https://raw.githubusercontent.com/xiph/flac/1.4.2/COPYING.Xiph",
             license_text_type="remote_address",
         ),
+        # libopus
         License(
             name="Opus",
             version="1.3.1",
@@ -277,6 +279,7 @@ def generate_licenses() -> list[License]:
             text="docs/licenses/mpg123/COPYING",
             license_text_type="local_address",
         ),
+        # liblame
         # https://sourceforge.net/projects/lame/files/lame/3.100/
         License(
             name="lame",

--- a/build_util/generate_licenses.py
+++ b/build_util/generate_licenses.py
@@ -41,103 +41,74 @@ class License:
 def generate_licenses() -> list[License]:
     licenses: list[License] = []
 
-    # openjtalk
-    # https://sourceforge.net/projects/open-jtalk/files/Open%20JTalk/open_jtalk-1.11/
-    licenses.append(
+    licenses += [
+        # https://sourceforge.net/projects/open-jtalk/files/Open%20JTalk/open_jtalk-1.11/
         License(
             name="Open JTalk",
             version="1.11",
             license="Modified BSD license",
             text="docs/licenses/open_jtalk/COPYING",
             license_text_type="local_address",
-        )
-    )
-    licenses.append(
+        ),
         License(
             name="MeCab",
             version=None,
             license="Modified BSD license",
             text="docs/licenses/open_jtalk/mecab/COPYING",
             license_text_type="local_address",
-        )
-    )
-    licenses.append(
+        ),
         License(
             name="NAIST Japanese Dictionary",
             version=None,
             license="Modified BSD license",
             text="docs/licenses//open_jtalk/mecab-naist-jdic/COPYING",
             license_text_type="local_address",
-        )
-    )
-    licenses.append(
+        ),
         License(
             name='HTS Voice "Mei"',
             version=None,
             license="Creative Commons Attribution 3.0 license",
             text="https://raw.githubusercontent.com/r9y9/pyopenjtalk/master/pyopenjtalk/htsvoice/LICENSE_mei_normal.htsvoice",  # noqa: B950
             license_text_type="remote_address",
-        )
-    )
-
-    # VOICEVOX CORE
-    licenses.append(
+        ),
         License(
             name="VOICEVOX CORE",
             version=None,
             license="MIT license",
             text="https://raw.githubusercontent.com/VOICEVOX/voicevox_core/main/LICENSE",
             license_text_type="remote_address",
-        )
-    )
-
-    # VOICEVOX ENGINE
-    licenses.append(
+        ),
         License(
             name="VOICEVOX ENGINE",
             version=None,
             license="LGPL license",
             text="https://raw.githubusercontent.com/VOICEVOX/voicevox_engine/master/LGPL_LICENSE",
             license_text_type="remote_address",
-        )
-    )
-
-    # world
-    licenses.append(
+        ),
         License(
             name="world",
             version=None,
             license="Modified BSD license",
             text="https://raw.githubusercontent.com/mmorise/World/master/LICENSE.txt",
             license_text_type="remote_address",
-        )
-    )
-
-    # pytorch
-    licenses.append(
+        ),
         License(
             name="PyTorch",
             version="1.9.0",
             license="BSD-style license",
             text="https://raw.githubusercontent.com/pytorch/pytorch/master/LICENSE",
             license_text_type="remote_address",
-        )
-    )
-
-    # onnxruntime
-    licenses.append(
+        ),
         License(
             name="ONNX Runtime",
             version="1.13.1",
             license="MIT license",
             text="https://raw.githubusercontent.com/microsoft/onnxruntime/master/LICENSE",
             license_text_type="remote_address",
-        )
-    )
-
-    # Python
+        ),
+    ]
     python_version = "3.11.3"
-    licenses.append(
+    licenses += [
         License(
             name="Python",
             version=python_version,
@@ -145,7 +116,7 @@ def generate_licenses() -> list[License]:
             text=f"https://raw.githubusercontent.com/python/cpython/v{python_version}/LICENSE",
             license_text_type="remote_address",
         )
-    )
+    ]
 
     # pip
     try:
@@ -255,124 +226,88 @@ def generate_licenses() -> list[License]:
         licenses.append(license)
 
     # OpenBLAS
-    licenses.append(
+    licenses += [
         License(
             name="OpenBLAS",
             version=None,
             license="BSD 3-clause license",
             text="https://raw.githubusercontent.com/xianyi/OpenBLAS/develop/LICENSE",
             license_text_type="remote_address",
-        )
-    )
-
-    # libsndfile-binaries
-    licenses.append(
+        ),
         License(
             name="libsndfile-binaries",
             version="1.2.0",
             license="LGPL-2.1 license",
             text="https://raw.githubusercontent.com/bastibe/libsndfile-binaries/d9887ef926bb11cf1a2526be4ab6f9dc690234c0/COPYING",  # noqa: B950
             license_text_type="remote_address",
-        )
-    )
-
-    # libogg
-    licenses.append(
+        ),
         License(
             name="libogg",
             version="1.3.5",
             license="BSD 3-clause license",
             text="https://raw.githubusercontent.com/xiph/ogg/v1.3.5/COPYING",
             license_text_type="remote_address",
-        )
-    )
-
-    # libvorbis
-    licenses.append(
+        ),
         License(
             name="libvorbis",
             version="1.3.7",
             license="BSD 3-clause license",
             text="https://raw.githubusercontent.com/xiph/vorbis/v1.3.7/COPYING",
             license_text_type="remote_address",
-        )
-    )
-
-    # libflac
-    licenses.append(
+        ),
         License(
             name="FLAC",
             version="1.4.2",
             license="Xiph.org's BSD-like license",
             text="https://raw.githubusercontent.com/xiph/flac/1.4.2/COPYING.Xiph",
             license_text_type="remote_address",
-        )
-    )
-
-    # libopus
-    licenses.append(
+        ),
         License(
             name="Opus",
             version="1.3.1",
             license="BSD 3-clause license",
             text="https://raw.githubusercontent.com/xiph/opus/v1.3.1/COPYING",
             license_text_type="remote_address",
-        )
-    )
-
-    # mpg123
-    # https://sourceforge.net/projects/mpg123/files/mpg123/1.30.2/
-    licenses.append(
+        ),
+        # https://sourceforge.net/projects/mpg123/files/mpg123/1.30.2/
         License(
             name="mpg123",
             version="1.30.2",
             license="LGPL-2.1 license",
             text="docs/licenses/mpg123/COPYING",
             license_text_type="local_address",
-        )
-    )
-
-    # liblame
-    # https://sourceforge.net/projects/lame/files/lame/3.100/
-    licenses.append(
+        ),
+        # https://sourceforge.net/projects/lame/files/lame/3.100/
         License(
             name="lame",
             version="3.100",
             license="LGPL-2.0 license",
             text="https://svn.code.sf.net/p/lame/svn/tags/RELEASE__3_100/lame/COPYING",
             license_text_type="remote_address",
-        )
-    )
-
-    # cuda
-    # license text from CUDA 11.8.0
-    # https://developer.nvidia.com/cuda-11-8-0-download-archive?target_os=Windows&target_arch=x86_64&target_version=10&target_type=exe_local # noqa: B950
-    # https://developer.download.nvidia.com/compute/cuda/11.8.0/local_installers/cuda_11.8.0_522.06_windows.exe # noqa: B950
-    # cuda_11.8.0_522.06_windows.exe (cuda_documentation/Doc/EULA.txt)
-    licenses.append(
+        ),
+        # license text from CUDA 11.8.0
+        # https://developer.nvidia.com/cuda-11-8-0-download-archive?target_os=Windows&target_arch=x86_64&target_version=10&target_type=exe_local # noqa: B950
+        # https://developer.download.nvidia.com/compute/cuda/11.8.0/local_installers/cuda_11.8.0_522.06_windows.exe # noqa: B950
+        # cuda_11.8.0_522.06_windows.exe (cuda_documentation/Doc/EULA.txt)
         License(
             name="CUDA Toolkit",
             version="11.8.0",
             license=None,
             text="docs/licenses/cuda/EULA.txt",
             license_text_type="local_address",
-        )
-    )
-    # cudnn
-    # license text from
-    # cuDNN v8.9.2 (June 1st, 2023), for CUDA 11.x, cuDNN Library for Windows
-    # https://developer.nvidia.com/rdp/cudnn-archive # noqa: B950
-    # https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/windows-x86_64/cudnn-windows-x86_64-8.9.2.26_cuda11-archive.zip # noqa: B950
-    # cudnn-windows-x86_64-8.9.2.26_cuda11-archive.zip (cudnn-windows-x86_64-8.9.2.26_cuda11-archive/LICENSE) # noqa: B950
-    licenses.append(
+        ),
+        # license text from cuDNN v8.9.2 (June 1st, 2023), for CUDA 11.x, cuDNN Library for Windows # noqa: B950
+        # https://developer.nvidia.com/rdp/cudnn-archive # noqa: B950
+        # https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/windows-x86_64/cudnn-windows-x86_64-8.9.2.26_cuda11-archive.zip # noqa: B950
+        # cudnn-windows-x86_64-8.9.2.26_cuda11-archive.zip (cudnn-windows-x86_64-8.9.2.26_cuda11-archive/LICENSE) # noqa: B950
         License(
             name="cuDNN",
             version="8.9.2",
             license=None,
             text="docs/licenses/cudnn/LICENSE",
             license_text_type="local_address",
-        )
-    )
+        ),
+    ]
 
     return licenses
 


### PR DESCRIPTION
## 内容
ライセンス生成時、リストへの `append` で都度登録していたライセンス情報を `+=[L1, L2, L3, ...]` で一括登録しリファクタリング  

## 関連 Issue
part of #1182
ref https://github.com/VOICEVOX/voicevox_engine/pull/1177#discussion_r1564804707  