### PR TITLE
整理: `Speaker` と内部型の分離

### DIFF
--- a/test/test_metas_store.py
+++ b/test/test_metas_store.py
@@ -1,7 +1,7 @@
 import uuid
 from unittest import TestCase
 
-from voicevox_engine.metas.Metas import Speaker, SpeakerStyle, StyleType, StyleId
+from voicevox_engine.metas.Metas import Speaker, SpeakerStyle, StyleId, StyleType
 from voicevox_engine.metas.MetasStore import filter_speakers_and_styles
 
 

--- a/test/test_metas_store.py
+++ b/test/test_metas_store.py
@@ -1,7 +1,7 @@
 import uuid
 from unittest import TestCase
 
-from voicevox_engine.metas.Metas import Speaker, SpeakerStyle, StyleType
+from voicevox_engine.metas.Metas import Speaker, SpeakerStyle, StyleType, StyleId
 from voicevox_engine.metas.MetasStore import filter_speakers_and_styles
 
 
@@ -12,7 +12,7 @@ def _gen_speaker(style_types: list[StyleType]) -> Speaker:
         styles=[
             SpeakerStyle(
                 name="",
-                id=0,
+                id=StyleId(0),
                 type=style_type,
             )
             for style_type in style_types

--- a/voicevox_engine/metas/Metas.py
+++ b/voicevox_engine/metas/Metas.py
@@ -54,13 +54,13 @@ class Speaker(BaseModel):
     話者情報
     """
 
-    supported_features: SpeakerSupportedFeatures = Field(
-        title="話者の対応機能", default_factory=SpeakerSupportedFeatures
-    )
     name: str = Field(title="名前")
     speaker_uuid: str = Field(title="話者のUUID")
     styles: List[SpeakerStyle] = Field(title="スタイルの一覧")
     version: str = Field("話者のバージョン")
+    supported_features: SpeakerSupportedFeatures = Field(
+        title="話者の対応機能", default_factory=SpeakerSupportedFeatures
+    )
 
 
 class StyleInfo(BaseModel):

--- a/voicevox_engine/metas/Metas.py
+++ b/voicevox_engine/metas/Metas.py
@@ -49,21 +49,14 @@ class SpeakerSupportedFeatures(BaseModel):
     )
 
 
-class EngineSpeaker(BaseModel):
+class Speaker(BaseModel):
     """
-    エンジンに含まれる話者情報
+    話者情報
     """
 
     supported_features: SpeakerSupportedFeatures = Field(
         title="話者の対応機能", default_factory=SpeakerSupportedFeatures
     )
-
-
-class Speaker(EngineSpeaker):
-    """
-    話者情報
-    """
-
     name: str = Field(title="名前")
     speaker_uuid: str = Field(title="話者のUUID")
     styles: List[SpeakerStyle] = Field(title="スタイルの一覧")

--- a/voicevox_engine/metas/Metas.py
+++ b/voicevox_engine/metas/Metas.py
@@ -49,17 +49,6 @@ class SpeakerSupportedFeatures(BaseModel):
     )
 
 
-class CoreSpeaker(BaseModel):
-    """
-    コアに含まれる話者情報
-    """
-
-    name: str = Field(title="名前")
-    speaker_uuid: str = Field(title="話者のUUID")
-    styles: List[SpeakerStyle] = Field(title="スタイルの一覧")
-    version: str = Field("話者のバージョン")
-
-
 class EngineSpeaker(BaseModel):
     """
     エンジンに含まれる話者情報
@@ -70,12 +59,15 @@ class EngineSpeaker(BaseModel):
     )
 
 
-class Speaker(CoreSpeaker, EngineSpeaker):
+class Speaker(EngineSpeaker):
     """
     話者情報
     """
 
-    pass
+    name: str = Field(title="名前")
+    speaker_uuid: str = Field(title="話者のUUID")
+    styles: List[SpeakerStyle] = Field(title="スタイルの一覧")
+    version: str = Field("話者のバージョン")
 
 
 class StyleInfo(BaseModel):

--- a/voicevox_engine/metas/MetasStore.py
+++ b/voicevox_engine/metas/MetasStore.py
@@ -42,7 +42,10 @@ class _CoreSpeakerStyle(BaseModel):
 
 def cast_styles(cores: list[_CoreSpeakerStyle]) -> list[SpeakerStyle]:
     """コアから取得したスタイル情報をエンジン形式へキャストする。"""
-    return [SpeakerStyle(name=core.name, id=core.id, type=core.type) for core in cores]
+    return [
+        SpeakerStyle(name=core.name, id=StyleId(core.id), type=core.type)
+        for core in cores
+    ]
 
 
 class _CoreSpeaker(BaseModel):

--- a/voicevox_engine/metas/MetasStore.py
+++ b/voicevox_engine/metas/MetasStore.py
@@ -17,18 +17,18 @@ if TYPE_CHECKING:
     from voicevox_engine.core.core_adapter import CoreAdapter
 
 
-CoreStyleId = NewType("CoreStyleId", int)
-CoreStyleType = Literal["talk", "singing_teacher", "frame_decode", "sing"]
+_CoreStyleId = NewType("_CoreStyleId", int)
+_CoreStyleType = Literal["talk", "singing_teacher", "frame_decode", "sing"]
 
 
-class CoreSpeakerStyle(BaseModel):
+class _CoreSpeakerStyle(BaseModel):
     """
     話者のスタイル情報
     """
 
     name: str = Field(title="スタイル名")
-    id: CoreStyleId = Field(title="スタイルID")
-    type: Optional[CoreStyleType] = Field(
+    id: _CoreStyleId = Field(title="スタイルID")
+    type: Optional[_CoreStyleType] = Field(
         default="talk",
         title=(
             "スタイルの種類。"
@@ -40,23 +40,23 @@ class CoreSpeakerStyle(BaseModel):
     )
 
 
-def cast_styles(cores: list[CoreSpeakerStyle]) -> list[SpeakerStyle]:
+def cast_styles(cores: list[_CoreSpeakerStyle]) -> list[SpeakerStyle]:
     """コアから取得したスタイル情報をエンジン形式へキャストする。"""
     return [SpeakerStyle(name=core.name, id=core.id, type=core.type) for core in cores]
 
 
-class CoreSpeaker(BaseModel):
+class _CoreSpeaker(BaseModel):
     """
     コアに含まれる話者情報
     """
 
     name: str = Field(title="名前")
     speaker_uuid: str = Field(title="話者のUUID")
-    styles: List[CoreSpeakerStyle] = Field(title="スタイルの一覧")
+    styles: List[_CoreSpeakerStyle] = Field(title="スタイルの一覧")
     version: str = Field("話者のバージョン")
 
 
-class EngineSpeaker(BaseModel):
+class _EngineSpeaker(BaseModel):
     """
     エンジンに含まれる話者情報
     """
@@ -79,8 +79,8 @@ class MetasStore:
             エンジンに含まれる話者メタ情報ディレクトリのパス。
         """
         # エンジンに含まれる各話者のメタ情報
-        self._loaded_metas: Dict[str, EngineSpeaker] = {
-            folder.name: EngineSpeaker(
+        self._loaded_metas: Dict[str, _EngineSpeaker] = {
+            folder.name: _EngineSpeaker(
                 **json.loads((folder / "metas.json").read_text(encoding="utf-8"))
             )
             for folder in engine_speakers_path.iterdir()
@@ -101,7 +101,7 @@ class MetasStore:
             エンジンとコアに含まれる話者メタ情報
         """
         # コアに含まれる話者メタ情報の収集
-        core_metas = [CoreSpeaker(**speaker) for speaker in json.loads(core.speakers)]
+        core_metas = [_CoreSpeaker(**speaker) for speaker in json.loads(core.speakers)]
         # エンジンに含まれる話者メタ情報との統合
         return [
             Speaker(

--- a/voicevox_engine/metas/MetasStore.py
+++ b/voicevox_engine/metas/MetasStore.py
@@ -1,7 +1,7 @@
 import json
 from copy import deepcopy
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, List, Literal, NewType, Optional, Tuple
+from typing import TYPE_CHECKING, Dict, List, Literal, NewType, Tuple
 
 from pydantic import BaseModel, Field
 

--- a/voicevox_engine/metas/MetasStore.py
+++ b/voicevox_engine/metas/MetasStore.py
@@ -6,9 +6,9 @@ from typing import TYPE_CHECKING, Dict, List, Literal, NewType, Optional, Tuple
 from pydantic import BaseModel, Field
 
 from voicevox_engine.metas.Metas import (
-    EngineSpeaker,
     Speaker,
     SpeakerStyle,
+    SpeakerSupportedFeatures,
     StyleId,
     StyleType,
 )
@@ -56,6 +56,16 @@ class CoreSpeaker(BaseModel):
     version: str = Field("話者のバージョン")
 
 
+class EngineSpeaker(BaseModel):
+    """
+    エンジンに含まれる話者情報
+    """
+
+    supported_features: SpeakerSupportedFeatures = Field(
+        title="話者の対応機能", default_factory=SpeakerSupportedFeatures
+    )
+
+
 class MetasStore:
     """
     話者やスタイルのメタ情報を管理する
@@ -95,7 +105,9 @@ class MetasStore:
         # エンジンに含まれる話者メタ情報との統合
         return [
             Speaker(
-                **self._loaded_metas[speaker_meta.speaker_uuid].dict(),
+                supported_features=self._loaded_metas[
+                    speaker_meta.speaker_uuid
+                ].supported_features,
                 name=speaker_meta.name,
                 speaker_uuid=speaker_meta.speaker_uuid,
                 styles=cast_styles(speaker_meta.styles),

--- a/voicevox_engine/metas/MetasStore.py
+++ b/voicevox_engine/metas/MetasStore.py
@@ -26,18 +26,9 @@ class _CoreSpeakerStyle(BaseModel):
     話者のスタイル情報
     """
 
-    name: str = Field(title="スタイル名")
-    id: _CoreStyleId = Field(title="スタイルID")
-    type: Optional[_CoreStyleType] = Field(
-        default="talk",
-        title=(
-            "スタイルの種類。"
-            "talk:音声合成クエリの作成と音声合成が可能。"
-            "singing_teacher:歌唱音声合成用のクエリの作成が可能。"
-            "frame_decode:歌唱音声合成が可能。"
-            "sing:歌唱音声合成用のクエリの作成と歌唱音声合成が可能。"
-        ),
-    )
+    name: str
+    id: _CoreStyleId
+    type: _CoreStyleType | None = Field(default="talk")
 
 
 def cast_styles(cores: list[_CoreSpeakerStyle]) -> list[SpeakerStyle]:
@@ -53,9 +44,9 @@ class _CoreSpeaker(BaseModel):
     コアに含まれる話者情報
     """
 
-    name: str = Field(title="名前")
-    speaker_uuid: str = Field(title="話者のUUID")
-    styles: List[_CoreSpeakerStyle] = Field(title="スタイルの一覧")
+    name: str
+    speaker_uuid: str
+    styles: List[_CoreSpeakerStyle]
     version: str = Field("話者のバージョン")
 
 
@@ -65,7 +56,7 @@ class _EngineSpeaker(BaseModel):
     """
 
     supported_features: SpeakerSupportedFeatures = Field(
-        title="話者の対応機能", default_factory=SpeakerSupportedFeatures
+        default_factory=SpeakerSupportedFeatures
     )
 
 

--- a/voicevox_engine/metas/MetasStore.py
+++ b/voicevox_engine/metas/MetasStore.py
@@ -1,7 +1,7 @@
 import json
 from copy import deepcopy
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, List, Literal, Tuple, NewType, Optional
+from typing import TYPE_CHECKING, Dict, List, Literal, NewType, Optional, Tuple
 
 from pydantic import BaseModel, Field
 

--- a/voicevox_engine/metas/MetasStore.py
+++ b/voicevox_engine/metas/MetasStore.py
@@ -3,8 +3,9 @@ from copy import deepcopy
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict, List, Literal, Tuple
 
+from pydantic import BaseModel, Field
+
 from voicevox_engine.metas.Metas import (
-    CoreSpeaker,
     EngineSpeaker,
     Speaker,
     SpeakerStyle,
@@ -14,6 +15,17 @@ from voicevox_engine.metas.Metas import (
 
 if TYPE_CHECKING:
     from voicevox_engine.core.core_adapter import CoreAdapter
+
+
+class CoreSpeaker(BaseModel):
+    """
+    コアに含まれる話者情報
+    """
+
+    name: str = Field(title="名前")
+    speaker_uuid: str = Field(title="話者のUUID")
+    styles: List[SpeakerStyle] = Field(title="スタイルの一覧")
+    version: str = Field("話者のバージョン")
 
 
 class MetasStore:
@@ -56,7 +68,10 @@ class MetasStore:
         return [
             Speaker(
                 **self._loaded_metas[speaker_meta.speaker_uuid].dict(),
-                **speaker_meta.dict(),
+                name=speaker_meta.name,
+                speaker_uuid=speaker_meta.speaker_uuid,
+                styles=speaker_meta.styles,
+                version=speaker_meta.version,
             )
             for speaker_meta in core_metas
         ]


### PR DESCRIPTION
## 内容
整理: VV API `Speaker` 型と ENGINE 内部型（`CoreSpeaker`・`EngineSpeaker`）を分離してリファクタリングした。  

属性 `SpeakerStyle` も `CoreSpeakerStyle` として分離したため、VV API 話者情報と Core 話者情報は完全に分離された。  
これによりピッチ範囲情報を任意の箇所（ENGINE or CORE）に実装可能となる。  

## 関連 Issue
ref https://github.com/VOICEVOX/voicevox_engine/pull/1121#discussion_r1550892889