### PR TITLE
整理：エンジンビルド後のテストの待機時間を可変に

### DIFF
--- a/build_util/check_release_build.py
+++ b/build_util/check_release_build.py
@@ -27,8 +27,8 @@ def test_release_build(dist_dir: Path, skip_run_process: bool) -> None:
         process = Popen([run_file.absolute()], cwd=dist_dir)
 
     # 起動待機
-    for i in range(10):
-        print(f"エンジン起動待機中... {i}")
+    for i in range(30):
+        print(f"Waiting for the engine to start... {i}")
         time.sleep(15)
         try:
             req = Request(base_url + "version")
@@ -38,7 +38,8 @@ def test_release_build(dist_dir: Path, skip_run_process: bool) -> None:
         except Exception:
             continue
     else:
-        raise RuntimeError("エンジンが起動しませんでした")
+        print("Failed to start the engine.")
+        exit(1)
 
     # テキスト -> クエリ
     text = "こんにちは、音声合成の世界へようこそ"

--- a/build_util/check_release_build.py
+++ b/build_util/check_release_build.py
@@ -27,7 +27,7 @@ def test_release_build(dist_dir: Path, skip_run_process: bool) -> None:
         process = Popen([run_file.absolute()], cwd=dist_dir)
 
     # 起動待機
-    for i in range(30):
+    for i in range(100):
         print(f"Waiting for the engine to start... {i}")
         time.sleep(15)
         try:

--- a/build_util/check_release_build.py
+++ b/build_util/check_release_build.py
@@ -28,7 +28,7 @@ def test_release_build(dist_dir: Path, skip_run_process: bool) -> None:
 
     # 起動待機
     for i in range(10):
-        print(f"サーバー起動待機中... {i}")
+        print(f"エンジン起動待機中... {i}")
         time.sleep(15)
         try:
             req = Request(base_url + "version")
@@ -38,7 +38,7 @@ def test_release_build(dist_dir: Path, skip_run_process: bool) -> None:
         except Exception:
             continue
     else:
-        raise RuntimeError("サーバーが起動しませんでした")
+        raise RuntimeError("エンジンが起動しませんでした")
 
     # テキスト -> クエリ
     text = "こんにちは、音声合成の世界へようこそ"

--- a/build_util/check_release_build.py
+++ b/build_util/check_release_build.py
@@ -25,12 +25,20 @@ def test_release_build(dist_dir: Path, skip_run_process: bool) -> None:
     process = None
     if not skip_run_process:
         process = Popen([run_file.absolute()], cwd=dist_dir)
-        time.sleep(60)  # 待機
 
-    # バージョン取得テスト
-    req = Request(base_url + "version")
-    with urlopen(req) as res:
-        assert len(res.read()) > 0
+    # 起動待機
+    for i in range(10):
+        print(f"サーバー起動待機中... {i}")
+        time.sleep(15)
+        try:
+            req = Request(base_url + "version")
+            with urlopen(req) as res:
+                if len(res.read()) > 0:
+                    break
+        except Exception:
+            continue
+    else:
+        raise RuntimeError("サーバーが起動しませんでした")
 
     # テキスト -> クエリ
     text = "こんにちは、音声合成の世界へようこそ"

--- a/build_util/check_release_build.py
+++ b/build_util/check_release_build.py
@@ -27,7 +27,7 @@ def test_release_build(dist_dir: Path, skip_run_process: bool) -> None:
         process = Popen([run_file.absolute()], cwd=dist_dir)
 
     # 起動待機
-    for i in range(100):
+    for i in range(10):
         print(f"Waiting for the engine to start... {i}")
         time.sleep(15)
         try:


### PR DESCRIPTION
## 内容

ビルド後のテストで、エンジンの待機が一律で６０秒だったのを、１５秒〜１５０秒にしました。
これで早めにエンジン起動が終わった場合は早めにテストが終わると思います。

サーバーの待機を６０秒から１５秒×１０回にします。

## その他

[macosで動かない問題](https://github.com/VOICEVOX/voicevox_engine/issues/1191)の解決になると思っていたPRですが、そもそも環境が良くなくて落ちてたっぽく、起動時間は関係ありませんでした。
↑の解決PRは[こちら](https://github.com/VOICEVOX/voicevox_engine/pull/1205)です。
