### PR TITLE
修正：macos-11を使わないようにする

### DIFF
--- a/.github/workflows/build-engine-package.yml
+++ b/.github/workflows/build-engine-package.yml
@@ -77,7 +77,7 @@ jobs:
             zlib_url: http://www.winimage.com/zLibDll/zlib123dllx64.zip
             target: windows-nvidia
           # Mac CPU (x64 arch only)
-          - os: macos-11
+          - os: macos-12
             architecture: "x64"
             voicevox_core_asset_prefix: voicevox_core-osx-x64-cpu
             onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.13.1/onnxruntime-osx-x86_64-1.13.1.tgz

--- a/.github/workflows/test-engine-package.yml
+++ b/.github/workflows/test-engine-package.yml
@@ -41,7 +41,7 @@ jobs:
             target: linux-cpu
           - os: ubuntu-20.04
             target: linux-nvidia
-          - os: macos-11
+          - os: macos-12
             target: macos-x64
           - os: windows-2019
             target: windows-cpu


### PR DESCRIPTION
## 内容

ビルド後のパッケージを使ってmacos-11で自動テストするCIがなぜか落ちるようになってしまいました。
その解決PRです。

なぜ動かなくなってしまったのかはしっかりした調査は行っていませんが、macos-11は来月にGithub Actionsでサポート終了となるので、どのみち使えなくなるからもう移行してしまっても良いかなと思いました。
macos-12であれば普通に動いたので、そちらに変更で良いかなと。

## 関連 Issue

close #1191 

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他

macos-11でビルドしたものがmacos-12で動くことは確認しているのですが、macos-12でビルドが通るかはまだ試していないので、いったんdraft PRになっています。
[ビルド中](https://github.com/Hiroshiba/voicevox_engine/actions/runs/8909231603)
