### PR TITLE
自動アサインされるレビュワーをmain-reviewerチームに変更する

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @VOICEVOX/maintainer
+* @VOICEVOX/main-reviewer


### PR DESCRIPTION
## 内容

自動アサインされるレビュワーをmain-reviewerチームに変更します。
今までは @Hiroshiba と @y-chan が自動アサインされていましたが、いったん @Hiroshiba だけアサインされる形になります。

経緯 https://discord.com/channels/879570910208733277/893889888208977960/1235452920691163206


## その他
