### PR TITLE
feat: 脆弱性診断結果をdiscordに通知させる

### DIFF
--- a/.github/workflows/test-security.yml
+++ b/.github/workflows/test-security.yml
@@ -41,5 +41,6 @@ jobs:
           username: GitHub Actions
           title: "依存パッケージ脆弱性診断の結果"
           status: ${{ job.status }}
-          url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           color: ${{ job.status == 'success' && 0x00FF00 || 0xFF0000 }} 
+          url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+

--- a/.github/workflows/test-security.yml
+++ b/.github/workflows/test-security.yml
@@ -36,8 +36,10 @@ jobs:
       - name: Notify Discord of security testing result
         uses: sarisia/actions-status-discord@v1
         if: always()
-        with:
+        with: 
           webhook: ${{ secrets.DISCORD_WEBHOOK_URL }}
           username: GitHub Actions
           title: "依存パッケージ脆弱性診断の結果"
-          url: "https://github.com/***"
+          status: ${{ job.status }}
+          url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          color: ${{ job.status == 'success' && 0x00FF00 || 0xFF0000 }} 

--- a/.github/workflows/test-security.yml
+++ b/.github/workflows/test-security.yml
@@ -32,3 +32,16 @@ jobs:
 
       - name: <Test> Check Python dependency security
         run: safety check -r requirements.txt -r requirements-dev.txt -r requirements-test.txt -r requirements-license.txt -o bare
+
+      - name: Notify Discord of security testing result
+        run: |
+          curl -H "Content-Type: application/json" -X POST -d '{
+          "username": "GitHub",
+          "embeds": [            
+          {          
+            "title": "脆弱性診断結果",
+            "description": "脆弱性診断結果",
+            "url": "ここにgithubURLを書く"
+          }]                               
+          } ' "ここにDiscordのWebhookURLを書く" 
+

--- a/.github/workflows/test-security.yml
+++ b/.github/workflows/test-security.yml
@@ -34,14 +34,10 @@ jobs:
         run: safety check -r requirements.txt -r requirements-dev.txt -r requirements-test.txt -r requirements-license.txt -o bare
 
       - name: Notify Discord of security testing result
-        run: |
-          curl -H "Content-Type: application/json" -X POST -d '{
-          "username": "GitHub",
-          "embeds": [            
-          {          
-            "title": "脆弱性診断結果",
-            "description": "脆弱性診断結果",
-            "url": "ここにgithubURLを書く"
-          }]                               
-          } ' "ここにDiscordのWebhookURLを書く" 
-
+        uses: sarisia/actions-status-discord@v1
+        if: always()
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          username: GitHub Actions
+          title: "依存パッケージ脆弱性診断の結果"
+          url: "https://github.com/***"

--- a/.github/workflows/test-security.yml
+++ b/.github/workflows/test-security.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Notify Discord of security testing result
         uses: sarisia/actions-status-discord@v1
         if: always()
-        with: 
+        with:
           webhook: ${{ secrets.DISCORD_WEBHOOK_URL }}
           username: GitHub Actions
           title: "依存パッケージ脆弱性診断の結果"


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->

依存パッケージ脆弱性診断の結果をdiscordに通知するために必要な、雛形のようなものを作ってみました。
この雛形を編集し、webhookのurlをsecretsの変数として定義することで、voicevoxコミュニティに脆弱性診断を送信できると思います。
## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->
- https://github.com/VOICEVOX/voicevox_engine/issues/1204

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->
