### PR TITLE
整理: 最新コアバージョン取得の簡略化

### DIFF
--- a/run.py
+++ b/run.py
@@ -343,7 +343,7 @@ def main() -> None:
     )
     tts_engines = make_tts_engines_from_cores(cores)
     assert len(tts_engines) != 0, "音声合成エンジンがありません。"
-    latest_core_version = get_latest_core_version(versions=list(tts_engines.keys()))
+    latest_core_version = get_latest_core_version(list(tts_engines.keys()))
 
     # Cancellable Engine
     enable_cancellable_synthesis: bool = args.enable_cancellable_synthesis

--- a/run.py
+++ b/run.py
@@ -40,7 +40,7 @@ from voicevox_engine.tts_pipeline.tts_engine import (
     make_tts_engines_from_cores,
 )
 from voicevox_engine.user_dict.user_dict import update_dict
-from voicevox_engine.utility.core_version_utility import get_latest_core_version
+from voicevox_engine.utility.core_version_utility import get_latest_version
 from voicevox_engine.utility.path_utility import engine_root, get_save_dir
 from voicevox_engine.utility.run_utility import decide_boolean_from_env
 
@@ -343,7 +343,7 @@ def main() -> None:
     )
     tts_engines = make_tts_engines_from_cores(cores)
     assert len(tts_engines) != 0, "音声合成エンジンがありません。"
-    latest_core_version = get_latest_core_version(list(tts_engines.keys()))
+    latest_core_version = get_latest_version(list(tts_engines.keys()))
 
     # Cancellable Engine
     enable_cancellable_synthesis: bool = args.enable_cancellable_synthesis

--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -11,14 +11,14 @@ from voicevox_engine.core.core_initializer import initialize_cores
 from voicevox_engine.preset.PresetManager import PresetManager
 from voicevox_engine.setting.SettingLoader import SettingHandler
 from voicevox_engine.tts_pipeline.tts_engine import make_tts_engines_from_cores
-from voicevox_engine.utility.core_version_utility import get_latest_core_version
+from voicevox_engine.utility.core_version_utility import get_latest_version
 
 
 @pytest.fixture()
 def app_params(tmp_path: Path) -> dict[str, Any]:
     cores = initialize_cores(use_gpu=False, enable_mock=True)
     tts_engines = make_tts_engines_from_cores(cores)
-    latest_core_version = get_latest_core_version(list(tts_engines.keys()))
+    latest_core_version = get_latest_version(list(tts_engines.keys()))
     setting_loader = SettingHandler(Path("./not_exist.yaml"))
 
     # 隔離されたプリセットの生成

--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -18,7 +18,7 @@ from voicevox_engine.utility.core_version_utility import get_latest_core_version
 def app_params(tmp_path: Path) -> dict[str, Any]:
     cores = initialize_cores(use_gpu=False, enable_mock=True)
     tts_engines = make_tts_engines_from_cores(cores)
-    latest_core_version = get_latest_core_version(versions=list(tts_engines.keys()))
+    latest_core_version = get_latest_core_version(list(tts_engines.keys()))
     setting_loader = SettingHandler(Path("./not_exist.yaml"))
 
     # 隔離されたプリセットの生成

--- a/test/test_core_version_utility.py
+++ b/test/test_core_version_utility.py
@@ -5,7 +5,7 @@
 from voicevox_engine.utility.core_version_utility import get_latest_version
 
 
-def test_get_latest_version_same_preview_normal(self) -> None:
+def test_get_latest_version_same_preview_normal() -> None:
     """`get_latest_version()` は同一バージョンの preview 版より正規版を優先する。"""
 
     # Inputs
@@ -29,7 +29,7 @@ def test_get_latest_version_same_preview_normal(self) -> None:
     assert true_latest == latest
 
 
-def test_get_latest_version_newer_preview(self) -> None:
+def test_get_latest_version_newer_preview() -> None:
     """`get_latest_version()` は旧バージョンの正規版より新バージョンの preview 版を優先する。"""
 
     # Inputs

--- a/test/test_core_version_utility.py
+++ b/test/test_core_version_utility.py
@@ -1,31 +1,48 @@
-from unittest import TestCase
+"""
+コアバージョンに関する utilities のテスト
+"""
 
 from voicevox_engine.utility.core_version_utility import get_latest_core_version
 
 
-class TestCoreVersion(TestCase):
-    def test_get_latest_core_version(self) -> None:
-        self.assertEqual(
-            get_latest_core_version(
-                [
-                    "0.0.0",
-                    "0.1.0",
-                    "0.10.0",
-                    "0.10.0-preview.1",
-                    "0.14.0",
-                    "0.14.0-preview.1",
-                    "0.14.0-preview.10",
-                ]
-            ),
-            "0.14.0",
-        )
+def test_get_latest_core_version_same_preview_normal(self) -> None:
+    """`get_latest_core_version()` は同一バージョンの preview 版より正規版を優先する。"""
 
-        self.assertEqual(
-            get_latest_core_version(
-                [
-                    "0.14.0",
-                    "0.15.0-preview.1",
-                ]
-            ),
-            "0.15.0-preview.1",
-        )
+    # Inputs
+    versions = [
+        "0.0.0",
+        "0.1.0",
+        "0.10.0",
+        "0.10.0-preview.1",
+        "0.14.0",
+        "0.14.0-preview.1",
+        "0.14.0-preview.10",
+    ]
+
+    # Expects
+    true_latest = "0.14.0"
+
+    # Outputs
+    latest = get_latest_core_version(versions)
+
+    # Tests
+    assert true_latest == latest
+
+
+def test_get_latest_core_version_newer_preview(self) -> None:
+    """`get_latest_core_version()` は旧バージョンの正規版より新バージョンの preview 版を優先する。"""
+
+    # Inputs
+    versions = [
+        "0.14.0",
+        "0.15.0-preview.1",
+    ]
+
+    # Expects
+    true_latest = "0.15.0-preview.1"
+
+    # Outputs
+    latest = get_latest_core_version(versions)
+
+    # Tests
+    assert true_latest == latest

--- a/test/test_core_version_utility.py
+++ b/test/test_core_version_utility.py
@@ -7,7 +7,7 @@ class TestCoreVersion(TestCase):
     def test_get_latest_core_version(self) -> None:
         self.assertEqual(
             get_latest_core_version(
-                versions=[
+                [
                     "0.0.0",
                     "0.1.0",
                     "0.10.0",
@@ -22,7 +22,7 @@ class TestCoreVersion(TestCase):
 
         self.assertEqual(
             get_latest_core_version(
-                versions=[
+                [
                     "0.14.0",
                     "0.15.0-preview.1",
                 ]

--- a/test/test_core_version_utility.py
+++ b/test/test_core_version_utility.py
@@ -1,21 +1,9 @@
 from unittest import TestCase
 
-from voicevox_engine.utility.core_version_utility import (
-    get_latest_core_version,
-    parse_core_version,
-)
+from voicevox_engine.utility.core_version_utility import get_latest_core_version
 
 
 class TestCoreVersion(TestCase):
-    def test_parse_core_version(self) -> None:
-        parse_core_version("0.0.0")
-        parse_core_version("0.1.0")
-        parse_core_version("0.10.0")
-        parse_core_version("0.10.0-preview.1")
-        parse_core_version("0.14.0")
-        parse_core_version("0.14.0-preview.1")
-        parse_core_version("0.14.0-preview.10")
-
     def test_get_latest_core_version(self) -> None:
         self.assertEqual(
             get_latest_core_version(

--- a/test/test_core_version_utility.py
+++ b/test/test_core_version_utility.py
@@ -2,11 +2,11 @@
 コアバージョンに関する utilities のテスト
 """
 
-from voicevox_engine.utility.core_version_utility import get_latest_core_version
+from voicevox_engine.utility.core_version_utility import get_latest_version
 
 
-def test_get_latest_core_version_same_preview_normal(self) -> None:
-    """`get_latest_core_version()` は同一バージョンの preview 版より正規版を優先する。"""
+def test_get_latest_version_same_preview_normal(self) -> None:
+    """`get_latest_version()` は同一バージョンの preview 版より正規版を優先する。"""
 
     # Inputs
     versions = [
@@ -23,14 +23,14 @@ def test_get_latest_core_version_same_preview_normal(self) -> None:
     true_latest = "0.14.0"
 
     # Outputs
-    latest = get_latest_core_version(versions)
+    latest = get_latest_version(versions)
 
     # Tests
     assert true_latest == latest
 
 
-def test_get_latest_core_version_newer_preview(self) -> None:
-    """`get_latest_core_version()` は旧バージョンの正規版より新バージョンの preview 版を優先する。"""
+def test_get_latest_version_newer_preview(self) -> None:
+    """`get_latest_version()` は旧バージョンの正規版より新バージョンの preview 版を優先する。"""
 
     # Inputs
     versions = [
@@ -42,7 +42,7 @@ def test_get_latest_core_version_newer_preview(self) -> None:
     true_latest = "0.15.0-preview.1"
 
     # Outputs
-    latest = get_latest_core_version(versions)
+    latest = get_latest_version(versions)
 
     # Tests
     assert true_latest == latest

--- a/voicevox_engine/cancellable_engine.py
+++ b/voicevox_engine/cancellable_engine.py
@@ -239,7 +239,7 @@ def start_synthesis_subprocess(
     tts_engines = make_tts_engines_from_cores(cores)
 
     assert len(tts_engines) != 0, "音声合成エンジンがありません。"
-    latest_core_version = get_latest_core_version(versions=list(tts_engines.keys()))
+    latest_core_version = get_latest_core_version(list(tts_engines.keys()))
     while True:
         try:
             query, style_id, core_version = sub_proc_con.recv()

--- a/voicevox_engine/cancellable_engine.py
+++ b/voicevox_engine/cancellable_engine.py
@@ -20,7 +20,7 @@ from .core.core_initializer import initialize_cores
 from .metas.Metas import StyleId
 from .model import AudioQuery
 from .tts_pipeline.tts_engine import make_tts_engines_from_cores
-from .utility.core_version_utility import get_latest_core_version
+from .utility.core_version_utility import get_latest_version
 
 
 class CancellableEngine:
@@ -239,7 +239,7 @@ def start_synthesis_subprocess(
     tts_engines = make_tts_engines_from_cores(cores)
 
     assert len(tts_engines) != 0, "音声合成エンジンがありません。"
-    latest_core_version = get_latest_core_version(list(tts_engines.keys()))
+    latest_core_version = get_latest_version(list(tts_engines.keys()))
     while True:
         try:
             query, style_id, core_version = sub_proc_con.recv()

--- a/voicevox_engine/utility/core_version_utility.py
+++ b/voicevox_engine/utility/core_version_utility.py
@@ -1,8 +1,8 @@
 from semver.version import Version
 
 
-def get_latest_core_version(versions: list[str]) -> str:
-    """一覧の中で最も新しいコアのバージョン番号を出力する。"""
+def get_latest_version(versions: list[str]) -> str:
+    """一覧の中で最も新しいバージョン番号を出力する。"""
     if len(versions) == 0:
         raise Exception("versions must be non-empty.")
     return str(max(map(Version.parse, versions)))

--- a/voicevox_engine/utility/core_version_utility.py
+++ b/voicevox_engine/utility/core_version_utility.py
@@ -2,6 +2,7 @@ from semver.version import Version
 
 
 def get_latest_core_version(versions: list[str]) -> str:
+    """一覧の中で最も新しいコアのバージョン番号を出力する。"""
     if len(versions) == 0:
         raise Exception("versions must be non-empty.")
     return str(max(map(Version.parse, versions)))

--- a/voicevox_engine/utility/core_version_utility.py
+++ b/voicevox_engine/utility/core_version_utility.py
@@ -1,14 +1,7 @@
-from collections.abc import Collection
-
 from semver.version import Version
 
 
-def parse_core_version(version: str) -> Version:
-    return Version.parse(version)
-
-
-def get_latest_core_version(versions: Collection[str]) -> str:
+def get_latest_core_version(versions: list[str]) -> str:
     if len(versions) == 0:
         raise Exception("versions must be non-empty.")
-
-    return str(max(map(parse_core_version, versions)))
+    return str(max(map(Version.parse, versions)))


### PR DESCRIPTION
## 内容
整理: 最新コアバージョン取得に関連するコードを簡略化してリファクタリング  

外部ライブラリの単なるラッパーとなっていた `parse_core_version()` を廃止した。`parse_core_version()` のテストはライブラリの使い方テストになっていたため廃止した。  

`get_latest_core_version()` はコアに関係なくバージョンリストから最新バージョン番号を拾っているため、`get_latest_version()` へリネームした。  

`get_latest_version()` のテストが旧形式で記述されていたため pytest ベースに修正し、テスト意図をコメントとして明示した。  

## 関連 Issue
無し