### PR TITLE
整理: `UserDictionary` クラスを追加

### DIFF
--- a/build_util/make_docs.py
+++ b/build_util/make_docs.py
@@ -7,6 +7,7 @@ from voicevox_engine.dev.tts_engine.mock import MockTTSEngine
 from voicevox_engine.preset.PresetManager import PresetManager
 from voicevox_engine.setting.SettingLoader import USER_SETTING_PATH, SettingHandler
 from voicevox_engine.tts_pipeline.tts_engine import CoreAdapter
+from voicevox_engine.user_dict.user_dict import UserDictionary
 from voicevox_engine.utility.path_utility import engine_root
 
 
@@ -44,6 +45,7 @@ if __name__ == "__main__":
         preset_manager=PresetManager(  # FIXME: impl MockPresetManager
             preset_path=engine_root() / "presets.yaml",
         ),
+        user_dict=UserDictionary(),
     )
     api_schema = json.dumps(app.openapi())
 

--- a/run.py
+++ b/run.py
@@ -17,6 +17,7 @@ from voicevox_engine.preset.PresetManager import PresetManager
 from voicevox_engine.setting.Setting import CorsPolicyMode
 from voicevox_engine.setting.SettingLoader import USER_SETTING_PATH, SettingHandler
 from voicevox_engine.tts_pipeline.tts_engine import make_tts_engines_from_cores
+from voicevox_engine.user_dict.user_dict import UserDictionary
 from voicevox_engine.utility.core_version_utility import get_latest_version
 from voicevox_engine.utility.path_utility import engine_root
 from voicevox_engine.utility.run_utility import decide_boolean_from_env
@@ -294,6 +295,8 @@ def main() -> None:
     # ファイルの存在に関わらず指定されたパスをプリセットファイルとして使用する
     preset_manager = PresetManager(preset_path)
 
+    use_dict = UserDictionary()
+
     if arg_disable_mutable_api:
         disable_mutable_api = True
     else:
@@ -306,6 +309,7 @@ def main() -> None:
         latest_core_version,
         setting_loader,
         preset_manager,
+        use_dict,
         cancellable_engine,
         root_dir,
         cors_policy_mode,

--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -11,6 +11,7 @@ from voicevox_engine.core.core_initializer import initialize_cores
 from voicevox_engine.preset.PresetManager import PresetManager
 from voicevox_engine.setting.SettingLoader import SettingHandler
 from voicevox_engine.tts_pipeline.tts_engine import make_tts_engines_from_cores
+from voicevox_engine.user_dict.user_dict import UserDictionary
 from voicevox_engine.utility.core_version_utility import get_latest_version
 
 
@@ -26,6 +27,7 @@ def app_params(tmp_path: Path) -> dict[str, Any]:
     preset_path = tmp_path / "presets.yaml"
     shutil.copyfile(original_preset_path, preset_path)
     preset_manager = PresetManager(preset_path)
+    user_dict = UserDictionary()
 
     return {
         "tts_engines": tts_engines,
@@ -33,6 +35,7 @@ def app_params(tmp_path: Path) -> dict[str, Any]:
         "latest_core_version": latest_core_version,
         "setting_loader": setting_loader,
         "preset_manager": preset_manager,
+        "user_dict": user_dict,
     }
 
 

--- a/voicevox_engine/app/application.py
+++ b/voicevox_engine/app/application.py
@@ -26,7 +26,7 @@ from voicevox_engine.preset.PresetManager import PresetManager
 from voicevox_engine.setting.Setting import CorsPolicyMode
 from voicevox_engine.setting.SettingLoader import SettingHandler
 from voicevox_engine.tts_pipeline.tts_engine import TTSEngine
-from voicevox_engine.user_dict.user_dict import update_dict
+from voicevox_engine.user_dict.user_dict import UserDictionary
 from voicevox_engine.utility.path_utility import engine_root, get_save_dir
 
 
@@ -36,6 +36,7 @@ def generate_app(
     latest_core_version: str,
     setting_loader: SettingHandler,
     preset_manager: PresetManager,
+    user_dict: UserDictionary,
     cancellable_engine: CancellableEngine | None = None,
     root_dir: Path | None = None,
     cors_policy_mode: CorsPolicyMode = CorsPolicyMode.localapps,
@@ -48,7 +49,7 @@ def generate_app(
 
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncIterator[None]:
-        update_dict()
+        user_dict.update_dict()
         yield
 
     app = FastAPI(
@@ -102,7 +103,7 @@ def generate_app(
         app.include_router(
             generate_library_router(engine_manifest_data, library_manager)
         )
-    app.include_router(generate_user_dict_router())
+    app.include_router(generate_user_dict_router(user_dict))
     app.include_router(
         generate_engine_info_router(get_core, cores, engine_manifest_data)
     )

--- a/voicevox_engine/app/routers/user_dict.py
+++ b/voicevox_engine/app/routers/user_dict.py
@@ -10,19 +10,12 @@ from pydantic import ValidationError
 
 from voicevox_engine.model import UserDictWord, WordTypes
 from voicevox_engine.user_dict.part_of_speech_data import MAX_PRIORITY, MIN_PRIORITY
-from voicevox_engine.user_dict.user_dict import (
-    UserDictInputError,
-    apply_word,
-    delete_word,
-    import_user_dict,
-    read_dict,
-    rewrite_word,
-)
+from voicevox_engine.user_dict.user_dict import UserDictInputError, UserDictionary
 
 from ..dependencies import check_disabled_mutable_api
 
 
-def generate_user_dict_router() -> APIRouter:
+def generate_user_dict_router(user_dict: UserDictionary) -> APIRouter:
     """ユーザー辞書 API Router を生成する"""
     router = APIRouter()
 
@@ -38,7 +31,7 @@ def generate_user_dict_router() -> APIRouter:
         単語の表層形(surface)は正規化済みの物を返します。
         """
         try:
-            return read_dict()
+            return user_dict.read_dict()
         except UserDictInputError as err:
             raise HTTPException(status_code=422, detail=str(err))
         except Exception:
@@ -78,7 +71,7 @@ def generate_user_dict_router() -> APIRouter:
         ユーザー辞書に言葉を追加します。
         """
         try:
-            word_uuid = apply_word(
+            word_uuid = user_dict.apply_word(
                 surface=surface,
                 pronunciation=pronunciation,
                 accent_type=accent_type,
@@ -130,7 +123,7 @@ def generate_user_dict_router() -> APIRouter:
         ユーザー辞書に登録されている言葉を更新します。
         """
         try:
-            rewrite_word(
+            user_dict.rewrite_word(
                 surface=surface,
                 pronunciation=pronunciation,
                 accent_type=accent_type,
@@ -164,7 +157,7 @@ def generate_user_dict_router() -> APIRouter:
         ユーザー辞書に登録されている言葉を削除します。
         """
         try:
-            delete_word(word_uuid=word_uuid)
+            user_dict.delete_word(word_uuid=word_uuid)
             return Response(status_code=204)
         except UserDictInputError as err:
             raise HTTPException(status_code=422, detail=str(err))
@@ -193,7 +186,7 @@ def generate_user_dict_router() -> APIRouter:
         他のユーザー辞書をインポートします。
         """
         try:
-            import_user_dict(dict_data=import_dict_data, override=override)
+            user_dict.import_user_dict(dict_data=import_dict_data, override=override)
             return Response(status_code=204)
         except UserDictInputError as err:
             raise HTTPException(status_code=422, detail=str(err))


### PR DESCRIPTION
## 内容
概要: `UserDictionary` クラスを追加してリファクタリング  

VOICEVOX ENGINE はユーザー辞書の実装として `read_dict()` などの個別関数を多数定義し、それらを直接呼び出している。  
これら関数が内部でアクセスする辞書は辞書パス引数によって設定されている。またデフォルトの辞書パスはハードコードしたうえでこのパス引数のデフォルト引数として渡されている。  

その結果、現在のユーザー辞書 API は DI 不可能な構造となっている。これによりユーザー辞書 E2E テストの実装がブロックされている。  
プリセットやマニフェストの実装はクラスベースとなっており、DI 可能な設計となっている。これを踏襲すれば DI 可能なユーザー辞書になる。  

このような背景から、ユーザー辞書機能の `UserDictionary` クラス化によるリファクタリングを提案します。  

## 関連 Issue
無し

## Review 向け補足情報
`UserDictionary` クラス新設が主です。  
`UserDictionary` は既存の `read_dict()` 等をラップし、従来関数呼び出しだった箇所をメソッド呼び出しで置き換えています。  
既存の `read_dict()` 等はローカル関数になったため、`_` prefix によるローカル化をしています。またこれらのデフォルト引数を廃止可能になったため、デフォルト引数は一括削除しています。  