### PR TITLE
追加: エンジン情報取得 API にドキュメントを追加

### DIFF
--- a/test/e2e/__snapshots__/test_openapi/test_OpenAPIの形が変わっていないことを確認.json
+++ b/test/e2e/__snapshots__/test_openapi/test_OpenAPIの形が変わっていないことを確認.json
@@ -1498,6 +1498,7 @@
     },
     "/core_versions": {
       "get": {
+        "description": "利用可能なコアのバージョン一覧を取得します。",
         "operationId": "core_versions_core_versions_get",
         "responses": {
           "200": {
@@ -1587,6 +1588,7 @@
     },
     "/engine_manifest": {
       "get": {
+        "description": "エンジンマニフェストを取得します。",
         "operationId": "engine_manifest_engine_manifest_get",
         "responses": {
           "200": {
@@ -2632,6 +2634,7 @@
     },
     "/supported_devices": {
       "get": {
+        "description": "対応デバイスの一覧を取得します。",
         "operationId": "supported_devices_supported_devices_get",
         "parameters": [
           {
@@ -3229,6 +3232,7 @@
     },
     "/version": {
       "get": {
+        "description": "エンジンのバージョンを取得します。",
         "operationId": "version_version_get",
         "responses": {
           "200": {

--- a/voicevox_engine/app/routers/engine_info.py
+++ b/voicevox_engine/app/routers/engine_info.py
@@ -21,10 +21,12 @@ def generate_engine_info_router(
 
     @router.get("/version", tags=["その他"])
     async def version() -> str:
+        """エンジンのバージョンを取得します。"""
         return __version__
 
     @router.get("/core_versions", response_model=list[str], tags=["その他"])
     async def core_versions() -> Response:
+        """利用可能なコアのバージョン一覧を取得します。"""
         return Response(
             content=json.dumps(list(cores.keys())),
             media_type="application/json",
@@ -33,9 +35,8 @@ def generate_engine_info_router(
     @router.get(
         "/supported_devices", response_model=SupportedDevicesInfo, tags=["その他"]
     )
-    def supported_devices(
-        core_version: str | None = None,
-    ) -> Response:
+    def supported_devices(core_version: str | None = None) -> Response:
+        """対応デバイスの一覧を取得します。"""
         supported_devices = get_core(core_version).supported_devices
         if supported_devices is None:
             raise HTTPException(status_code=422, detail="非対応の機能です。")
@@ -46,6 +47,7 @@ def generate_engine_info_router(
 
     @router.get("/engine_manifest", response_model=EngineManifest, tags=["その他"])
     async def engine_manifest() -> EngineManifest:
+        """エンジンマニフェストを取得します。"""
         return engine_manifest_data
 
     return router


### PR DESCRIPTION
## 内容
概要: エンジン情報取得 API にドキュメントを追加

`engine_info` ルーターで定義されるエンジン情報取得 APIs には docstring が定義されていない。ゆえに API docs 生成でも API 詳細が生成されていない。  

![image](https://github.com/VOICEVOX/voicevox_engine/assets/19833110/a10dddfd-e236-48ab-aa96-b08f9d7851ff)

よって、docstring 追加によるエンジン情報取得 API へのドキュメント追加を提案します。  

## 関連 Issue
無し