### PR TITLE
修正: 対応デバイスモックの属性不足を修正

### DIFF
--- a/test/e2e/single_api/__snapshots__/test_supported_devices/test_get_supported_devices_200.json
+++ b/test/e2e/single_api/__snapshots__/test_supported_devices/test_get_supported_devices_200.json
@@ -1,4 +1,5 @@
 {
   "cpu": true,
-  "cuda": false
+  "cuda": false,
+  "dml": false
 }

--- a/test/tts_pipeline/test_tts_engine.py
+++ b/test/tts_pipeline/test_tts_engine.py
@@ -1,3 +1,4 @@
+import json
 from test.utility import pydantic_to_native_type, round_floats
 from unittest import TestCase
 from unittest.mock import Mock
@@ -97,7 +98,7 @@ class MockCore:
         return ""
 
     def supported_devices(self) -> str:
-        return ""
+        return json.dumps({"cpu": True, "cuda": False, "dml": False})
 
     def is_model_loaded(self, style_id: str) -> bool:
         return True

--- a/voicevox_engine/dev/core/mock.py
+++ b/voicevox_engine/dev/core/mock.py
@@ -229,12 +229,7 @@ class MockCoreWrapper(CoreWrapper):
         return np.array(result, dtype=np.float32)
 
     def supported_devices(self) -> str:
-        return json.dumps(
-            {
-                "cpu": True,
-                "cuda": False,
-            }
-        )
+        return json.dumps({"cpu": True, "cuda": False, "dml": False})
 
     def finalize(self) -> None:
         pass


### PR DESCRIPTION
## 内容
概要: 対応デバイスモックの属性不足を修正

コアの対応デバイス一覧である `SupportedDevicesInfo` は 3 属性全てが required である。  

https://github.com/VOICEVOX/voicevox_engine/blob/477cdb6a8b58bbcb648d98284b266830b824166d/voicevox_engine/model.py#L329-L336

このインスタンスはコア由来の `supported_devices` 文字列をパースして生成されている。ゆえに `supported_devices` 文字列は 3 属性の json 文字列となっていなければならない。  
しかし現状のモックは属性が欠けているケースがあり、不正なモックとなっている。  

このような背景から、対応デバイスモックの属性不足を修正することを提案します。  

## 関連 Issue
無し