### PR TITLE
整理: `response_model` を廃止

### DIFF
--- a/voicevox_engine/app/routers/library.py
+++ b/voicevox_engine/app/routers/library.py
@@ -23,7 +23,6 @@ def generate_library_router(
 
     @router.get(
         "/downloadable_libraries",
-        response_model=list[DownloadableLibraryInfo],
         response_description="ダウンロード可能な音声ライブラリの情報リスト",
         tags=["音声ライブラリ管理"],
     )
@@ -37,7 +36,6 @@ def generate_library_router(
 
     @router.get(
         "/installed_libraries",
-        response_model=dict[str, InstalledLibraryInfo],
         response_description="インストールした音声ライブラリの情報",
         tags=["音声ライブラリ管理"],
     )

--- a/voicevox_engine/app/routers/morphing.py
+++ b/voicevox_engine/app/routers/morphing.py
@@ -40,7 +40,6 @@ def generate_morphing_router(
 
     @router.post(
         "/morphable_targets",
-        response_model=list[dict[str, MorphableTargetInfo]],
         tags=["音声合成"],
         summary="指定したスタイルに対してエンジン内の話者がモーフィングが可能か判定する",
     )

--- a/voicevox_engine/app/routers/preset.py
+++ b/voicevox_engine/app/routers/preset.py
@@ -17,7 +17,6 @@ def generate_preset_router(preset_manager: PresetManager) -> APIRouter:
 
     @router.get(
         "/presets",
-        response_model=list[Preset],
         response_description="プリセットのリスト",
         tags=["その他"],
     )
@@ -35,7 +34,6 @@ def generate_preset_router(preset_manager: PresetManager) -> APIRouter:
 
     @router.post(
         "/add_preset",
-        response_model=int,
         response_description="追加したプリセットのプリセットID",
         tags=["その他"],
         dependencies=[Depends(check_disabled_mutable_api)],
@@ -61,7 +59,6 @@ def generate_preset_router(preset_manager: PresetManager) -> APIRouter:
 
     @router.post(
         "/update_preset",
-        response_model=int,
         response_description="更新したプリセットのプリセットID",
         tags=["その他"],
         dependencies=[Depends(check_disabled_mutable_api)],

--- a/voicevox_engine/app/routers/speaker.py
+++ b/voicevox_engine/app/routers/speaker.py
@@ -26,14 +26,14 @@ def generate_speaker_router(
     """話者情報 API Router を生成する"""
     router = APIRouter()
 
-    @router.get("/speakers", response_model=list[Speaker], tags=["その他"])
+    @router.get("/speakers", tags=["その他"])
     def speakers(
         core_version: str | None = None,
     ) -> list[Speaker]:
         speakers = metas_store.load_combined_metas(get_core(core_version))
         return filter_speakers_and_styles(speakers, "speaker")
 
-    @router.get("/speaker_info", response_model=SpeakerInfo, tags=["その他"])
+    @router.get("/speaker_info", tags=["その他"])
     def speaker_info(
         speaker_uuid: str,
         core_version: str | None = None,
@@ -143,14 +143,14 @@ def generate_speaker_router(
         )
         return ret_data
 
-    @router.get("/singers", response_model=list[Speaker], tags=["その他"])
+    @router.get("/singers", tags=["その他"])
     def singers(
         core_version: str | None = None,
     ) -> list[Speaker]:
         singers = metas_store.load_combined_metas(get_core(core_version))
         return filter_speakers_and_styles(singers, "singer")
 
-    @router.get("/singer_info", response_model=SpeakerInfo, tags=["その他"])
+    @router.get("/singer_info", tags=["その他"])
     def singer_info(
         speaker_uuid: str,
         core_version: str | None = None,
@@ -184,7 +184,7 @@ def generate_speaker_router(
         core.initialize_style_id_synthesis(style_id, skip_reinit=skip_reinit)
         return Response(status_code=204)
 
-    @router.get("/is_initialized_speaker", response_model=bool, tags=["その他"])
+    @router.get("/is_initialized_speaker", tags=["その他"])
     def is_initialized_speaker(
         style_id: Annotated[StyleId, Query(alias="speaker")],
         core_version: str | None = None,

--- a/voicevox_engine/app/routers/tts_pipeline.py
+++ b/voicevox_engine/app/routers/tts_pipeline.py
@@ -42,7 +42,6 @@ def generate_tts_pipeline_router(
 
     @router.post(
         "/audio_query",
-        response_model=AudioQuery,
         tags=["クエリ作成"],
         summary="音声合成用のクエリを作成する",
     )
@@ -72,7 +71,6 @@ def generate_tts_pipeline_router(
 
     @router.post(
         "/audio_query_from_preset",
-        response_model=AudioQuery,
         tags=["クエリ作成"],
         summary="音声合成用のクエリをプリセットを用いて作成する",
     )
@@ -117,7 +115,6 @@ def generate_tts_pipeline_router(
 
     @router.post(
         "/accent_phrases",
-        response_model=list[AccentPhrase],
         tags=["クエリ編集"],
         summary="テキストからアクセント句を得る",
         responses={
@@ -155,7 +152,6 @@ def generate_tts_pipeline_router(
 
     @router.post(
         "/mora_data",
-        response_model=list[AccentPhrase],
         tags=["クエリ編集"],
         summary="アクセント句から音高・音素長を得る",
     )
@@ -169,7 +165,6 @@ def generate_tts_pipeline_router(
 
     @router.post(
         "/mora_length",
-        response_model=list[AccentPhrase],
         tags=["クエリ編集"],
         summary="アクセント句から音素長を得る",
     )
@@ -183,7 +178,6 @@ def generate_tts_pipeline_router(
 
     @router.post(
         "/mora_pitch",
-        response_model=list[AccentPhrase],
         tags=["クエリ編集"],
         summary="アクセント句から音高を得る",
     )
@@ -322,7 +316,6 @@ def generate_tts_pipeline_router(
 
     @router.post(
         "/sing_frame_audio_query",
-        response_model=FrameAudioQuery,
         tags=["クエリ作成"],
         summary="歌唱音声合成用のクエリを作成する",
     )
@@ -351,7 +344,6 @@ def generate_tts_pipeline_router(
 
     @router.post(
         "/sing_frame_volume",
-        response_model=list[float],
         tags=["クエリ編集"],
         summary="スコア・歌唱音声合成用のクエリからフレームごとの音量を得る",
     )
@@ -438,7 +430,6 @@ def generate_tts_pipeline_router(
 
     @router.post(
         "/validate_kana",
-        response_model=bool,
         tags=["その他"],
         summary="テキストがAquesTalk 風記法に従っているか判定する",
         responses={

--- a/voicevox_engine/app/routers/user_dict.py
+++ b/voicevox_engine/app/routers/user_dict.py
@@ -28,7 +28,6 @@ def generate_user_dict_router() -> APIRouter:
 
     @router.get(
         "/user_dict",
-        response_model=dict[str, UserDictWord],
         response_description="単語のUUIDとその詳細",
         tags=["ユーザー辞書"],
     )
@@ -49,7 +48,6 @@ def generate_user_dict_router() -> APIRouter:
 
     @router.post(
         "/user_dict_word",
-        response_model=str,
         tags=["ユーザー辞書"],
         dependencies=[Depends(check_disabled_mutable_api)],
     )
@@ -73,7 +71,7 @@ def generate_user_dict_router() -> APIRouter:
                 description="単語の優先度（0から10までの整数）。数字が大きいほど優先度が高くなる。1から9までの値を指定することを推奨",
             ),
         ] = None,
-    ) -> Response:
+    ) -> str:
         """
         ユーザー辞書に言葉を追加します。
         """
@@ -85,7 +83,7 @@ def generate_user_dict_router() -> APIRouter:
                 word_type=word_type,
                 priority=priority,
             )
-            return Response(content=word_uuid)
+            return word_uuid
         except ValidationError as e:
             raise HTTPException(
                 status_code=422, detail="パラメータに誤りがあります。\n" + str(e)


### PR DESCRIPTION
## 内容
概要: `response_model` を廃止してリファクタリング  

FastAPI は返り値のハンドリング（自動バリデーション、API docs生成など）のために返り値情報を必要とする。  
返り値情報は以下の2通りのいずれかで渡される：  

- path operation 関数の型
- API デコレータの `response_model` 引数

現在の VOICEVOX ENGINE は型情報の充実により全ての path operation 関数が型づけされており、前者により返り値情報が FastAPI で伝わっている。  
これと同時に、一部の API では `response_model` も定義している（歴史的経緯？）。  
二重管理はバグの温床であり、前者があれば後者は不要である。  

このような背景から、`response_model` の廃止によるリファクタリングを提案します。  

なお、他 PR との兼ね合いにより、`engine_info` モジュールのみ別 PR にて `response_model` を廃止します。  

## 関連 Issue
無し