### PR TITLE
整理: タグ付与をルーターに集約

### DIFF
--- a/voicevox_engine/app/routers/engine_info.py
+++ b/voicevox_engine/app/routers/engine_info.py
@@ -17,25 +17,21 @@ def generate_engine_info_router(
     engine_manifest_data: EngineManifest,
 ) -> APIRouter:
     """エンジン情報 API Router を生成する"""
-    router = APIRouter()
+    router = APIRouter(tags=["その他"])
 
-    @router.get("/version", tags=["その他"])
+    @router.get("/version")
     async def version() -> str:
         return __version__
 
-    @router.get("/core_versions", response_model=list[str], tags=["その他"])
+    @router.get("/core_versions", response_model=list[str])
     async def core_versions() -> Response:
         return Response(
             content=json.dumps(list(cores.keys())),
             media_type="application/json",
         )
 
-    @router.get(
-        "/supported_devices", response_model=SupportedDevicesInfo, tags=["その他"]
-    )
-    def supported_devices(
-        core_version: str | None = None,
-    ) -> Response:
+    @router.get("/supported_devices", response_model=SupportedDevicesInfo)
+    def supported_devices(core_version: str | None = None) -> Response:
         supported_devices = get_core(core_version).supported_devices
         if supported_devices is None:
             raise HTTPException(status_code=422, detail="非対応の機能です。")
@@ -44,7 +40,7 @@ def generate_engine_info_router(
             media_type="application/json",
         )
 
-    @router.get("/engine_manifest", response_model=EngineManifest, tags=["その他"])
+    @router.get("/engine_manifest", response_model=EngineManifest)
     async def engine_manifest() -> EngineManifest:
         return engine_manifest_data
 

--- a/voicevox_engine/app/routers/library.py
+++ b/voicevox_engine/app/routers/library.py
@@ -19,13 +19,12 @@ def generate_library_router(
     engine_manifest_data: EngineManifest, library_manager: LibraryManager
 ) -> APIRouter:
     """音声ライブラリ API Router を生成する"""
-    router = APIRouter()
+    router = APIRouter(tags=["音声ライブラリ管理"])
 
     @router.get(
         "/downloadable_libraries",
         response_model=list[DownloadableLibraryInfo],
         response_description="ダウンロード可能な音声ライブラリの情報リスト",
-        tags=["音声ライブラリ管理"],
     )
     def downloadable_libraries() -> list[DownloadableLibraryInfo]:
         """
@@ -39,7 +38,6 @@ def generate_library_router(
         "/installed_libraries",
         response_model=dict[str, InstalledLibraryInfo],
         response_description="インストールした音声ライブラリの情報",
-        tags=["音声ライブラリ管理"],
     )
     def installed_libraries() -> dict[str, InstalledLibraryInfo]:
         """
@@ -52,7 +50,6 @@ def generate_library_router(
     @router.post(
         "/install_library/{library_uuid}",
         status_code=204,
-        tags=["音声ライブラリ管理"],
         dependencies=[Depends(check_disabled_mutable_api)],
     )
     async def install_library(
@@ -75,7 +72,6 @@ def generate_library_router(
     @router.post(
         "/uninstall_library/{library_uuid}",
         status_code=204,
-        tags=["音声ライブラリ管理"],
         dependencies=[Depends(check_disabled_mutable_api)],
     )
     def uninstall_library(

--- a/voicevox_engine/app/routers/morphing.py
+++ b/voicevox_engine/app/routers/morphing.py
@@ -36,12 +36,11 @@ def generate_morphing_router(
     metas_store: MetasStore,
 ) -> APIRouter:
     """モーフィング API Router を生成する"""
-    router = APIRouter()
+    router = APIRouter(tags=["音声合成"])
 
     @router.post(
         "/morphable_targets",
         response_model=list[dict[str, MorphableTargetInfo]],
-        tags=["音声合成"],
         summary="指定したスタイルに対してエンジン内の話者がモーフィングが可能か判定する",
     )
     def morphable_targets(
@@ -81,7 +80,6 @@ def generate_morphing_router(
                 },
             }
         },
-        tags=["音声合成"],
         summary="2種類のスタイルでモーフィングした音声を合成する",
     )
     def _synthesis_morphing(

--- a/voicevox_engine/app/routers/preset.py
+++ b/voicevox_engine/app/routers/preset.py
@@ -13,13 +13,12 @@ from ..dependencies import check_disabled_mutable_api
 
 def generate_preset_router(preset_manager: PresetManager) -> APIRouter:
     """プリセット API Router を生成する"""
-    router = APIRouter()
+    router = APIRouter(tags=["その他"])
 
     @router.get(
         "/presets",
         response_model=list[Preset],
         response_description="プリセットのリスト",
-        tags=["その他"],
     )
     def get_presets() -> list[Preset]:
         """
@@ -37,7 +36,6 @@ def generate_preset_router(preset_manager: PresetManager) -> APIRouter:
         "/add_preset",
         response_model=int,
         response_description="追加したプリセットのプリセットID",
-        tags=["その他"],
         dependencies=[Depends(check_disabled_mutable_api)],
     )
     def add_preset(
@@ -63,7 +61,6 @@ def generate_preset_router(preset_manager: PresetManager) -> APIRouter:
         "/update_preset",
         response_model=int,
         response_description="更新したプリセットのプリセットID",
-        tags=["その他"],
         dependencies=[Depends(check_disabled_mutable_api)],
     )
     def update_preset(
@@ -88,7 +85,6 @@ def generate_preset_router(preset_manager: PresetManager) -> APIRouter:
     @router.post(
         "/delete_preset",
         status_code=204,
-        tags=["その他"],
         dependencies=[Depends(check_disabled_mutable_api)],
     )
     def delete_preset(

--- a/voicevox_engine/app/routers/setting.py
+++ b/voicevox_engine/app/routers/setting.py
@@ -24,9 +24,9 @@ def generate_setting_router(
     engine_manifest_data: EngineManifest,
 ) -> APIRouter:
     """設定 API Router を生成する"""
-    router = APIRouter()
+    router = APIRouter(tags=["設定"])
 
-    @router.get("/setting", response_class=Response, tags=["設定"])
+    @router.get("/setting", response_class=Response)
     def setting_get(request: Request) -> Response:
         """
         設定ページを返します。
@@ -53,7 +53,6 @@ def generate_setting_router(
     @router.post(
         "/setting",
         response_class=Response,
-        tags=["設定"],
         dependencies=[Depends(check_disabled_mutable_api)],
     )
     def setting_post(

--- a/voicevox_engine/app/routers/speaker.py
+++ b/voicevox_engine/app/routers/speaker.py
@@ -24,20 +24,15 @@ def generate_speaker_router(
     root_dir: Path,
 ) -> APIRouter:
     """話者情報 API Router を生成する"""
-    router = APIRouter()
+    router = APIRouter(tags=["その他"])
 
-    @router.get("/speakers", response_model=list[Speaker], tags=["その他"])
-    def speakers(
-        core_version: str | None = None,
-    ) -> list[Speaker]:
+    @router.get("/speakers", response_model=list[Speaker])
+    def speakers(core_version: str | None = None) -> list[Speaker]:
         speakers = metas_store.load_combined_metas(get_core(core_version))
         return filter_speakers_and_styles(speakers, "speaker")
 
-    @router.get("/speaker_info", response_model=SpeakerInfo, tags=["その他"])
-    def speaker_info(
-        speaker_uuid: str,
-        core_version: str | None = None,
-    ) -> SpeakerInfo:
+    @router.get("/speaker_info", response_model=SpeakerInfo)
+    def speaker_info(speaker_uuid: str, core_version: str | None = None) -> SpeakerInfo:
         """
         指定されたspeaker_uuidに関する情報をjson形式で返します。
         画像や音声はbase64エンコードされたものが返されます。
@@ -143,18 +138,13 @@ def generate_speaker_router(
         )
         return ret_data
 
-    @router.get("/singers", response_model=list[Speaker], tags=["その他"])
-    def singers(
-        core_version: str | None = None,
-    ) -> list[Speaker]:
+    @router.get("/singers", response_model=list[Speaker])
+    def singers(core_version: str | None = None) -> list[Speaker]:
         singers = metas_store.load_combined_metas(get_core(core_version))
         return filter_speakers_and_styles(singers, "singer")
 
-    @router.get("/singer_info", response_model=SpeakerInfo, tags=["その他"])
-    def singer_info(
-        speaker_uuid: str,
-        core_version: str | None = None,
-    ) -> SpeakerInfo:
+    @router.get("/singer_info", response_model=SpeakerInfo)
+    def singer_info(speaker_uuid: str, core_version: str | None = None) -> SpeakerInfo:
         """
         指定されたspeaker_uuidに関する情報をjson形式で返します。
         画像や音声はbase64エンコードされたものが返されます。
@@ -165,7 +155,7 @@ def generate_speaker_router(
             core_version=core_version,
         )
 
-    @router.post("/initialize_speaker", status_code=204, tags=["その他"])
+    @router.post("/initialize_speaker", status_code=204)
     def initialize_speaker(
         style_id: Annotated[StyleId, Query(alias="speaker")],
         skip_reinit: Annotated[
@@ -184,7 +174,7 @@ def generate_speaker_router(
         core.initialize_style_id_synthesis(style_id, skip_reinit=skip_reinit)
         return Response(status_code=204)
 
-    @router.get("/is_initialized_speaker", response_model=bool, tags=["その他"])
+    @router.get("/is_initialized_speaker", response_model=bool)
     def is_initialized_speaker(
         style_id: Annotated[StyleId, Query(alias="speaker")],
         core_version: str | None = None,

--- a/voicevox_engine/app/routers/user_dict.py
+++ b/voicevox_engine/app/routers/user_dict.py
@@ -24,13 +24,12 @@ from ..dependencies import check_disabled_mutable_api
 
 def generate_user_dict_router() -> APIRouter:
     """ユーザー辞書 API Router を生成する"""
-    router = APIRouter()
+    router = APIRouter(tags=["ユーザー辞書"])
 
     @router.get(
         "/user_dict",
         response_model=dict[str, UserDictWord],
         response_description="単語のUUIDとその詳細",
-        tags=["ユーザー辞書"],
     )
     def get_user_dict_words() -> dict[str, UserDictWord]:
         """
@@ -50,7 +49,6 @@ def generate_user_dict_router() -> APIRouter:
     @router.post(
         "/user_dict_word",
         response_model=str,
-        tags=["ユーザー辞書"],
         dependencies=[Depends(check_disabled_mutable_api)],
     )
     def add_user_dict_word(
@@ -101,7 +99,6 @@ def generate_user_dict_router() -> APIRouter:
     @router.put(
         "/user_dict_word/{word_uuid}",
         status_code=204,
-        tags=["ユーザー辞書"],
         dependencies=[Depends(check_disabled_mutable_api)],
     )
     def rewrite_user_dict_word(
@@ -154,7 +151,6 @@ def generate_user_dict_router() -> APIRouter:
     @router.delete(
         "/user_dict_word/{word_uuid}",
         status_code=204,
-        tags=["ユーザー辞書"],
         dependencies=[Depends(check_disabled_mutable_api)],
     )
     def delete_user_dict_word(
@@ -177,7 +173,6 @@ def generate_user_dict_router() -> APIRouter:
     @router.post(
         "/import_user_dict",
         status_code=204,
-        tags=["ユーザー辞書"],
         dependencies=[Depends(check_disabled_mutable_api)],
     )
     def import_user_dict_words(


### PR DESCRIPTION
## 内容
整理: タグ付与をルーターに集約してリファクタリング  

現在の VOICEVOX ENGINE は巨大 `generate_app()` が解体され、各 API が種別ごとのルーター内で定義されている。  
その結果、ルーター内の APIs が共通タグを持つケースが大半となった。  
`APIRouter` は `tags` 引数により傘下の APIs へ一括タグ付与ができ、これにより各 path operation デコレータが簡略化できる。  

このような背景から、タグ付与をルーターに集約してリファクタリングすることを提案します。  

## 関連 Issue
無し