### PR TITLE
修正: エンジン名のハードコードをマニフェスト参照に変更

### DIFF
--- a/test/e2e/__snapshots__/test_openapi/test_OpenAPIの形が変わっていないことを確認.json
+++ b/test/e2e/__snapshots__/test_openapi/test_OpenAPIの形が変わっていないことを確認.json
@@ -1103,8 +1103,8 @@
     }
   },
   "info": {
-    "description": "VOICEVOXの音声合成エンジンです。",
-    "title": "VOICEVOX Engine",
+    "description": "DUMMY の音声合成エンジンです。",
+    "title": "DUMMY Engine",
     "version": "latest"
   },
   "openapi": "3.1.0",

--- a/voicevox_engine/app/application.py
+++ b/voicevox_engine/app/application.py
@@ -46,14 +46,18 @@ def generate_app(
     if root_dir is None:
         root_dir = engine_root()
 
+    engine_manifest_data = EngineManifestLoader(
+        engine_root() / "engine_manifest.json", engine_root()
+    ).load_manifest()
+
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         update_dict()
         yield
 
     app = FastAPI(
-        title="VOICEVOX Engine",
-        description="VOICEVOXの音声合成エンジンです。",
+        title=engine_manifest_data.name,
+        description=f"{engine_manifest_data.brand_name} の音声合成エンジンです。",
         version=__version__,
         lifespan=lifespan,
     )
@@ -62,9 +66,6 @@ def generate_app(
     if disable_mutable_api:
         deprecated_mutable_api.enable = False
 
-    engine_manifest_data = EngineManifestLoader(
-        engine_root() / "engine_manifest.json", engine_root()
-    ).load_manifest()
     library_manager = LibraryManager(
         get_save_dir() / "installed_libraries",
         engine_manifest_data.supported_vvlib_manifest_version,


### PR DESCRIPTION
## 内容
概要: エンジン名のハードコードをマニフェスト参照に変更して修正

本レポジトリはマルチエンジンを前提とし、ブランド名 (`VOICEVOX`) 等をハードコードでなくマニフェスト参照により設定している。  
しかし `FastAPI` インスタンス生成部においてハードコードがなされている。  
これは本来マニフェストファイルを参照すべきである。  

このような背景から、エンジン名のハードコードをマニフェスト参照に変更する修正を提案します。  

## 関連 Issue
無し