### PR TITLE
整理: `EngineManifestLoader` を削除して簡略化

### DIFF
--- a/voicevox_engine/app/application.py
+++ b/voicevox_engine/app/application.py
@@ -19,7 +19,7 @@ from voicevox_engine.app.routers.tts_pipeline import generate_tts_pipeline_route
 from voicevox_engine.app.routers.user_dict import generate_user_dict_router
 from voicevox_engine.cancellable_engine import CancellableEngine
 from voicevox_engine.core.core_adapter import CoreAdapter
-from voicevox_engine.engine_manifest.EngineManifestLoader import EngineManifestLoader
+from voicevox_engine.engine_manifest.EngineManifestLoader import load_manifest
 from voicevox_engine.library_manager import LibraryManager
 from voicevox_engine.metas.MetasStore import MetasStore
 from voicevox_engine.preset.PresetManager import PresetManager
@@ -62,9 +62,7 @@ def generate_app(
     if disable_mutable_api:
         deprecated_mutable_api.enable = False
 
-    engine_manifest_data = EngineManifestLoader(
-        engine_root() / "engine_manifest.json", engine_root()
-    ).load_manifest()
+    engine_manifest_data = load_manifest(engine_root() / "engine_manifest.json")
     library_manager = LibraryManager(
         get_save_dir() / "installed_libraries",
         engine_manifest_data.supported_vvlib_manifest_version,

--- a/voicevox_engine/engine_manifest/EngineManifestLoader.py
+++ b/voicevox_engine/engine_manifest/EngineManifestLoader.py
@@ -5,47 +5,39 @@ from pathlib import Path
 from .EngineManifest import EngineManifest, LicenseInfo, UpdateInfo
 
 
-class EngineManifestLoader:
-    def __init__(self, manifest_path: Path, root_dir: Path):
-        self.manifest_path = manifest_path
-        self.root_dir = root_dir
+def load_manifest(manifest_path: Path) -> EngineManifest:
+    """エンジンマニフェストを指定ファイルから読み込む。"""
 
-    def load_manifest(self) -> EngineManifest:
-        manifest = json.loads(self.manifest_path.read_text(encoding="utf-8"))
-
-        return EngineManifest(
-            manifest_version=manifest["manifest_version"],
-            name=manifest["name"],
-            brand_name=manifest["brand_name"],
-            uuid=manifest["uuid"],
-            url=manifest["url"],
-            default_sampling_rate=manifest["default_sampling_rate"],
-            frame_rate=manifest["frame_rate"],
-            icon=b64encode((self.root_dir / manifest["icon"]).read_bytes()).decode(
-                "utf-8"
-            ),
-            terms_of_service=(self.root_dir / manifest["terms_of_service"]).read_text(
-                "utf-8"
-            ),
-            update_infos=[
-                UpdateInfo(**update_info)
-                for update_info in json.loads(
-                    (self.root_dir / manifest["update_infos"]).read_text("utf-8")
-                )
-            ],
-            # supported_vvlib_manifest_versionを持たないengine_manifestのために
-            # キーが存在しない場合はNoneを返すgetを使う
-            supported_vvlib_manifest_version=manifest.get(
-                "supported_vvlib_manifest_version"
-            ),
-            dependency_licenses=[
-                LicenseInfo(**license_info)
-                for license_info in json.loads(
-                    (self.root_dir / manifest["dependency_licenses"]).read_text("utf-8")
-                )
-            ],
-            supported_features={
-                key: item["value"]
-                for key, item in manifest["supported_features"].items()
-            },
-        )
+    root_dir = manifest_path.parent
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    return EngineManifest(
+        manifest_version=manifest["manifest_version"],
+        name=manifest["name"],
+        brand_name=manifest["brand_name"],
+        uuid=manifest["uuid"],
+        url=manifest["url"],
+        default_sampling_rate=manifest["default_sampling_rate"],
+        frame_rate=manifest["frame_rate"],
+        icon=b64encode((root_dir / manifest["icon"]).read_bytes()).decode("utf-8"),
+        terms_of_service=(root_dir / manifest["terms_of_service"]).read_text("utf-8"),
+        update_infos=[
+            UpdateInfo(**update_info)
+            for update_info in json.loads(
+                (root_dir / manifest["update_infos"]).read_text("utf-8")
+            )
+        ],
+        # supported_vvlib_manifest_versionを持たないengine_manifestのために
+        # キーが存在しない場合はNoneを返すgetを使う
+        supported_vvlib_manifest_version=manifest.get(
+            "supported_vvlib_manifest_version"
+        ),
+        dependency_licenses=[
+            LicenseInfo(**license_info)
+            for license_info in json.loads(
+                (root_dir / manifest["dependency_licenses"]).read_text("utf-8")
+            )
+        ],
+        supported_features={
+            key: item["value"] for key, item in manifest["supported_features"].items()
+        },
+    )


### PR DESCRIPTION
## 内容
概要: `EngineManifestLoader` を削除してリファクタリング  

`EngineManifestLoader` はエンジンマニフェストを取得するクラスである。  
そのインスタンスは生成直後に `.load_manifest()` メソッドが呼ばれており、実質的には関数として機能している。  
ゆえにクラスが過剰なラッパーとなっている。  

このような背景から、`EngineManifestLoader` の削除によるリファクタリングを提案します。  

## 関連 Issue
無し