### PR TITLE
整理: app 起動に依存せずユーザー辞書を立ち上げ

### DIFF
--- a/voicevox_engine/app/application.py
+++ b/voicevox_engine/app/application.py
@@ -1,5 +1,3 @@
-from collections.abc import AsyncIterator
-from contextlib import asynccontextmanager
 from pathlib import Path
 
 from fastapi import FastAPI, HTTPException
@@ -46,16 +44,12 @@ def generate_app(
     if root_dir is None:
         root_dir = engine_root()
 
-    @asynccontextmanager
-    async def lifespan(app: FastAPI) -> AsyncIterator[None]:
-        update_dict()
-        yield
+    update_dict()
 
     app = FastAPI(
         title="VOICEVOX Engine",
         description="VOICEVOXの音声合成エンジンです。",
         version=__version__,
-        lifespan=lifespan,
     )
     app = configure_middlewares(app, cors_policy_mode, allow_origin)
 


### PR DESCRIPTION
## 内容
概要: app 起動に依存せずユーザー辞書を立ち上げるようリファクタリング  

現在の VOICEVOX ENGINE はユーザー辞書の初期化を FastAPI app の立ち上げ hook (`lifespan`) 内でおこなっており、そのために hook 用の `lifespan` 関数を定義している。  
立ち上げ hook は uvicorn でのサーバー起動時に動く（と思われる）が、ユーザー辞書初期化はそれより前におこなわれても問題はない。  
ゆえに必要のない hook 待機のためにコードが複雑化しているといえる。  
app インスタンス生成前に独立してユーザー辞書初期化をおこなえば、この hook 用コードを削除できる。  

このような背景から、app 起動に依存せずユーザー辞書を立ち上げるリファクタリングを提案します。  

## 関連 Issue
無し