### PR TITLE
整理: `root_dir` デフォルト引数を指定

### DIFF
--- a/voicevox_engine/app/application.py
+++ b/voicevox_engine/app/application.py
@@ -37,14 +37,12 @@ def generate_app(
     setting_loader: SettingHandler,
     preset_manager: PresetManager,
     cancellable_engine: CancellableEngine | None = None,
-    root_dir: Path | None = None,
+    root_dir: Path = engine_root(),
     cors_policy_mode: CorsPolicyMode = CorsPolicyMode.localapps,
     allow_origin: list[str] | None = None,
     disable_mutable_api: bool = False,
 ) -> FastAPI:
     """ASGI 'application' 仕様に準拠した VOICEVOX ENGINE アプリケーションインスタンスを生成する。"""
-    if root_dir is None:
-        root_dir = engine_root()
 
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncIterator[None]:

--- a/voicevox_engine/app/application.py
+++ b/voicevox_engine/app/application.py
@@ -29,6 +29,8 @@ from voicevox_engine.tts_pipeline.tts_engine import TTSEngine
 from voicevox_engine.user_dict.user_dict import update_dict
 from voicevox_engine.utility.path_utility import engine_root, get_save_dir
 
+_DEFAULT_ROOT_DIR = engine_root()
+
 
 def generate_app(
     tts_engines: dict[str, TTSEngine],
@@ -37,7 +39,7 @@ def generate_app(
     setting_loader: SettingHandler,
     preset_manager: PresetManager,
     cancellable_engine: CancellableEngine | None = None,
-    root_dir: Path = engine_root(),
+    root_dir: Path = _DEFAULT_ROOT_DIR,
     cors_policy_mode: CorsPolicyMode = CorsPolicyMode.localapps,
     allow_origin: list[str] | None = None,
     disable_mutable_api: bool = False,


### PR DESCRIPTION
## 内容
概要: `root_dir` デフォルト引数を指定してリファクタリング  

`generate_app()` の `root_dir` 引数はデフォルトが `None` であり、`None` 時に `engine_root()` を代入している。  
デフォルト引数を用いれば None チェックを削除してコードを簡略化できる。  
`engine_root()` のデフォルト引数代入はリンターに弾かれるが、モジュールローカル定数として用意すれば問題ない。  

このような背景から、`root_dir` デフォルト引数の指定によるリファクタリングを提案します。  

## 関連 Issue
無し