### PR TITLE
修正: `POST /setting` レスポンススキーマを 200 から 204 へ変更

### DIFF
--- a/test/e2e/__snapshots__/test_openapi/test_OpenAPIの形が変わっていないことを確認.json
+++ b/test/e2e/__snapshots__/test_openapi/test_OpenAPIの形が変わっていないことを確認.json
@@ -2287,7 +2287,7 @@
           "required": true
         },
         "responses": {
-          "200": {
+          "204": {
             "description": "Successful Response"
           },
           "422": {

--- a/voicevox_engine/app/routers/setting.py
+++ b/voicevox_engine/app/routers/setting.py
@@ -71,6 +71,4 @@ def generate_setting_router(
         # 更新した設定へ上書き
         setting_loader.save(settings)
 
-        return
-
     return router

--- a/voicevox_engine/app/routers/setting.py
+++ b/voicevox_engine/app/routers/setting.py
@@ -52,14 +52,14 @@ def generate_setting_router(
 
     @router.post(
         "/setting",
-        response_class=Response,
+        status_code=204,
         tags=["設定"],
         dependencies=[Depends(check_disabled_mutable_api)],
     )
     def setting_post(
         cors_policy_mode: Annotated[CorsPolicyMode, Form()],
         allow_origin: Annotated[str | None, Form()] = None,
-    ) -> Response:
+    ) -> None:
         """
         設定を更新します。
         """
@@ -71,6 +71,6 @@ def generate_setting_router(
         # 更新した設定へ上書き
         setting_loader.save(settings)
 
-        return Response(status_code=204)
+        return
 
     return router


### PR DESCRIPTION
## 内容
概要: `POST /setting` レスポンススキーマを 200 から 204 へ変更して修正  

`POST /setting` は設定変更 API であり、success 時は常に `204 No Content` を返す。ゆえにスキーマとしても Response は `204` であるべきである。  
しかし path operation デコレータで `status_code` を指定し忘れておりスキーマ上は `200` となっている。これはバグである。  

このような背景から、`POST /setting` レスポンススキーマを 200 から 204 へ変更して修正することを提案します。  

## 関連 Issue
無し