### PR TITLE
整理: FastAPI `Path` エイリアスを削除

### DIFF
--- a/voicevox_engine/app/routers/library.py
+++ b/voicevox_engine/app/routers/library.py
@@ -4,9 +4,7 @@ import asyncio
 from io import BytesIO
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException
-from fastapi import Path as FAPath
-from fastapi import Request, Response
+from fastapi import APIRouter, Depends, HTTPException, Path, Request, Response
 
 from voicevox_engine.engine_manifest.EngineManifest import EngineManifest
 from voicevox_engine.library_manager import LibraryManager
@@ -56,7 +54,7 @@ def generate_library_router(
         dependencies=[Depends(check_disabled_mutable_api)],
     )
     async def install_library(
-        library_uuid: Annotated[str, FAPath(description="音声ライブラリのID")],
+        library_uuid: Annotated[str, Path(description="音声ライブラリのID")],
         request: Request,
     ) -> Response:
         """
@@ -79,7 +77,7 @@ def generate_library_router(
         dependencies=[Depends(check_disabled_mutable_api)],
     )
     def uninstall_library(
-        library_uuid: Annotated[str, FAPath(description="音声ライブラリのID")]
+        library_uuid: Annotated[str, Path(description="音声ライブラリのID")]
     ) -> Response:
         """
         音声ライブラリをアンインストールします。

--- a/voicevox_engine/app/routers/user_dict.py
+++ b/voicevox_engine/app/routers/user_dict.py
@@ -3,9 +3,7 @@
 import traceback
 from typing import Annotated
 
-from fastapi import APIRouter, Body, Depends, HTTPException
-from fastapi import Path as FAPath
-from fastapi import Query, Response
+from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query, Response
 from pydantic import ValidationError
 
 from voicevox_engine.model import UserDictWord, WordTypes
@@ -110,7 +108,7 @@ def generate_user_dict_router() -> APIRouter:
         accent_type: Annotated[
             int, Query(description="アクセント型（音が下がる場所を指す）")
         ],
-        word_uuid: Annotated[str, FAPath(description="更新する言葉のUUID")],
+        word_uuid: Annotated[str, Path(description="更新する言葉のUUID")],
         word_type: Annotated[
             WordTypes | None,
             Query(
@@ -158,7 +156,7 @@ def generate_user_dict_router() -> APIRouter:
         dependencies=[Depends(check_disabled_mutable_api)],
     )
     def delete_user_dict_word(
-        word_uuid: Annotated[str, FAPath(description="削除する言葉のUUID")]
+        word_uuid: Annotated[str, Path(description="削除する言葉のUUID")]
     ) -> Response:
         """
         ユーザー辞書に登録されている言葉を削除します。


### PR DESCRIPTION
## 内容
概要: FastAPI `Path` エイリアスを削除してリファクタリング  

FastAPI `Path` クラスは `generate_app()` が `pathlib.Path` を利用していた関係で `FAPath` エイリアスとして利用されていた。  
`generate_app()` 分割により router 側では `pathlib.Path` が不要になったため、エイリアスを解除可能になった。  

このような背景から、FastAPI `Path` エイリアスの削除によるリファクタリングを提案します。  

## 関連 Issue
無し