### PR TITLE
整理: `UserDictionary` メソッドへ関数を移植

### DIFF
--- a/voicevox_engine/user_dict/user_dict.py
+++ b/voicevox_engine/user_dict/user_dict.py
@@ -240,63 +240,6 @@ def _create_word(
     )
 
 
-def _rewrite_word(
-    word_uuid: str,
-    surface: str,
-    pronunciation: str,
-    accent_type: int,
-    word_type: WordTypes | None,
-    priority: int | None,
-    default_dict_path: Path,
-    user_dict_path: Path,
-    compiled_dict_path: Path,
-) -> None:
-    """
-    既存単語の上書き更新
-    Parameters
-    ----------
-    word_uuid : str
-        単語UUID
-    surface : str
-        単語情報
-    pronunciation : str
-        単語情報
-    accent_type : int
-        単語情報
-    word_type : WordTypes | None
-        品詞
-    priority : int | None
-        優先度
-    default_dict_path : Path
-        デフォルト辞書ファイルのパス
-    user_dict_path : Path
-        ユーザー辞書ファイルのパス
-    compiled_dict_path : Path
-        コンパイル済み辞書ファイルのパス
-    """
-    word = _create_word(
-        surface=surface,
-        pronunciation=pronunciation,
-        accent_type=accent_type,
-        word_type=word_type,
-        priority=priority,
-    )
-
-    # 既存単語の上書きによる辞書データの更新
-    user_dict = _read_dict(user_dict_path=user_dict_path)
-    if word_uuid not in user_dict:
-        raise UserDictInputError("UUIDに該当するワードが見つかりませんでした")
-    user_dict[word_uuid] = word
-
-    # 更新された辞書データの保存と適用
-    _write_to_json(user_dict, user_dict_path)
-    _update_dict(
-        default_dict_path=default_dict_path,
-        user_dict_path=user_dict_path,
-        compiled_dict_path=compiled_dict_path,
-    )
-
-
 def _delete_word(
     word_uuid: str,
     default_dict_path: Path,
@@ -548,13 +491,23 @@ class UserDictionary:
         priority : int | None
             優先度
         """
-        _rewrite_word(
-            word_uuid=word_uuid,
+        word = _create_word(
             surface=surface,
             pronunciation=pronunciation,
             accent_type=accent_type,
             word_type=word_type,
             priority=priority,
+        )
+
+        # 既存単語の上書きによる辞書データの更新
+        user_dict = _read_dict(user_dict_path=self._user_dict_path)
+        if word_uuid not in user_dict:
+            raise UserDictInputError("UUIDに該当するワードが見つかりませんでした")
+        user_dict[word_uuid] = word
+
+        # 更新された辞書データの保存と適用
+        _write_to_json(user_dict, self._user_dict_path)
+        _update_dict(
             default_dict_path=self._default_dict_path,
             user_dict_path=self._user_dict_path,
             compiled_dict_path=self._compiled_dict_path,

--- a/voicevox_engine/user_dict/user_dict.py
+++ b/voicevox_engine/user_dict/user_dict.py
@@ -240,40 +240,6 @@ def _create_word(
     )
 
 
-def _delete_word(
-    word_uuid: str,
-    default_dict_path: Path,
-    user_dict_path: Path,
-    compiled_dict_path: Path,
-) -> None:
-    """
-    単語の削除
-    Parameters
-    ----------
-    word_uuid : str
-        単語UUID
-    default_dict_path : Path
-        デフォルト辞書ファイルのパス
-    user_dict_path : Path
-        ユーザー辞書ファイルのパス
-    compiled_dict_path : Path
-        コンパイル済み辞書ファイルのパス
-    """
-    # 既存単語の削除による辞書データの更新
-    user_dict = _read_dict(user_dict_path=user_dict_path)
-    if word_uuid not in user_dict:
-        raise UserDictInputError("IDに該当するワードが見つかりませんでした")
-    del user_dict[word_uuid]
-
-    # 更新された辞書データの保存と適用
-    _write_to_json(user_dict, user_dict_path)
-    _update_dict(
-        default_dict_path=default_dict_path,
-        user_dict_path=user_dict_path,
-        compiled_dict_path=compiled_dict_path,
-    )
-
-
 def _import_user_dict(
     dict_data: dict[str, UserDictWord],
     override: bool,
@@ -515,8 +481,15 @@ class UserDictionary:
 
     def delete_word(self, word_uuid: str) -> None:
         """単語UUIDで指定された単語を削除する。"""
-        _delete_word(
-            word_uuid=word_uuid,
+        # 既存単語の削除による辞書データの更新
+        user_dict = _read_dict(user_dict_path=self._user_dict_path)
+        if word_uuid not in user_dict:
+            raise UserDictInputError("IDに該当するワードが見つかりませんでした")
+        del user_dict[word_uuid]
+
+        # 更新された辞書データの保存と適用
+        _write_to_json(user_dict, self._user_dict_path)
+        _update_dict(
             default_dict_path=self._default_dict_path,
             user_dict_path=self._user_dict_path,
             compiled_dict_path=self._compiled_dict_path,

--- a/voicevox_engine/user_dict/user_dict.py
+++ b/voicevox_engine/user_dict/user_dict.py
@@ -240,64 +240,6 @@ def _create_word(
     )
 
 
-def _apply_word(
-    surface: str,
-    pronunciation: str,
-    accent_type: int,
-    word_type: WordTypes | None,
-    priority: int | None,
-    default_dict_path: Path,
-    user_dict_path: Path,
-    compiled_dict_path: Path,
-) -> str:
-    """
-    新規単語の追加
-    Parameters
-    ----------
-    surface : str
-        単語情報
-    pronunciation : str
-        単語情報
-    accent_type : int
-        単語情報
-    word_type : WordTypes | None
-        品詞
-    priority : int | None
-        優先度
-    default_dict_path: Path
-        デフォルト辞書ファイルのパス
-    user_dict_path : Path
-        ユーザー辞書ファイルのパス
-    compiled_dict_path : Path
-        コンパイル済み辞書ファイルのパス
-    Returns
-    -------
-    word_uuid : UserDictWord
-        追加された単語に発行されたUUID
-    """
-    # 新規単語の追加による辞書データの更新
-    word = _create_word(
-        surface=surface,
-        pronunciation=pronunciation,
-        accent_type=accent_type,
-        word_type=word_type,
-        priority=priority,
-    )
-    user_dict = _read_dict(user_dict_path=user_dict_path)
-    word_uuid = str(uuid4())
-    user_dict[word_uuid] = word
-
-    # 更新された辞書データの保存と適用
-    _write_to_json(user_dict, user_dict_path)
-    _update_dict(
-        default_dict_path=default_dict_path,
-        user_dict_path=user_dict_path,
-        compiled_dict_path=compiled_dict_path,
-    )
-
-    return word_uuid
-
-
 def _rewrite_word(
     word_uuid: str,
     surface: str,
@@ -558,16 +500,27 @@ class UserDictionary:
         word_uuid : UserDictWord
             追加された単語に発行されたUUID
         """
-        return _apply_word(
+        # 新規単語の追加による辞書データの更新
+        word = _create_word(
             surface=surface,
             pronunciation=pronunciation,
             accent_type=accent_type,
             word_type=word_type,
             priority=priority,
+        )
+        user_dict = _read_dict(user_dict_path=self._user_dict_path)
+        word_uuid = str(uuid4())
+        user_dict[word_uuid] = word
+
+        # 更新された辞書データの保存と適用
+        _write_to_json(user_dict, self._user_dict_path)
+        _update_dict(
             default_dict_path=self._default_dict_path,
             user_dict_path=self._user_dict_path,
             compiled_dict_path=self._compiled_dict_path,
         )
+
+        return word_uuid
 
     def rewrite_word(
         self,


### PR DESCRIPTION
## 内容
`UserDictionary` メソッドへ関数を移植してリファクタリング  

mutex デコレータ周りは動作が不安なため、本 PR では着手しない（辞書周り DI が実現 → API unit test を有効化 → 着手、の予定）

## 関連 Issue
successor of #1222