### PR TITLE
整理: `generate_app()` と独立してユーザー辞書を初期化

### DIFF
--- a/voicevox_engine/app/application.py
+++ b/voicevox_engine/app/application.py
@@ -47,8 +47,6 @@ def generate_app(
 
     engine_manifest_data = load_manifest(engine_root() / "engine_manifest.json")
 
-    user_dict.update_dict()
-
     app = FastAPI(
         title=engine_manifest_data.name,
         description=f"{engine_manifest_data.brand_name} の音声合成エンジンです。",

--- a/voicevox_engine/user_dict/user_dict.py
+++ b/voicevox_engine/user_dict/user_dict.py
@@ -301,6 +301,7 @@ class UserDictionary:
         self._default_dict_path = default_dict_path
         self._user_dict_path = user_dict_path
         self._compiled_dict_path = compiled_dict_path
+        self.update_dict()
 
     def update_dict(self) -> None:
         """辞書を更新する。"""


### PR DESCRIPTION
## 内容
概要: `generate_app()` と独立してユーザー辞書を初期化してリファクタリング  

現在のユーザー辞書は `generate_app()` 内において app と独立して初期化されている。  

https://github.com/VOICEVOX/voicevox_engine/blob/856a1171c9cb2d83a8a71c27e6ed36da31103f05/voicevox_engine/app/application.py#L50-L52

app と独立しているので、そもそも `generate_app()` 内で初期化する必然性がない。`UserDictionary` の `__init__()` で初期化する方が実装忘れのリスクを 0 にできる。  

このような背景から、`generate_app()` と独立してユーザー辞書を初期化するリファクタリングを提案します。  

## 関連 Issue
無し