### PR TITLE
整理: tts pipeline テストを pytest 化

### DIFF
--- a/test/tts_pipeline/test_connect_base64_waves.py
+++ b/test/tts_pipeline/test_connect_base64_waves.py
@@ -1,9 +1,9 @@
 import base64
 import io
-from unittest import TestCase
 
 import numpy as np
 import numpy.testing
+import pytest
 import soundfile
 from numpy.typing import NDArray
 from soxr import resample
@@ -54,81 +54,66 @@ def generate_sine_wave_base64(seconds: float, samplerate: int, frequency: float)
     return wave_base64
 
 
-class TestConnectBase64Waves(TestCase):
-    def test_connect(self) -> None:
-        samplerate = 1000
-        wave = generate_sine_wave_ndarray(
-            seconds=2, samplerate=samplerate, frequency=10
-        )
-        wave_base64 = encode_base64(encode_bytes(wave, samplerate=samplerate))
+def test_connect() -> None:
+    samplerate = 1000
+    wave = generate_sine_wave_ndarray(seconds=2, samplerate=samplerate, frequency=10)
+    wave_base64 = encode_base64(encode_bytes(wave, samplerate=samplerate))
 
-        wave_x2_ref = np.concatenate([wave, wave])
+    wave_x2_ref = np.concatenate([wave, wave])
 
-        wave_x2, _ = connect_base64_waves(waves=[wave_base64, wave_base64])
+    wave_x2, _ = connect_base64_waves(waves=[wave_base64, wave_base64])
 
-        self.assertEqual(wave_x2_ref.shape, wave_x2.shape)
+    assert wave_x2_ref.shape == wave_x2.shape
 
-        self.assertTrue((wave_x2_ref == wave_x2).all())
+    assert (wave_x2_ref == wave_x2).all()
 
-    def test_no_wave_error(self) -> None:
-        self.assertRaises(ConnectBase64WavesException, connect_base64_waves, waves=[])
 
-    def test_invalid_base64_error(self) -> None:
-        wave_1000hz = generate_sine_wave_base64(
-            seconds=2, samplerate=1000, frequency=10
-        )
-        wave_1000hz_broken = wave_1000hz[1:]  # remove head 1 char
+def test_no_wave_error() -> None:
+    with pytest.raises(ConnectBase64WavesException):
+        connect_base64_waves(waves=[])
 
-        self.assertRaises(
-            ConnectBase64WavesException,
-            connect_base64_waves,
-            waves=[
-                wave_1000hz_broken,
-            ],
-        )
 
-    def test_invalid_wave_file_error(self) -> None:
-        wave_1000hz = generate_sine_wave_bytes(seconds=2, samplerate=1000, frequency=10)
-        wave_1000hz_broken_bytes = wave_1000hz[1:]  # remove head 1 byte
-        wave_1000hz_broken = encode_base64(wave_1000hz_broken_bytes)
+def test_invalid_base64_error() -> None:
+    wave_1000hz = generate_sine_wave_base64(seconds=2, samplerate=1000, frequency=10)
+    wave_1000hz_broken = wave_1000hz[1:]  # remove head 1 char
 
-        self.assertRaises(
-            ConnectBase64WavesException,
-            connect_base64_waves,
-            waves=[
-                wave_1000hz_broken,
-            ],
-        )
+    with pytest.raises(ConnectBase64WavesException):
+        connect_base64_waves(waves=[wave_1000hz_broken])
 
-    def test_different_frequency(self) -> None:
-        wave_24000hz = generate_sine_wave_ndarray(
-            seconds=1, samplerate=24000, frequency=10
-        )
-        wave_1000hz = generate_sine_wave_ndarray(
-            seconds=2, samplerate=1000, frequency=10
-        )
-        wave_24000_base64 = encode_base64(encode_bytes(wave_24000hz, samplerate=24000))
-        wave_1000_base64 = encode_base64(encode_bytes(wave_1000hz, samplerate=1000))
 
-        wave_1000hz_to24000hz = resample(wave_1000hz, 1000, 24000)
-        wave_x2_ref = np.concatenate([wave_24000hz, wave_1000hz_to24000hz])
+def test_invalid_wave_file_error() -> None:
+    wave_1000hz = generate_sine_wave_bytes(seconds=2, samplerate=1000, frequency=10)
+    wave_1000hz_broken_bytes = wave_1000hz[1:]  # remove head 1 byte
+    wave_1000hz_broken = encode_base64(wave_1000hz_broken_bytes)
 
-        wave_x2, _ = connect_base64_waves(waves=[wave_24000_base64, wave_1000_base64])
+    with pytest.raises(ConnectBase64WavesException):
+        connect_base64_waves(waves=[wave_1000hz_broken])
 
-        self.assertEqual(wave_x2_ref.shape, wave_x2.shape)
-        numpy.testing.assert_array_almost_equal(wave_x2_ref, wave_x2)
 
-    def test_different_channels(self) -> None:
-        wave_1000hz = generate_sine_wave_ndarray(
-            seconds=2, samplerate=1000, frequency=10
-        )
-        wave_2ch_1000hz = np.array([wave_1000hz, wave_1000hz]).T
-        wave_1ch_base64 = encode_base64(encode_bytes(wave_1000hz, samplerate=1000))
-        wave_2ch_base64 = encode_base64(encode_bytes(wave_2ch_1000hz, samplerate=1000))
+def test_different_frequency() -> None:
+    wave_24000hz = generate_sine_wave_ndarray(seconds=1, samplerate=24000, frequency=10)
+    wave_1000hz = generate_sine_wave_ndarray(seconds=2, samplerate=1000, frequency=10)
+    wave_24000_base64 = encode_base64(encode_bytes(wave_24000hz, samplerate=24000))
+    wave_1000_base64 = encode_base64(encode_bytes(wave_1000hz, samplerate=1000))
 
-        wave_x2_ref = np.concatenate([wave_2ch_1000hz, wave_2ch_1000hz])
+    wave_1000hz_to24000hz = resample(wave_1000hz, 1000, 24000)
+    wave_x2_ref = np.concatenate([wave_24000hz, wave_1000hz_to24000hz])
 
-        wave_x2, _ = connect_base64_waves(waves=[wave_1ch_base64, wave_2ch_base64])
+    wave_x2, _ = connect_base64_waves(waves=[wave_24000_base64, wave_1000_base64])
 
-        self.assertEqual(wave_x2_ref.shape, wave_x2.shape)
-        self.assertTrue((wave_x2_ref == wave_x2).all())
+    assert wave_x2_ref.shape == wave_x2.shape
+    numpy.testing.assert_array_almost_equal(wave_x2_ref, wave_x2)
+
+
+def test_different_channels() -> None:
+    wave_1000hz = generate_sine_wave_ndarray(seconds=2, samplerate=1000, frequency=10)
+    wave_2ch_1000hz = np.array([wave_1000hz, wave_1000hz]).T
+    wave_1ch_base64 = encode_base64(encode_bytes(wave_1000hz, samplerate=1000))
+    wave_2ch_base64 = encode_base64(encode_bytes(wave_2ch_1000hz, samplerate=1000))
+
+    wave_x2_ref = np.concatenate([wave_2ch_1000hz, wave_2ch_1000hz])
+
+    wave_x2, _ = connect_base64_waves(waves=[wave_1ch_base64, wave_2ch_base64])
+
+    assert wave_x2_ref.shape == wave_x2.shape
+    assert (wave_x2_ref == wave_x2).all()

--- a/test/tts_pipeline/test_kana_converter.py
+++ b/test/tts_pipeline/test_kana_converter.py
@@ -10,528 +10,535 @@ def parse_kana(text: str) -> list[AccentPhrase]:
     return accent_phrases
 
 
-class TestParseKana(TestCase):
-    def test_phrase_length(self) -> None:
-        self.assertEqual(len(parse_kana("ア'/ア'")), 2)
-        self.assertEqual(len(parse_kana("ア'、ア'")), 2)
-        self.assertEqual(len(parse_kana("ア'/ア'/ア'/ア'/ア'")), 5)
-        self.assertEqual(len(parse_kana("ス'")), 1)
-        self.assertEqual(len(parse_kana("_ス'")), 1)
-        self.assertEqual(len(parse_kana("ギェ'")), 1)
-        self.assertEqual(len(parse_kana("ギェ'、ギェ'/ギェ'")), 3)
+def test_phrase_length() -> None:
+    assert len(parse_kana("ア'/ア'")) == 2
+    assert len(parse_kana("ア'、ア'")) == 2
+    assert len(parse_kana("ア'/ア'/ア'/ア'/ア'")) == 5
+    assert len(parse_kana("ス'")) == 1
+    assert len(parse_kana("_ス'")) == 1
+    assert len(parse_kana("ギェ'")) == 1
+    assert len(parse_kana("ギェ'、ギェ'/ギェ'")) == 3
 
-    def test_accent(self) -> None:
-        self.assertEqual(parse_kana("シャ'シシュシェショ")[0].accent, 1)
-        self.assertEqual(parse_kana("シャ'_シシュシェショ")[0].accent, 1)
-        self.assertEqual(parse_kana("シャシ'シュシェショ")[0].accent, 2)
-        self.assertEqual(parse_kana("シャ_シ'シュシェショ")[0].accent, 2)
-        self.assertEqual(parse_kana("シャシシュ'シェショ")[0].accent, 3)
-        self.assertEqual(parse_kana("シャ_シシュ'シェショ")[0].accent, 3)
-        self.assertEqual(parse_kana("シャシシュシェショ'")[0].accent, 5)
-        self.assertEqual(parse_kana("シャ_シシュシェショ'")[0].accent, 5)
 
-    def test_mora_length(self) -> None:
-        self.assertEqual(len(parse_kana("シャ'シシュシェショ")[0].moras), 5)
-        self.assertEqual(len(parse_kana("シャ'_シシュシェショ")[0].moras), 5)
-        self.assertEqual(len(parse_kana("シャシ'シュシェショ")[0].moras), 5)
-        self.assertEqual(len(parse_kana("シャ_シ'シュシェショ")[0].moras), 5)
-        self.assertEqual(len(parse_kana("シャシシュシェショ'")[0].moras), 5)
-        self.assertEqual(len(parse_kana("シャ_シシュシェショ'")[0].moras), 5)
+def test_accent() -> None:
+    assert parse_kana("シャ'シシュシェショ")[0].accent == 1
+    assert parse_kana("シャ'_シシュシェショ")[0].accent == 1
+    assert parse_kana("シャシ'シュシェショ")[0].accent == 2
+    assert parse_kana("シャ_シ'シュシェショ")[0].accent == 2
+    assert parse_kana("シャシシュ'シェショ")[0].accent == 3
+    assert parse_kana("シャ_シシュ'シェショ")[0].accent == 3
+    assert parse_kana("シャシシュシェショ'")[0].accent == 5
+    assert parse_kana("シャ_シシュシェショ'")[0].accent == 5
 
-    def test_pause(self) -> None:
-        self.assertIsNone(parse_kana("ア'/ア'")[0].pause_mora)
-        self.assertIsNone(parse_kana("ア'/ア'")[1].pause_mora)
-        self.assertIsNotNone(parse_kana("ア'、ア'")[0].pause_mora)
-        self.assertIsNone(parse_kana("ア'、ア'")[1].pause_mora)
 
-    def test_unvoice(self) -> None:
-        self.assertEqual(parse_kana("ス'")[0].moras[0].vowel, "u")
-        self.assertEqual(parse_kana("_ス'")[0].moras[0].vowel, "U")
+def test_mora_length() -> None:
+    assert len(parse_kana("シャ'シシュシェショ")[0].moras) == 5
+    assert len(parse_kana("シャ'_シシュシェショ")[0].moras) == 5
+    assert len(parse_kana("シャシ'シュシェショ")[0].moras) == 5
+    assert len(parse_kana("シャ_シ'シュシェショ")[0].moras) == 5
+    assert len(parse_kana("シャシシュシェショ'")[0].moras) == 5
+    assert len(parse_kana("シャ_シシュシェショ'")[0].moras) == 5
 
-    def test_roundtrip(self) -> None:
-        for text in [
-            "コンニチワ'",
-            "ワタシワ'/シャチョオデ'_ス",
-            "トテモ'、エラ'インデス",
-        ]:
-            self.assertEqual(create_kana(parse_kana(text)), text)
 
-        for text in ["ヲ'", "ェ'"]:
-            self.assertEqual(create_kana(parse_kana(text)), text)
+def test_pause() -> None:
+    assert parse_kana("ア'/ア'")[0].pause_mora is None
+    assert parse_kana("ア'/ア'")[1].pause_mora is None
+    assert parse_kana("ア'、ア'")[0].pause_mora is not None
+    assert parse_kana("ア'、ア'")[1].pause_mora is None
 
-    def _accent_phrase_marks_base(
-        self, text: str, expected_accent_phrases: list[AccentPhrase]
-    ) -> None:
-        accent_phrases = kana_converter.parse_kana(text)
-        self.assertEqual(expected_accent_phrases, accent_phrases)
 
-    def test_accent_phrase_marks(self) -> None:
-        def a_slash_a_accent_phrases() -> list[AccentPhrase]:
-            return [
-                AccentPhrase(
-                    moras=[
-                        Mora(
-                            text="ア",
-                            consonant=None,
-                            consonant_length=None,
-                            vowel="a",
-                            vowel_length=0.0,
-                            pitch=0.0,
-                        ),
-                    ],
-                    accent=1,
-                    pause_mora=None,
-                ),
-                AccentPhrase(
-                    moras=[
-                        Mora(
-                            text="ア",
-                            consonant=None,
-                            consonant_length=None,
-                            vowel="a",
-                            vowel_length=0.0,
-                            pitch=0.0,
-                        ),
-                    ],
-                    accent=1,
-                    pause_mora=None,
-                ),
-            ]
+def test_unvoice() -> None:
+    assert parse_kana("ス'")[0].moras[0].vowel == "u"
+    assert parse_kana("_ス'")[0].moras[0].vowel == "U"
 
-        expected_accent_phrases = a_slash_a_accent_phrases()
-        self._accent_phrase_marks_base(
-            text="ア'/ア'",
-            expected_accent_phrases=expected_accent_phrases,
-        )
 
-        def a_jp_comma_a_accent_phrases() -> list[AccentPhrase]:
-            return [
-                AccentPhrase(
-                    moras=[
-                        Mora(
-                            text="ア",
-                            consonant=None,
-                            consonant_length=None,
-                            vowel="a",
-                            vowel_length=0.0,
-                            pitch=0.0,
-                        ),
-                    ],
-                    accent=1,
-                    pause_mora=Mora(
-                        text="、",
+def test_roundtrip() -> None:
+    for text in [
+        "コンニチワ'",
+        "ワタシワ'/シャチョオデ'_ス",
+        "トテモ'、エラ'インデス",
+    ]:
+        assert create_kana(parse_kana(text)) == text
+
+    for text in ["ヲ'", "ェ'"]:
+        assert create_kana(parse_kana(text)) == text
+
+
+def _accent_phrase_marks_base(
+    text: str, expected_accent_phrases: list[AccentPhrase]
+) -> None:
+    accent_phrases = kana_converter.parse_kana(text)
+    assert expected_accent_phrases == accent_phrases
+
+
+def test_accent_phrase_marks() -> None:
+    def a_slash_a_accent_phrases() -> list[AccentPhrase]:
+        return [
+            AccentPhrase(
+                moras=[
+                    Mora(
+                        text="ア",
                         consonant=None,
                         consonant_length=None,
-                        vowel="pau",
+                        vowel="a",
                         vowel_length=0.0,
                         pitch=0.0,
                     ),
-                ),
-                AccentPhrase(
-                    moras=[
-                        Mora(
-                            text="ア",
-                            consonant=None,
-                            consonant_length=None,
-                            vowel="a",
-                            vowel_length=0.0,
-                            pitch=0.0,
-                        ),
-                    ],
-                    accent=1,
-                    pause_mora=None,
-                ),
-            ]
-
-        expected_accent_phrases = a_jp_comma_a_accent_phrases()
-        self._accent_phrase_marks_base(
-            text="ア'、ア'",
-            expected_accent_phrases=expected_accent_phrases,
-        )
-
-        def a_slash_a_slash_a_slash_a_slash_a_accent_phrases() -> list[AccentPhrase]:
-            return [
-                AccentPhrase(
-                    moras=[
-                        Mora(
-                            text="ア",
-                            consonant=None,
-                            consonant_length=None,
-                            vowel="a",
-                            vowel_length=0.0,
-                            pitch=0.0,
-                        ),
-                    ],
-                    accent=1,
-                    pause_mora=None,
-                ),
-                AccentPhrase(
-                    moras=[
-                        Mora(
-                            text="ア",
-                            consonant=None,
-                            consonant_length=None,
-                            vowel="a",
-                            vowel_length=0.0,
-                            pitch=0.0,
-                        ),
-                    ],
-                    accent=1,
-                    pause_mora=None,
-                ),
-                AccentPhrase(
-                    moras=[
-                        Mora(
-                            text="ア",
-                            consonant=None,
-                            consonant_length=None,
-                            vowel="a",
-                            vowel_length=0.0,
-                            pitch=0.0,
-                        ),
-                    ],
-                    accent=1,
-                    pause_mora=None,
-                ),
-                AccentPhrase(
-                    moras=[
-                        Mora(
-                            text="ア",
-                            consonant=None,
-                            consonant_length=None,
-                            vowel="a",
-                            vowel_length=0.0,
-                            pitch=0.0,
-                        ),
-                    ],
-                    accent=1,
-                    pause_mora=None,
-                ),
-                AccentPhrase(
-                    moras=[
-                        Mora(
-                            text="ア",
-                            consonant=None,
-                            consonant_length=None,
-                            vowel="a",
-                            vowel_length=0.0,
-                            pitch=0.0,
-                        ),
-                    ],
-                    accent=1,
-                    pause_mora=None,
-                ),
-            ]
-
-        expected_accent_phrases = a_slash_a_slash_a_slash_a_slash_a_accent_phrases()
-        self._accent_phrase_marks_base(
-            text="ア'/ア'/ア'/ア'/ア'",
-            expected_accent_phrases=expected_accent_phrases,
-        )
-
-        def su_accent_phrases() -> list[AccentPhrase]:
-            return [
-                AccentPhrase(
-                    moras=[
-                        Mora(
-                            text="ス",
-                            consonant="s",
-                            consonant_length=0.0,
-                            vowel="u",
-                            vowel_length=0.0,
-                            pitch=0.0,
-                        ),
-                    ],
-                    accent=1,
-                    pause_mora=None,
-                ),
-            ]
-
-        expected_accent_phrases = su_accent_phrases()
-        self._accent_phrase_marks_base(
-            text="ス'",
-            expected_accent_phrases=expected_accent_phrases,
-        )
-
-        def under_score_su_accent_phrases() -> list[AccentPhrase]:
-            return [
-                AccentPhrase(
-                    moras=[
-                        Mora(
-                            text="ス",
-                            consonant="s",
-                            consonant_length=0.0,
-                            vowel="U",
-                            vowel_length=0.0,
-                            pitch=0.0,
-                        ),
-                    ],
-                    accent=1,
-                    pause_mora=None,
-                ),
-            ]
-
-        expected_accent_phrases = under_score_su_accent_phrases()
-        self._accent_phrase_marks_base(
-            text="_ス'",
-            expected_accent_phrases=expected_accent_phrases,
-        )
-
-        def gye_accent_phrases() -> list[AccentPhrase]:
-            return [
-                AccentPhrase(
-                    moras=[
-                        Mora(
-                            text="ギェ",
-                            consonant="gy",
-                            consonant_length=0.0,
-                            vowel="e",
-                            vowel_length=0.0,
-                            pitch=0.0,
-                        ),
-                    ],
-                    accent=1,
-                    pause_mora=None,
-                ),
-            ]
-
-        expected_accent_phrases = gye_accent_phrases()
-        self._accent_phrase_marks_base(
-            text="ギェ'",
-            expected_accent_phrases=expected_accent_phrases,
-        )
-
-        def gye_gye_gye_accent_phrases() -> list[AccentPhrase]:
-            return [
-                AccentPhrase(
-                    moras=[
-                        Mora(
-                            text="ギェ",
-                            consonant="gy",
-                            consonant_length=0.0,
-                            vowel="e",
-                            vowel_length=0.0,
-                            pitch=0.0,
-                        ),
-                    ],
-                    accent=1,
-                    pause_mora=Mora(
-                        text="、",
+                ],
+                accent=1,
+                pause_mora=None,
+            ),
+            AccentPhrase(
+                moras=[
+                    Mora(
+                        text="ア",
                         consonant=None,
                         consonant_length=None,
-                        vowel="pau",
+                        vowel="a",
                         vowel_length=0.0,
                         pitch=0.0,
                     ),
-                ),
-                AccentPhrase(
-                    moras=[
-                        Mora(
-                            text="ギェ",
-                            consonant="gy",
-                            consonant_length=0.0,
-                            vowel="e",
-                            vowel_length=0.0,
-                            pitch=0.0,
-                        ),
-                    ],
-                    accent=1,
-                    pause_mora=None,
-                ),
-                AccentPhrase(
-                    moras=[
-                        Mora(
-                            text="ギェ",
-                            consonant="gy",
-                            consonant_length=0.0,
-                            vowel="e",
-                            vowel_length=0.0,
-                            pitch=0.0,
-                        ),
-                    ],
-                    accent=1,
-                    pause_mora=None,
-                ),
-            ]
+                ],
+                accent=1,
+                pause_mora=None,
+            ),
+        ]
 
-        expected_accent_phrases = gye_gye_gye_accent_phrases()
-        self._accent_phrase_marks_base(
-            text="ギェ'、ギェ'/ギェ'",
-            expected_accent_phrases=expected_accent_phrases,
-        )
+    expected_accent_phrases = a_slash_a_accent_phrases()
+    _accent_phrase_marks_base(
+        text="ア'/ア'",
+        expected_accent_phrases=expected_accent_phrases,
+    )
 
-    def test_interrogative_accent_phrase_marks(self) -> None:
-        def a_question_mark_accent_phrases() -> list[AccentPhrase]:
-            return [
-                AccentPhrase(
-                    moras=[
-                        Mora(
-                            text="ア",
-                            consonant=None,
-                            consonant_length=None,
-                            vowel="a",
-                            vowel_length=0.0,
-                            pitch=0.0,
-                        ),
-                    ],
-                    accent=1,
-                    pause_mora=None,
-                    is_interrogative=True,
-                ),
-            ]
-
-        expected_accent_phrases = a_question_mark_accent_phrases()
-        self._accent_phrase_marks_base(
-            text="ア'？",
-            expected_accent_phrases=expected_accent_phrases,
-        )
-
-        def gye_gye_gye_question_mark_accent_phrases() -> list[AccentPhrase]:
-            return [
-                AccentPhrase(
-                    moras=[
-                        Mora(
-                            text="ギェ",
-                            consonant="gy",
-                            consonant_length=0.0,
-                            vowel="e",
-                            vowel_length=0.0,
-                            pitch=0.0,
-                        ),
-                    ],
-                    accent=1,
-                    pause_mora=Mora(
-                        text="、",
+    def a_jp_comma_a_accent_phrases() -> list[AccentPhrase]:
+        return [
+            AccentPhrase(
+                moras=[
+                    Mora(
+                        text="ア",
                         consonant=None,
                         consonant_length=None,
-                        vowel="pau",
+                        vowel="a",
                         vowel_length=0.0,
                         pitch=0.0,
                     ),
+                ],
+                accent=1,
+                pause_mora=Mora(
+                    text="、",
+                    consonant=None,
+                    consonant_length=None,
+                    vowel="pau",
+                    vowel_length=0.0,
+                    pitch=0.0,
                 ),
-                AccentPhrase(
-                    moras=[
-                        Mora(
-                            text="ギェ",
-                            consonant="gy",
-                            consonant_length=0.0,
-                            vowel="e",
-                            vowel_length=0.0,
-                            pitch=0.0,
-                        ),
-                    ],
-                    accent=1,
-                    pause_mora=None,
-                ),
-                AccentPhrase(
-                    moras=[
-                        Mora(
-                            text="ギェ",
-                            consonant="gy",
-                            consonant_length=0.0,
-                            vowel="e",
-                            vowel_length=0.0,
-                            pitch=0.0,
-                        ),
-                    ],
-                    accent=1,
-                    pause_mora=None,
-                    is_interrogative=True,
-                ),
-            ]
-
-        expected_accent_phrases = gye_gye_gye_question_mark_accent_phrases()
-        self._accent_phrase_marks_base(
-            text="ギェ'、ギェ'/ギェ'？",
-            expected_accent_phrases=expected_accent_phrases,
-        )
-
-        def a_pause_a_question_pause_a_question_a_question_mark_accent_phrases() -> (
-            list[AccentPhrase]
-        ):
-            return [
-                AccentPhrase(
-                    moras=[
-                        Mora(
-                            text="ア",
-                            consonant=None,
-                            consonant_length=None,
-                            vowel="a",
-                            vowel_length=0.0,
-                            pitch=0.0,
-                        ),
-                    ],
-                    accent=1,
-                    pause_mora=Mora(
-                        text="、",
+            ),
+            AccentPhrase(
+                moras=[
+                    Mora(
+                        text="ア",
                         consonant=None,
                         consonant_length=None,
-                        vowel="pau",
+                        vowel="a",
                         vowel_length=0.0,
                         pitch=0.0,
                     ),
-                ),
-                AccentPhrase(
-                    moras=[
-                        Mora(
-                            text="ア",
-                            consonant=None,
-                            consonant_length=None,
-                            vowel="a",
-                            vowel_length=0.0,
-                            pitch=0.0,
-                        ),
-                    ],
-                    accent=1,
-                    pause_mora=Mora(
-                        text="、",
+                ],
+                accent=1,
+                pause_mora=None,
+            ),
+        ]
+
+    expected_accent_phrases = a_jp_comma_a_accent_phrases()
+    _accent_phrase_marks_base(
+        text="ア'、ア'",
+        expected_accent_phrases=expected_accent_phrases,
+    )
+
+    def a_slash_a_slash_a_slash_a_slash_a_accent_phrases() -> list[AccentPhrase]:
+        return [
+            AccentPhrase(
+                moras=[
+                    Mora(
+                        text="ア",
                         consonant=None,
                         consonant_length=None,
-                        vowel="pau",
+                        vowel="a",
                         vowel_length=0.0,
                         pitch=0.0,
                     ),
-                    is_interrogative=True,
-                ),
-                AccentPhrase(
-                    moras=[
-                        Mora(
-                            text="ア",
-                            consonant=None,
-                            consonant_length=None,
-                            vowel="a",
-                            vowel_length=0.0,
-                            pitch=0.0,
-                        ),
-                    ],
-                    accent=1,
-                    pause_mora=None,
-                    is_interrogative=True,
-                ),
-                AccentPhrase(
-                    moras=[
-                        Mora(
-                            text="ア",
-                            consonant=None,
-                            consonant_length=None,
-                            vowel="a",
-                            vowel_length=0.0,
-                            pitch=0.0,
-                        ),
-                    ],
-                    accent=1,
-                    pause_mora=None,
-                    is_interrogative=True,
-                ),
-            ]
+                ],
+                accent=1,
+                pause_mora=None,
+            ),
+            AccentPhrase(
+                moras=[
+                    Mora(
+                        text="ア",
+                        consonant=None,
+                        consonant_length=None,
+                        vowel="a",
+                        vowel_length=0.0,
+                        pitch=0.0,
+                    ),
+                ],
+                accent=1,
+                pause_mora=None,
+            ),
+            AccentPhrase(
+                moras=[
+                    Mora(
+                        text="ア",
+                        consonant=None,
+                        consonant_length=None,
+                        vowel="a",
+                        vowel_length=0.0,
+                        pitch=0.0,
+                    ),
+                ],
+                accent=1,
+                pause_mora=None,
+            ),
+            AccentPhrase(
+                moras=[
+                    Mora(
+                        text="ア",
+                        consonant=None,
+                        consonant_length=None,
+                        vowel="a",
+                        vowel_length=0.0,
+                        pitch=0.0,
+                    ),
+                ],
+                accent=1,
+                pause_mora=None,
+            ),
+            AccentPhrase(
+                moras=[
+                    Mora(
+                        text="ア",
+                        consonant=None,
+                        consonant_length=None,
+                        vowel="a",
+                        vowel_length=0.0,
+                        pitch=0.0,
+                    ),
+                ],
+                accent=1,
+                pause_mora=None,
+            ),
+        ]
 
-        expected_accent_phrases = (
-            a_pause_a_question_pause_a_question_a_question_mark_accent_phrases()
-        )
-        self._accent_phrase_marks_base(
-            text="ア'、ア'？、ア'？/ア'？",
-            expected_accent_phrases=expected_accent_phrases,
-        )
+    expected_accent_phrases = a_slash_a_slash_a_slash_a_slash_a_accent_phrases()
+    _accent_phrase_marks_base(
+        text="ア'/ア'/ア'/ア'/ア'",
+        expected_accent_phrases=expected_accent_phrases,
+    )
+
+    def su_accent_phrases() -> list[AccentPhrase]:
+        return [
+            AccentPhrase(
+                moras=[
+                    Mora(
+                        text="ス",
+                        consonant="s",
+                        consonant_length=0.0,
+                        vowel="u",
+                        vowel_length=0.0,
+                        pitch=0.0,
+                    ),
+                ],
+                accent=1,
+                pause_mora=None,
+            ),
+        ]
+
+    expected_accent_phrases = su_accent_phrases()
+    _accent_phrase_marks_base(
+        text="ス'",
+        expected_accent_phrases=expected_accent_phrases,
+    )
+
+    def under_score_su_accent_phrases() -> list[AccentPhrase]:
+        return [
+            AccentPhrase(
+                moras=[
+                    Mora(
+                        text="ス",
+                        consonant="s",
+                        consonant_length=0.0,
+                        vowel="U",
+                        vowel_length=0.0,
+                        pitch=0.0,
+                    ),
+                ],
+                accent=1,
+                pause_mora=None,
+            ),
+        ]
+
+    expected_accent_phrases = under_score_su_accent_phrases()
+    _accent_phrase_marks_base(
+        text="_ス'",
+        expected_accent_phrases=expected_accent_phrases,
+    )
+
+    def gye_accent_phrases() -> list[AccentPhrase]:
+        return [
+            AccentPhrase(
+                moras=[
+                    Mora(
+                        text="ギェ",
+                        consonant="gy",
+                        consonant_length=0.0,
+                        vowel="e",
+                        vowel_length=0.0,
+                        pitch=0.0,
+                    ),
+                ],
+                accent=1,
+                pause_mora=None,
+            ),
+        ]
+
+    expected_accent_phrases = gye_accent_phrases()
+    _accent_phrase_marks_base(
+        text="ギェ'",
+        expected_accent_phrases=expected_accent_phrases,
+    )
+
+    def gye_gye_gye_accent_phrases() -> list[AccentPhrase]:
+        return [
+            AccentPhrase(
+                moras=[
+                    Mora(
+                        text="ギェ",
+                        consonant="gy",
+                        consonant_length=0.0,
+                        vowel="e",
+                        vowel_length=0.0,
+                        pitch=0.0,
+                    ),
+                ],
+                accent=1,
+                pause_mora=Mora(
+                    text="、",
+                    consonant=None,
+                    consonant_length=None,
+                    vowel="pau",
+                    vowel_length=0.0,
+                    pitch=0.0,
+                ),
+            ),
+            AccentPhrase(
+                moras=[
+                    Mora(
+                        text="ギェ",
+                        consonant="gy",
+                        consonant_length=0.0,
+                        vowel="e",
+                        vowel_length=0.0,
+                        pitch=0.0,
+                    ),
+                ],
+                accent=1,
+                pause_mora=None,
+            ),
+            AccentPhrase(
+                moras=[
+                    Mora(
+                        text="ギェ",
+                        consonant="gy",
+                        consonant_length=0.0,
+                        vowel="e",
+                        vowel_length=0.0,
+                        pitch=0.0,
+                    ),
+                ],
+                accent=1,
+                pause_mora=None,
+            ),
+        ]
+
+    expected_accent_phrases = gye_gye_gye_accent_phrases()
+    _accent_phrase_marks_base(
+        text="ギェ'、ギェ'/ギェ'",
+        expected_accent_phrases=expected_accent_phrases,
+    )
+
+
+def test_interrogative_accent_phrase_marks() -> None:
+    def a_question_mark_accent_phrases() -> list[AccentPhrase]:
+        return [
+            AccentPhrase(
+                moras=[
+                    Mora(
+                        text="ア",
+                        consonant=None,
+                        consonant_length=None,
+                        vowel="a",
+                        vowel_length=0.0,
+                        pitch=0.0,
+                    ),
+                ],
+                accent=1,
+                pause_mora=None,
+                is_interrogative=True,
+            ),
+        ]
+
+    expected_accent_phrases = a_question_mark_accent_phrases()
+    _accent_phrase_marks_base(
+        text="ア'？",
+        expected_accent_phrases=expected_accent_phrases,
+    )
+
+    def gye_gye_gye_question_mark_accent_phrases() -> list[AccentPhrase]:
+        return [
+            AccentPhrase(
+                moras=[
+                    Mora(
+                        text="ギェ",
+                        consonant="gy",
+                        consonant_length=0.0,
+                        vowel="e",
+                        vowel_length=0.0,
+                        pitch=0.0,
+                    ),
+                ],
+                accent=1,
+                pause_mora=Mora(
+                    text="、",
+                    consonant=None,
+                    consonant_length=None,
+                    vowel="pau",
+                    vowel_length=0.0,
+                    pitch=0.0,
+                ),
+            ),
+            AccentPhrase(
+                moras=[
+                    Mora(
+                        text="ギェ",
+                        consonant="gy",
+                        consonant_length=0.0,
+                        vowel="e",
+                        vowel_length=0.0,
+                        pitch=0.0,
+                    ),
+                ],
+                accent=1,
+                pause_mora=None,
+            ),
+            AccentPhrase(
+                moras=[
+                    Mora(
+                        text="ギェ",
+                        consonant="gy",
+                        consonant_length=0.0,
+                        vowel="e",
+                        vowel_length=0.0,
+                        pitch=0.0,
+                    ),
+                ],
+                accent=1,
+                pause_mora=None,
+                is_interrogative=True,
+            ),
+        ]
+
+    expected_accent_phrases = gye_gye_gye_question_mark_accent_phrases()
+    _accent_phrase_marks_base(
+        text="ギェ'、ギェ'/ギェ'？",
+        expected_accent_phrases=expected_accent_phrases,
+    )
+
+    def a_pause_a_question_pause_a_question_a_question_mark_accent_phrases() -> (
+        list[AccentPhrase]
+    ):
+        return [
+            AccentPhrase(
+                moras=[
+                    Mora(
+                        text="ア",
+                        consonant=None,
+                        consonant_length=None,
+                        vowel="a",
+                        vowel_length=0.0,
+                        pitch=0.0,
+                    ),
+                ],
+                accent=1,
+                pause_mora=Mora(
+                    text="、",
+                    consonant=None,
+                    consonant_length=None,
+                    vowel="pau",
+                    vowel_length=0.0,
+                    pitch=0.0,
+                ),
+            ),
+            AccentPhrase(
+                moras=[
+                    Mora(
+                        text="ア",
+                        consonant=None,
+                        consonant_length=None,
+                        vowel="a",
+                        vowel_length=0.0,
+                        pitch=0.0,
+                    ),
+                ],
+                accent=1,
+                pause_mora=Mora(
+                    text="、",
+                    consonant=None,
+                    consonant_length=None,
+                    vowel="pau",
+                    vowel_length=0.0,
+                    pitch=0.0,
+                ),
+                is_interrogative=True,
+            ),
+            AccentPhrase(
+                moras=[
+                    Mora(
+                        text="ア",
+                        consonant=None,
+                        consonant_length=None,
+                        vowel="a",
+                        vowel_length=0.0,
+                        pitch=0.0,
+                    ),
+                ],
+                accent=1,
+                pause_mora=None,
+                is_interrogative=True,
+            ),
+            AccentPhrase(
+                moras=[
+                    Mora(
+                        text="ア",
+                        consonant=None,
+                        consonant_length=None,
+                        vowel="a",
+                        vowel_length=0.0,
+                        pitch=0.0,
+                    ),
+                ],
+                accent=1,
+                pause_mora=None,
+                is_interrogative=True,
+            ),
+        ]
+
+    expected_accent_phrases = (
+        a_pause_a_question_pause_a_question_a_question_mark_accent_phrases()
+    )
+    _accent_phrase_marks_base(
+        text="ア'、ア'？、ア'？/ア'？",
+        expected_accent_phrases=expected_accent_phrases,
+    )
 
 
 class TestParseKanaException(TestCase):
@@ -567,127 +574,126 @@ class TestParseKanaException(TestCase):
         )
 
 
-class TestCreateKana(TestCase):
-    def test_create_kana_interrogative(self) -> None:
-        def koreha_arimasuka_accent_phrases() -> list[AccentPhrase]:
-            return [
-                AccentPhrase(
-                    moras=[
-                        Mora(
-                            text="コ",
-                            consonant="k",
-                            consonant_length=2.5,
-                            vowel="o",
-                            vowel_length=2.5,
-                            pitch=2.5,
-                        ),
-                        Mora(
-                            text="レ",
-                            consonant="r",
-                            consonant_length=2.5,
-                            vowel="e",
-                            vowel_length=2.5,
-                            pitch=2.5,
-                        ),
-                        Mora(
-                            text="ワ",
-                            consonant="w",
-                            consonant_length=2.5,
-                            vowel="a",
-                            vowel_length=2.5,
-                            pitch=2.5,
-                        ),
-                    ],
-                    accent=3,
-                    pause_mora=None,
-                    is_interrogative=False,
-                ),
-                AccentPhrase(
-                    moras=[
-                        Mora(
-                            text="ア",
-                            consonant=None,
-                            consonant_length=None,
-                            vowel="a",
-                            vowel_length=2.5,
-                            pitch=2.5,
-                        ),
-                        Mora(
-                            text="リ",
-                            consonant="r",
-                            consonant_length=2.5,
-                            vowel="i",
-                            vowel_length=2.5,
-                            pitch=2.5,
-                        ),
-                        Mora(
-                            text="マ",
-                            consonant="m",
-                            consonant_length=2.5,
-                            vowel="a",
-                            vowel_length=2.5,
-                            pitch=2.5,
-                        ),
-                        Mora(
-                            text="ス",
-                            consonant="s",
-                            consonant_length=2.5,
-                            vowel="U",
-                            vowel_length=2.5,
-                            pitch=2.5,
-                        ),
-                        Mora(
-                            text="カ",
-                            consonant="k",
-                            consonant_length=2.5,
-                            vowel="a",
-                            vowel_length=2.5,
-                            pitch=2.5,
-                        ),
-                    ],
-                    accent=3,
-                    pause_mora=None,
-                    is_interrogative=False,
-                ),
-            ]
+def test_create_kana_interrogative() -> None:
+    def koreha_arimasuka_accent_phrases() -> list[AccentPhrase]:
+        return [
+            AccentPhrase(
+                moras=[
+                    Mora(
+                        text="コ",
+                        consonant="k",
+                        consonant_length=2.5,
+                        vowel="o",
+                        vowel_length=2.5,
+                        pitch=2.5,
+                    ),
+                    Mora(
+                        text="レ",
+                        consonant="r",
+                        consonant_length=2.5,
+                        vowel="e",
+                        vowel_length=2.5,
+                        pitch=2.5,
+                    ),
+                    Mora(
+                        text="ワ",
+                        consonant="w",
+                        consonant_length=2.5,
+                        vowel="a",
+                        vowel_length=2.5,
+                        pitch=2.5,
+                    ),
+                ],
+                accent=3,
+                pause_mora=None,
+                is_interrogative=False,
+            ),
+            AccentPhrase(
+                moras=[
+                    Mora(
+                        text="ア",
+                        consonant=None,
+                        consonant_length=None,
+                        vowel="a",
+                        vowel_length=2.5,
+                        pitch=2.5,
+                    ),
+                    Mora(
+                        text="リ",
+                        consonant="r",
+                        consonant_length=2.5,
+                        vowel="i",
+                        vowel_length=2.5,
+                        pitch=2.5,
+                    ),
+                    Mora(
+                        text="マ",
+                        consonant="m",
+                        consonant_length=2.5,
+                        vowel="a",
+                        vowel_length=2.5,
+                        pitch=2.5,
+                    ),
+                    Mora(
+                        text="ス",
+                        consonant="s",
+                        consonant_length=2.5,
+                        vowel="U",
+                        vowel_length=2.5,
+                        pitch=2.5,
+                    ),
+                    Mora(
+                        text="カ",
+                        consonant="k",
+                        consonant_length=2.5,
+                        vowel="a",
+                        vowel_length=2.5,
+                        pitch=2.5,
+                    ),
+                ],
+                accent=3,
+                pause_mora=None,
+                is_interrogative=False,
+            ),
+        ]
 
-        accent_phrases = koreha_arimasuka_accent_phrases()
-        self.assertEqual(create_kana(accent_phrases), "コレワ'/アリマ'_スカ")
+    accent_phrases = koreha_arimasuka_accent_phrases()
+    assert create_kana(accent_phrases) == "コレワ'/アリマ'_スカ"
 
-        accent_phrases = koreha_arimasuka_accent_phrases()
-        accent_phrases[-1].is_interrogative = True
-        self.assertEqual(create_kana(accent_phrases), "コレワ'/アリマ'_スカ？")
+    accent_phrases = koreha_arimasuka_accent_phrases()
+    accent_phrases[-1].is_interrogative = True
+    assert create_kana(accent_phrases) == "コレワ'/アリマ'_スカ？"
 
-        def kya_accent_phrases() -> list[AccentPhrase]:
-            return [
-                AccentPhrase(
-                    moras=[
-                        Mora(
-                            text="キャ",
-                            consonant="ky",
-                            consonant_length=2.5,
-                            vowel="a",
-                            vowel_length=2.5,
-                            pitch=2.5,
-                        ),
-                        Mora(
-                            text="ッ",
-                            consonant=None,
-                            consonant_length=None,
-                            vowel="cl",
-                            vowel_length=0.1,
-                            pitch=0,
-                        ),
-                    ],
-                    accent=1,
-                    pause_mora=None,
-                    is_interrogative=False,
-                ),
-            ]
+    def kya_accent_phrases() -> list[AccentPhrase]:
+        return [
+            AccentPhrase(
+                moras=[
+                    Mora(
+                        text="キャ",
+                        consonant="ky",
+                        consonant_length=2.5,
+                        vowel="a",
+                        vowel_length=2.5,
+                        pitch=2.5,
+                    ),
+                    Mora(
+                        text="ッ",
+                        consonant=None,
+                        consonant_length=None,
+                        vowel="cl",
+                        vowel_length=0.1,
+                        pitch=0,
+                    ),
+                ],
+                accent=1,
+                pause_mora=None,
+                is_interrogative=False,
+            ),
+        ]
 
-        accent_phrases = kya_accent_phrases()
-        self.assertEqual(create_kana(accent_phrases), "キャ'ッ")
+    accent_phrases = kya_accent_phrases()
+    assert create_kana(accent_phrases) == "キャ'ッ"
 
-        accent_phrases = kya_accent_phrases()
-        accent_phrases[-1].is_interrogative = True
-        self.assertEqual(create_kana(accent_phrases), "キャ'ッ？")
+    accent_phrases = kya_accent_phrases()
+    accent_phrases[-1].is_interrogative = True
+    assert create_kana(accent_phrases) == "キャ'ッ？"

--- a/test/tts_pipeline/test_mora_mapping.py
+++ b/test/tts_pipeline/test_mora_mapping.py
@@ -1,20 +1,18 @@
-from unittest import TestCase
-
 from voicevox_engine.tts_pipeline.mora_mapping import mora_phonemes_to_mora_kana
 
 
-class TestOpenJTalkMoraList(TestCase):
-    def test_mora2text(self) -> None:
-        self.assertEqual("ッ", mora_phonemes_to_mora_kana["cl"])
-        self.assertEqual("ティ", mora_phonemes_to_mora_kana["ti"])
-        self.assertEqual("トゥ", mora_phonemes_to_mora_kana["tu"])
-        self.assertEqual("ディ", mora_phonemes_to_mora_kana["di"])
-        # GitHub issue #60
-        self.assertEqual("ギェ", mora_phonemes_to_mora_kana["gye"])
-        self.assertEqual("イェ", mora_phonemes_to_mora_kana["ye"])
+def test_mora2text() -> None:
+    assert "ッ" == mora_phonemes_to_mora_kana["cl"]
+    assert "ティ" == mora_phonemes_to_mora_kana["ti"]
+    assert "トゥ" == mora_phonemes_to_mora_kana["tu"]
+    assert "ディ" == mora_phonemes_to_mora_kana["di"]
+    # GitHub issue #60
+    assert "ギェ" == mora_phonemes_to_mora_kana["gye"]
+    assert "イェ" == mora_phonemes_to_mora_kana["ye"]
 
-    def test_mora2text_injective(self) -> None:
-        """異なるモーラが同じ読みがなに対応しないか確認する"""
-        values = list(mora_phonemes_to_mora_kana.values())
-        uniq_values = list(set(values))
-        self.assertCountEqual(values, uniq_values)
+
+def test_mora2text_injective() -> None:
+    """異なるモーラが同じ読みがなに対応しないか確認する"""
+    values = list(mora_phonemes_to_mora_kana.values())
+    uniq_values = list(set(values))
+    assert sorted(values) == sorted(uniq_values)

--- a/test/tts_pipeline/test_phoneme.py
+++ b/test/tts_pipeline/test_phoneme.py
@@ -1,5 +1,3 @@
-from unittest import TestCase
-
 import pytest
 
 from voicevox_engine.tts_pipeline.phoneme import Phoneme
@@ -13,61 +11,60 @@ def test_unknown_phoneme() -> None:
     unknown_phoneme = Phoneme("xx")
 
     # Tests
-    with pytest.raises(ValueError) as _:
-        _ = unknown_phoneme.id
+    with pytest.raises(ValueError):
+        unknown_phoneme.id
 
 
-class TestPhoneme(TestCase):
-    def setUp(self) -> None:
-        super().setUp()
-        # list_idx      0 1 2 3 4 5  6 7 8 9  10 1 2 3 4 5 6 7 8   9
-        hello_hiho = "sil k o N n i ch i w a pau h i h o d e s U sil".split()
-        self.ojt_hello_hiho = [Phoneme(s) for s in hello_hiho]
+# list_idx      0 1 2 3 4 5  6 7 8 9  10 1 2 3 4 5 6 7 8   9
+hello_hiho = "sil k o N n i ch i w a pau h i h o d e s U sil".split()
+ojt_hello_hiho = [Phoneme(s) for s in hello_hiho]
 
-    def test_const(self) -> None:
-        self.assertEqual(Phoneme._NUM_PHONEME, TRUE_NUM_PHONEME)
-        self.assertEqual(Phoneme._PHONEME_LIST[1], "A")
-        self.assertEqual(Phoneme._PHONEME_LIST[14], "e")
-        self.assertEqual(Phoneme._PHONEME_LIST[26], "m")
-        self.assertEqual(Phoneme._PHONEME_LIST[38], "ts")
-        self.assertEqual(Phoneme._PHONEME_LIST[41], "v")
 
-    def test_convert(self) -> None:
-        sil_phoneme = Phoneme("sil")
-        self.assertEqual(sil_phoneme._phoneme, "pau")
+def test_const() -> None:
+    assert Phoneme._NUM_PHONEME == TRUE_NUM_PHONEME
+    assert Phoneme._PHONEME_LIST[1] == "A"
+    assert Phoneme._PHONEME_LIST[14] == "e"
+    assert Phoneme._PHONEME_LIST[26] == "m"
+    assert Phoneme._PHONEME_LIST[38] == "ts"
+    assert Phoneme._PHONEME_LIST[41] == "v"
 
-    def test_phoneme_id(self) -> None:
-        ojt_str_hello_hiho = " ".join([str(p.id) for p in self.ojt_hello_hiho])
-        self.assertEqual(
-            ojt_str_hello_hiho, "0 23 30 4 28 21 10 21 42 7 0 19 21 19 30 12 14 35 6 0"
-        )
 
-    def test_onehot(self) -> None:
-        phoneme_id_list = [
-            0,
-            23,
-            30,
-            4,
-            28,
-            21,
-            10,
-            21,
-            42,
-            7,
-            0,
-            19,
-            21,
-            19,
-            30,
-            12,
-            14,
-            35,
-            6,
-            0,
-        ]
-        for i, phoneme in enumerate(self.ojt_hello_hiho):
-            for j in range(TRUE_NUM_PHONEME):
-                if phoneme_id_list[i] == j:
-                    self.assertEqual(phoneme.onehot[j], 1.0)
-                else:
-                    self.assertEqual(phoneme.onehot[j], 0.0)
+def test_convert() -> None:
+    sil_phoneme = Phoneme("sil")
+    assert sil_phoneme._phoneme == "pau"
+
+
+def test_phoneme_id() -> None:
+    ojt_str_hello_hiho = " ".join([str(p.id) for p in ojt_hello_hiho])
+    assert ojt_str_hello_hiho == "0 23 30 4 28 21 10 21 42 7 0 19 21 19 30 12 14 35 6 0"
+
+
+def test_onehot() -> None:
+    phoneme_id_list = [
+        0,
+        23,
+        30,
+        4,
+        28,
+        21,
+        10,
+        21,
+        42,
+        7,
+        0,
+        19,
+        21,
+        19,
+        30,
+        12,
+        14,
+        35,
+        6,
+        0,
+    ]
+    for i, phoneme in enumerate(ojt_hello_hiho):
+        for j in range(TRUE_NUM_PHONEME):
+            if phoneme_id_list[i] == j:
+                assert phoneme.onehot[j] == 1.0
+            else:
+                assert phoneme.onehot[j] == 0.0

--- a/test/tts_pipeline/test_text_analyzer.py
+++ b/test/tts_pipeline/test_text_analyzer.py
@@ -1,5 +1,3 @@
-from unittest import TestCase
-
 from voicevox_engine.model import AccentPhrase, Mora
 from voicevox_engine.tts_pipeline.text_analyzer import (
     AccentPhraseLabel,
@@ -39,97 +37,92 @@ def features(ojt_container: OjtContainer) -> list[str]:
     return [contexts_to_feature(p.contexts) for p in ojt_container.labels]
 
 
-class TestBaseLabels(TestCase):
-    def setUp(self) -> None:
-        super().setUp()
-        # pyopenjtalk.extract_fullcontext("こんにちは、ヒホです。")の結果
-        # 出来る限りテスト内で他のライブラリに依存しないため、
-        # またテスト内容を透明化するために、テストケースを生成している
-        self.test_case_hello_hiho = [
-            # sil (無音)
-            "xx^xx-sil+k=o/A:xx+xx+xx/B:xx-xx_xx/C:xx_xx+xx/D:09+xx_xx/E:xx_xx!xx_xx-xx"
-            + "/F:xx_xx#xx_xx@xx_xx|xx_xx/G:5_5%0_xx_xx/H:xx_xx/I:xx-xx"
-            + "@xx+xx&xx-xx|xx+xx/J:1_5/K:2+2-9",
-            # k
-            "xx^sil-k+o=N/A:-4+1+5/B:xx-xx_xx/C:09_xx+xx/D:09+xx_xx/E:xx_xx!xx_xx-xx"
-            + "/F:5_5#0_xx@1_1|1_5/G:4_1%0_xx_0/H:xx_xx/I:1-5"
-            + "@1+2&1-2|1+9/J:1_4/K:2+2-9",
-            # o
-            "sil^k-o+N=n/A:-4+1+5/B:xx-xx_xx/C:09_xx+xx/D:09+xx_xx/E:xx_xx!xx_xx-xx"
-            + "/F:5_5#0_xx@1_1|1_5/G:4_1%0_xx_0/H:xx_xx/I:1-5"
-            + "@1+2&1-2|1+9/J:1_4/K:2+2-9",
-            # N (ん)
-            "k^o-N+n=i/A:-3+2+4/B:xx-xx_xx/C:09_xx+xx/D:09+xx_xx/E:xx_xx!xx_xx-xx"
-            + "/F:5_5#0_xx@1_1|1_5/G:4_1%0_xx_0/H:xx_xx/I:1-5"
-            + "@1+2&1-2|1+9/J:1_4/K:2+2-9",
-            # n
-            "o^N-n+i=ch/A:-2+3+3/B:xx-xx_xx/C:09_xx+xx/D:09+xx_xx/E:xx_xx!xx_xx-xx"
-            + "/F:5_5#0_xx@1_1|1_5/G:4_1%0_xx_0/H:xx_xx/I:1-5"
-            + "@1+2&1-2|1+9/J:1_4/K:2+2-9",
-            # i
-            "N^n-i+ch=i/A:-2+3+3/B:xx-xx_xx/C:09_xx+xx/D:09+xx_xx/E:xx_xx!xx_xx-xx"
-            + "/F:5_5#0_xx@1_1|1_5/G:4_1%0_xx_0/H:xx_xx/I:1-5"
-            + "@1+2&1-2|1+9/J:1_4/K:2+2-9",
-            # ch
-            "n^i-ch+i=w/A:-1+4+2/B:xx-xx_xx/C:09_xx+xx/D:09+xx_xx/E:xx_xx!xx_xx-xx"
-            + "/F:5_5#0_xx@1_1|1_5/G:4_1%0_xx_0/H:xx_xx/I:1-5"
-            + "@1+2&1-2|1+9/J:1_4/K:2+2-9",
-            # i
-            "i^ch-i+w=a/A:-1+4+2/B:xx-xx_xx/C:09_xx+xx/D:09+xx_xx/E:xx_xx!xx_xx-xx"
-            + "/F:5_5#0_xx@1_1|1_5/G:4_1%0_xx_0/H:xx_xx/I:1-5"
-            + "@1+2&1-2|1+9/J:1_4/K:2+2-9",
-            # w
-            "ch^i-w+a=pau/A:0+5+1/B:xx-xx_xx/C:09_xx+xx/D:09+xx_xx/E:xx_xx!xx_xx-xx"
-            + "/F:5_5#0_xx@1_1|1_5/G:4_1%0_xx_0/H:xx_xx/I:1-5"
-            + "@1+2&1-2|1+9/J:1_4/K:2+2-9",
-            # a
-            "i^w-a+pau=h/A:0+5+1/B:xx-xx_xx/C:09_xx+xx/D:09+xx_xx/E:xx_xx!xx_xx-xx"
-            + "/F:5_5#0_xx@1_1|1_5/G:4_1%0_xx_0/H:xx_xx/I:1-5"
-            + "@1+2&1-2|1+9/J:1_4/K:2+2-9",
-            # pau (読点)
-            "w^a-pau+h=i/A:xx+xx+xx/B:09-xx_xx/C:xx_xx+xx/D:09+xx_xx/E:5_5!0_xx-xx"
-            + "/F:xx_xx#xx_xx@xx_xx|xx_xx/G:4_1%0_xx_xx/H:1_5/I:xx-xx"
-            + "@xx+xx&xx-xx|xx+xx/J:1_4/K:2+2-9",
-            # h
-            "a^pau-h+i=h/A:0+1+4/B:09-xx_xx/C:09_xx+xx/D:22+xx_xx/E:5_5!0_xx-0"
-            + "/F:4_1#0_xx@1_1|1_4/G:xx_xx%xx_xx_xx/H:1_5/I:1-4"
-            + "@2+1&2-1|6+4/J:xx_xx/K:2+2-9",
-            # i
-            "pau^h-i+h=o/A:0+1+4/B:09-xx_xx/C:09_xx+xx/D:22+xx_xx/E:5_5!0_xx-0"
-            + "/F:4_1#0_xx@1_1|1_4/G:xx_xx%xx_xx_xx/H:1_5/I:1-4"
-            + "@2+1&2-1|6+4/J:xx_xx/K:2+2-9",
-            # h
-            "h^i-h+o=d/A:1+2+3/B:09-xx_xx/C:22_xx+xx/D:10+7_2/E:5_5!0_xx-0"
-            + "/F:4_1#0_xx@1_1|1_4/G:xx_xx%xx_xx_xx/H:1_5/I:1-4"
-            + "@2+1&2-1|6+4/J:xx_xx/K:2+2-9",
-            # o
-            "i^h-o+d=e/A:1+2+3/B:09-xx_xx/C:22_xx+xx/D:10+7_2/E:5_5!0_xx-0"
-            + "/F:4_1#0_xx@1_1|1_4/G:xx_xx%xx_xx_xx/H:1_5/I:1-4"
-            + "@2+1&2-1|6+4/J:xx_xx/K:2+2-9",
-            # d
-            "h^o-d+e=s/A:2+3+2/B:22-xx_xx/C:10_7+2/D:xx+xx_xx/E:5_5!0_xx-0"
-            + "/F:4_1#0_xx@1_1|1_4/G:xx_xx%xx_xx_xx/H:1_5/I:1-4"
-            + "@2+1&2-1|6+4/J:xx_xx/K:2+2-9",
-            # e
-            "o^d-e+s=U/A:2+3+2/B:22-xx_xx/C:10_7+2/D:xx+xx_xx/E:5_5!0_xx-0"
-            + "/F:4_1#0_xx@1_1|1_4/G:xx_xx%xx_xx_xx/H:1_5/I:1-4"
-            + "@2+1&2-1|6+4/J:xx_xx/K:2+2-9",
-            # s
-            "d^e-s+U=sil/A:3+4+1/B:22-xx_xx/C:10_7+2/D:xx+xx_xx/E:5_5!0_xx-0"
-            + "/F:4_1#0_xx@1_1|1_4/G:xx_xx%xx_xx_xx/H:1_5/I:1-4"
-            + "@2+1&2-1|6+4/J:xx_xx/K:2+2-9",
-            # U (無声母音)
-            "e^s-U+sil=xx/A:3+4+1/B:22-xx_xx/C:10_7+2/D:xx+xx_xx/E:5_5!0_xx-0"
-            + "/F:4_1#0_xx@1_1|1_4/G:xx_xx%xx_xx_xx/H:1_5/I:1-4"
-            + "@2+1&2-1|6+4/J:xx_xx/K:2+2-9",
-            # sil (無音)
-            "s^U-sil+xx=xx/A:xx+xx+xx/B:10-7_2/C:xx_xx+xx/D:xx+xx_xx/E:4_1!0_xx-xx"
-            + "/F:xx_xx#xx_xx@xx_xx|xx_xx/G:xx_xx%xx_xx_xx/H:1_4/I:xx-xx"
-            + "@xx+xx&xx-xx|xx+xx/J:xx_xx/K:2+2-9",
-        ]
-        self.labels_hello_hiho = [
-            Label.from_feature(feature) for feature in self.test_case_hello_hiho
-        ]
+# pyopenjtalk.extract_fullcontext("こんにちは、ヒホです。")の結果
+# 出来る限りテスト内で他のライブラリに依存しないため、
+# またテスト内容を透明化するために、テストケースを生成している
+test_case_hello_hiho = [
+    # sil (無音)
+    "xx^xx-sil+k=o/A:xx+xx+xx/B:xx-xx_xx/C:xx_xx+xx/D:09+xx_xx/E:xx_xx!xx_xx-xx"
+    + "/F:xx_xx#xx_xx@xx_xx|xx_xx/G:5_5%0_xx_xx/H:xx_xx/I:xx-xx"
+    + "@xx+xx&xx-xx|xx+xx/J:1_5/K:2+2-9",
+    # k
+    "xx^sil-k+o=N/A:-4+1+5/B:xx-xx_xx/C:09_xx+xx/D:09+xx_xx/E:xx_xx!xx_xx-xx"
+    + "/F:5_5#0_xx@1_1|1_5/G:4_1%0_xx_0/H:xx_xx/I:1-5"
+    + "@1+2&1-2|1+9/J:1_4/K:2+2-9",
+    # o
+    "sil^k-o+N=n/A:-4+1+5/B:xx-xx_xx/C:09_xx+xx/D:09+xx_xx/E:xx_xx!xx_xx-xx"
+    + "/F:5_5#0_xx@1_1|1_5/G:4_1%0_xx_0/H:xx_xx/I:1-5"
+    + "@1+2&1-2|1+9/J:1_4/K:2+2-9",
+    # N (ん)
+    "k^o-N+n=i/A:-3+2+4/B:xx-xx_xx/C:09_xx+xx/D:09+xx_xx/E:xx_xx!xx_xx-xx"
+    + "/F:5_5#0_xx@1_1|1_5/G:4_1%0_xx_0/H:xx_xx/I:1-5"
+    + "@1+2&1-2|1+9/J:1_4/K:2+2-9",
+    # n
+    "o^N-n+i=ch/A:-2+3+3/B:xx-xx_xx/C:09_xx+xx/D:09+xx_xx/E:xx_xx!xx_xx-xx"
+    + "/F:5_5#0_xx@1_1|1_5/G:4_1%0_xx_0/H:xx_xx/I:1-5"
+    + "@1+2&1-2|1+9/J:1_4/K:2+2-9",
+    # i
+    "N^n-i+ch=i/A:-2+3+3/B:xx-xx_xx/C:09_xx+xx/D:09+xx_xx/E:xx_xx!xx_xx-xx"
+    + "/F:5_5#0_xx@1_1|1_5/G:4_1%0_xx_0/H:xx_xx/I:1-5"
+    + "@1+2&1-2|1+9/J:1_4/K:2+2-9",
+    # ch
+    "n^i-ch+i=w/A:-1+4+2/B:xx-xx_xx/C:09_xx+xx/D:09+xx_xx/E:xx_xx!xx_xx-xx"
+    + "/F:5_5#0_xx@1_1|1_5/G:4_1%0_xx_0/H:xx_xx/I:1-5"
+    + "@1+2&1-2|1+9/J:1_4/K:2+2-9",
+    # i
+    "i^ch-i+w=a/A:-1+4+2/B:xx-xx_xx/C:09_xx+xx/D:09+xx_xx/E:xx_xx!xx_xx-xx"
+    + "/F:5_5#0_xx@1_1|1_5/G:4_1%0_xx_0/H:xx_xx/I:1-5"
+    + "@1+2&1-2|1+9/J:1_4/K:2+2-9",
+    # w
+    "ch^i-w+a=pau/A:0+5+1/B:xx-xx_xx/C:09_xx+xx/D:09+xx_xx/E:xx_xx!xx_xx-xx"
+    + "/F:5_5#0_xx@1_1|1_5/G:4_1%0_xx_0/H:xx_xx/I:1-5"
+    + "@1+2&1-2|1+9/J:1_4/K:2+2-9",
+    # a
+    "i^w-a+pau=h/A:0+5+1/B:xx-xx_xx/C:09_xx+xx/D:09+xx_xx/E:xx_xx!xx_xx-xx"
+    + "/F:5_5#0_xx@1_1|1_5/G:4_1%0_xx_0/H:xx_xx/I:1-5"
+    + "@1+2&1-2|1+9/J:1_4/K:2+2-9",
+    # pau (読点)
+    "w^a-pau+h=i/A:xx+xx+xx/B:09-xx_xx/C:xx_xx+xx/D:09+xx_xx/E:5_5!0_xx-xx"
+    + "/F:xx_xx#xx_xx@xx_xx|xx_xx/G:4_1%0_xx_xx/H:1_5/I:xx-xx"
+    + "@xx+xx&xx-xx|xx+xx/J:1_4/K:2+2-9",
+    # h
+    "a^pau-h+i=h/A:0+1+4/B:09-xx_xx/C:09_xx+xx/D:22+xx_xx/E:5_5!0_xx-0"
+    + "/F:4_1#0_xx@1_1|1_4/G:xx_xx%xx_xx_xx/H:1_5/I:1-4"
+    + "@2+1&2-1|6+4/J:xx_xx/K:2+2-9",
+    # i
+    "pau^h-i+h=o/A:0+1+4/B:09-xx_xx/C:09_xx+xx/D:22+xx_xx/E:5_5!0_xx-0"
+    + "/F:4_1#0_xx@1_1|1_4/G:xx_xx%xx_xx_xx/H:1_5/I:1-4"
+    + "@2+1&2-1|6+4/J:xx_xx/K:2+2-9",
+    # h
+    "h^i-h+o=d/A:1+2+3/B:09-xx_xx/C:22_xx+xx/D:10+7_2/E:5_5!0_xx-0"
+    + "/F:4_1#0_xx@1_1|1_4/G:xx_xx%xx_xx_xx/H:1_5/I:1-4"
+    + "@2+1&2-1|6+4/J:xx_xx/K:2+2-9",
+    # o
+    "i^h-o+d=e/A:1+2+3/B:09-xx_xx/C:22_xx+xx/D:10+7_2/E:5_5!0_xx-0"
+    + "/F:4_1#0_xx@1_1|1_4/G:xx_xx%xx_xx_xx/H:1_5/I:1-4"
+    + "@2+1&2-1|6+4/J:xx_xx/K:2+2-9",
+    # d
+    "h^o-d+e=s/A:2+3+2/B:22-xx_xx/C:10_7+2/D:xx+xx_xx/E:5_5!0_xx-0"
+    + "/F:4_1#0_xx@1_1|1_4/G:xx_xx%xx_xx_xx/H:1_5/I:1-4"
+    + "@2+1&2-1|6+4/J:xx_xx/K:2+2-9",
+    # e
+    "o^d-e+s=U/A:2+3+2/B:22-xx_xx/C:10_7+2/D:xx+xx_xx/E:5_5!0_xx-0"
+    + "/F:4_1#0_xx@1_1|1_4/G:xx_xx%xx_xx_xx/H:1_5/I:1-4"
+    + "@2+1&2-1|6+4/J:xx_xx/K:2+2-9",
+    # s
+    "d^e-s+U=sil/A:3+4+1/B:22-xx_xx/C:10_7+2/D:xx+xx_xx/E:5_5!0_xx-0"
+    + "/F:4_1#0_xx@1_1|1_4/G:xx_xx%xx_xx_xx/H:1_5/I:1-4"
+    + "@2+1&2-1|6+4/J:xx_xx/K:2+2-9",
+    # U (無声母音)
+    "e^s-U+sil=xx/A:3+4+1/B:22-xx_xx/C:10_7+2/D:xx+xx_xx/E:5_5!0_xx-0"
+    + "/F:4_1#0_xx@1_1|1_4/G:xx_xx%xx_xx_xx/H:1_5/I:1-4"
+    + "@2+1&2-1|6+4/J:xx_xx/K:2+2-9",
+    # sil (無音)
+    "s^U-sil+xx=xx/A:xx+xx+xx/B:10-7_2/C:xx_xx+xx/D:xx+xx_xx/E:4_1!0_xx-xx"
+    + "/F:xx_xx#xx_xx@xx_xx|xx_xx/G:xx_xx%xx_xx_xx/H:1_4/I:xx-xx"
+    + "@xx+xx&xx-xx|xx+xx/J:xx_xx/K:2+2-9",
+]
+labels_hello_hiho = [Label.from_feature(feature) for feature in test_case_hello_hiho]
 
 
 def jointed_phonemes(ojt_container: OjtContainer) -> str:
@@ -142,208 +135,179 @@ def space_jointed_phonemes(ojt_container: OjtContainer) -> str:
     return " ".join([label.phoneme for label in ojt_container.labels])
 
 
-class TestLabel(TestBaseLabels):
-    def test_phoneme(self) -> None:
-        """Label に含まれる音素をテスト"""
-        self.assertEqual(
-            " ".join([label.phoneme for label in self.labels_hello_hiho]),
-            "sil k o N n i ch i w a pau h i h o d e s U sil",
-        )
-
-    def test_is_pause(self) -> None:
-        """Label のポーズ判定をテスト"""
-        self.assertEqual(
-            [label.is_pause() for label in self.labels_hello_hiho],
-            [
-                True,  # sil
-                False,  # k
-                False,  # o
-                False,  # N
-                False,  # n
-                False,  # i
-                False,  # ch
-                False,  # i
-                False,  # w
-                False,  # a
-                True,  # pau
-                False,  # h
-                False,  # i
-                False,  # h
-                False,  # o
-                False,  # d
-                False,  # e
-                False,  # s
-                False,  # u
-                True,  # sil
-            ],
-        )
-
-    def test_feature(self) -> None:
-        """Label に含まれる features をテスト"""
-        self.assertEqual(
-            [contexts_to_feature(label.contexts) for label in self.labels_hello_hiho],
-            self.test_case_hello_hiho,
-        )
+def test_label_phoneme() -> None:
+    """Label に含まれる音素をテスト"""
+    assert (
+        " ".join([label.phoneme for label in labels_hello_hiho])
+        == "sil k o N n i ch i w a pau h i h o d e s U sil"
+    )
 
 
-class TestMoraLabel(TestBaseLabels):
-    def setUp(self) -> None:
-        super().setUp()
-        # contexts["a2"] == "1" ko
-        self.mora_hello_1 = MoraLabel(
-            consonant=self.labels_hello_hiho[1], vowel=self.labels_hello_hiho[2]
-        )
-        # contexts["a2"] == "2" N
-        self.mora_hello_2 = MoraLabel(consonant=None, vowel=self.labels_hello_hiho[3])
-        # contexts["a2"] == "3" ni
-        self.mora_hello_3 = MoraLabel(
-            consonant=self.labels_hello_hiho[4], vowel=self.labels_hello_hiho[5]
-        )
-        # contexts["a2"] == "4" chi
-        self.mora_hello_4 = MoraLabel(
-            consonant=self.labels_hello_hiho[6], vowel=self.labels_hello_hiho[7]
-        )
-        # contexts["a2"] == "5" wa
-        self.mora_hello_5 = MoraLabel(
-            consonant=self.labels_hello_hiho[8], vowel=self.labels_hello_hiho[9]
-        )
-        # contexts["a2"] == "1" hi
-        self.mora_hiho_1 = MoraLabel(
-            consonant=self.labels_hello_hiho[11], vowel=self.labels_hello_hiho[12]
-        )
-        # contexts["a2"] == "2" ho
-        self.mora_hiho_2 = MoraLabel(
-            consonant=self.labels_hello_hiho[13], vowel=self.labels_hello_hiho[14]
-        )
-        # contexts["a2"] == "3" de
-        self.mora_hiho_3 = MoraLabel(
-            consonant=self.labels_hello_hiho[15], vowel=self.labels_hello_hiho[16]
-        )
-        # contexts["a2"] == "1" sU
-        self.mora_hiho_4 = MoraLabel(
-            consonant=self.labels_hello_hiho[17], vowel=self.labels_hello_hiho[18]
-        )
-
-    def test_phonemes(self) -> None:
-        """MoraLabel に含まれる音素系列をテスト"""
-        self.assertEqual(jointed_phonemes(self.mora_hello_1), "ko")
-        self.assertEqual(jointed_phonemes(self.mora_hello_2), "N")
-        self.assertEqual(jointed_phonemes(self.mora_hello_3), "ni")
-        self.assertEqual(jointed_phonemes(self.mora_hello_4), "chi")
-        self.assertEqual(jointed_phonemes(self.mora_hello_5), "wa")
-        self.assertEqual(jointed_phonemes(self.mora_hiho_1), "hi")
-        self.assertEqual(jointed_phonemes(self.mora_hiho_2), "ho")
-        self.assertEqual(jointed_phonemes(self.mora_hiho_3), "de")
-        self.assertEqual(jointed_phonemes(self.mora_hiho_4), "sU")
-
-    def test_features(self) -> None:
-        """MoraLabel に含まれる features をテスト"""
-        expects = self.test_case_hello_hiho
-        self.assertEqual(features(self.mora_hello_1), expects[1:3])
-        self.assertEqual(features(self.mora_hello_2), expects[3:4])
-        self.assertEqual(features(self.mora_hello_3), expects[4:6])
-        self.assertEqual(features(self.mora_hello_4), expects[6:8])
-        self.assertEqual(features(self.mora_hello_5), expects[8:10])
-        self.assertEqual(features(self.mora_hiho_1), expects[11:13])
-        self.assertEqual(features(self.mora_hiho_2), expects[13:15])
-        self.assertEqual(features(self.mora_hiho_3), expects[15:17])
-        self.assertEqual(features(self.mora_hiho_4), expects[17:19])
+def test_label_is_pause() -> None:
+    """Label のポーズ判定をテスト"""
+    assert [label.is_pause() for label in labels_hello_hiho] == [
+        True,  # sil
+        False,  # k
+        False,  # o
+        False,  # N
+        False,  # n
+        False,  # i
+        False,  # ch
+        False,  # i
+        False,  # w
+        False,  # a
+        True,  # pau
+        False,  # h
+        False,  # i
+        False,  # h
+        False,  # o
+        False,  # d
+        False,  # e
+        False,  # s
+        False,  # u
+        True,  # sil
+    ]
 
 
-class TestAccentPhraseLabel(TestBaseLabels):
-    def setUp(self) -> None:
-        super().setUp()
-        # TODO: ValueErrorを吐く作為的ではない自然な例の模索
-        # 存在しないなら放置でよい
-        self.accent_phrase_hello = AccentPhraseLabel.from_labels(
-            self.labels_hello_hiho[1:10]
-        )
-        self.accent_phrase_hiho = AccentPhraseLabel.from_labels(
-            self.labels_hello_hiho[11:19]
-        )
-
-    def test_accent(self) -> None:
-        """AccentPhraseLabel に含まれるアクセント位置をテスト"""
-        self.assertEqual(self.accent_phrase_hello.accent, 5)
-        self.assertEqual(self.accent_phrase_hiho.accent, 1)
-
-    def test_phonemes(self) -> None:
-        """AccentPhraseLabel に含まれる音素系列をテスト"""
-        outputs_hello = space_jointed_phonemes(self.accent_phrase_hello)
-        outputs_hiho = space_jointed_phonemes(self.accent_phrase_hiho)
-        self.assertEqual(outputs_hello, "k o N n i ch i w a")
-        self.assertEqual(outputs_hiho, "h i h o d e s U")
-
-    def test_features(self) -> None:
-        """AccentPhraseLabel に含まれる features をテスト"""
-        expects = self.test_case_hello_hiho
-        self.assertEqual(features(self.accent_phrase_hello), expects[1:10])
-        self.assertEqual(features(self.accent_phrase_hiho), expects[11:19])
+def test_label_feature() -> None:
+    """Label に含まれる features をテスト"""
+    assert [
+        contexts_to_feature(label.contexts) for label in labels_hello_hiho
+    ] == test_case_hello_hiho
 
 
-class TestBreathGroupLabel(TestBaseLabels):
-    def setUp(self) -> None:
-        super().setUp()
-        self.breath_group_hello = BreathGroupLabel.from_labels(
-            self.labels_hello_hiho[1:10]
-        )
-        self.breath_group_hiho = BreathGroupLabel.from_labels(
-            self.labels_hello_hiho[11:19]
-        )
-
-    def test_phonemes(self) -> None:
-        """BreathGroupLabel に含まれる音素系列をテスト"""
-        outputs_hello = space_jointed_phonemes(self.breath_group_hello)
-        outputs_hiho = space_jointed_phonemes(self.breath_group_hiho)
-        self.assertEqual(outputs_hello, "k o N n i ch i w a")
-        self.assertEqual(outputs_hiho, "h i h o d e s U")
-
-    def test_features(self) -> None:
-        """BreathGroupLabel に含まれる features をテスト"""
-        expects = self.test_case_hello_hiho
-        self.assertEqual(features(self.breath_group_hello), expects[1:10])
-        self.assertEqual(features(self.breath_group_hiho), expects[11:19])
+# contexts["a2"] == "1" ko
+mora_hello_1 = MoraLabel(consonant=labels_hello_hiho[1], vowel=labels_hello_hiho[2])
+# contexts["a2"] == "2" N
+mora_hello_2 = MoraLabel(consonant=None, vowel=labels_hello_hiho[3])
+# contexts["a2"] == "3" ni
+mora_hello_3 = MoraLabel(consonant=labels_hello_hiho[4], vowel=labels_hello_hiho[5])
+# contexts["a2"] == "4" chi
+mora_hello_4 = MoraLabel(consonant=labels_hello_hiho[6], vowel=labels_hello_hiho[7])
+# contexts["a2"] == "5" wa
+mora_hello_5 = MoraLabel(consonant=labels_hello_hiho[8], vowel=labels_hello_hiho[9])
+# contexts["a2"] == "1" hi
+mora_hiho_1 = MoraLabel(consonant=labels_hello_hiho[11], vowel=labels_hello_hiho[12])
+# contexts["a2"] == "2" ho
+mora_hiho_2 = MoraLabel(consonant=labels_hello_hiho[13], vowel=labels_hello_hiho[14])
+# contexts["a2"] == "3" de
+mora_hiho_3 = MoraLabel(consonant=labels_hello_hiho[15], vowel=labels_hello_hiho[16])
+# contexts["a2"] == "1" sU
+mora_hiho_4 = MoraLabel(consonant=labels_hello_hiho[17], vowel=labels_hello_hiho[18])
 
 
-class TestUtteranceLabel(TestBaseLabels):
-    def setUp(self) -> None:
-        super().setUp()
-        self.utterance_hello_hiho = UtteranceLabel.from_labels(self.labels_hello_hiho)
-
-    def test_phonemes(self) -> None:
-        """UtteranceLabel に含まれる音素系列をテスト"""
-        outputs_hello_hiho = space_jointed_phonemes(self.utterance_hello_hiho)
-        expects_hello_hiho = "sil k o N n i ch i w a pau h i h o d e s U sil"
-        self.assertEqual(outputs_hello_hiho, expects_hello_hiho)
-
-    def test_features(self) -> None:
-        """UtteranceLabel に含まれる features をテスト"""
-        self.assertEqual(features(self.utterance_hello_hiho), self.test_case_hello_hiho)
+def test_mora_label_phonemes() -> None:
+    """MoraLabel に含まれる音素系列をテスト"""
+    assert jointed_phonemes(mora_hello_1) == "ko"
+    assert jointed_phonemes(mora_hello_2) == "N"
+    assert jointed_phonemes(mora_hello_3) == "ni"
+    assert jointed_phonemes(mora_hello_4) == "chi"
+    assert jointed_phonemes(mora_hello_5) == "wa"
+    assert jointed_phonemes(mora_hiho_1) == "hi"
+    assert jointed_phonemes(mora_hiho_2) == "ho"
+    assert jointed_phonemes(mora_hiho_3) == "de"
+    assert jointed_phonemes(mora_hiho_4) == "sU"
 
 
-class TestMoraToText(TestCase):
-    def test_voice(self) -> None:
-        self.assertEqual(mora_to_text("a"), "ア")
-        self.assertEqual(mora_to_text("i"), "イ")
-        self.assertEqual(mora_to_text("ka"), "カ")
-        self.assertEqual(mora_to_text("N"), "ン")
-        self.assertEqual(mora_to_text("cl"), "ッ")
-        self.assertEqual(mora_to_text("gye"), "ギェ")
-        self.assertEqual(mora_to_text("ye"), "イェ")
-        self.assertEqual(mora_to_text("wo"), "ウォ")
+def test_mora_label_features() -> None:
+    """MoraLabel に含まれる features をテスト"""
+    expects = test_case_hello_hiho
+    assert features(mora_hello_1) == expects[1:3]
+    assert features(mora_hello_2) == expects[3:4]
+    assert features(mora_hello_3) == expects[4:6]
+    assert features(mora_hello_4) == expects[6:8]
+    assert features(mora_hello_5) == expects[8:10]
+    assert features(mora_hiho_1) == expects[11:13]
+    assert features(mora_hiho_2) == expects[13:15]
+    assert features(mora_hiho_3) == expects[15:17]
+    assert features(mora_hiho_4) == expects[17:19]
 
-    def test_unvoice(self) -> None:
-        self.assertEqual(mora_to_text("A"), "ア")
-        self.assertEqual(mora_to_text("I"), "イ")
-        self.assertEqual(mora_to_text("kA"), "カ")
-        self.assertEqual(mora_to_text("gyE"), "ギェ")
-        self.assertEqual(mora_to_text("yE"), "イェ")
-        self.assertEqual(mora_to_text("wO"), "ウォ")
 
-    def test_invalid_mora(self) -> None:
-        """変なモーラが来ても例外を投げない"""
-        self.assertEqual(mora_to_text("x"), "x")
-        self.assertEqual(mora_to_text(""), "")
+# TODO: ValueErrorを吐く作為的ではない自然な例の模索
+# 存在しないなら放置でよい
+accent_phrase_hello = AccentPhraseLabel.from_labels(labels_hello_hiho[1:10])
+accent_phrase_hiho = AccentPhraseLabel.from_labels(labels_hello_hiho[11:19])
+
+
+def test_accentphrase_accent() -> None:
+    """AccentPhraseLabel に含まれるアクセント位置をテスト"""
+    assert accent_phrase_hello.accent == 5
+    assert accent_phrase_hiho.accent == 1
+
+
+def test_accentphrase_phonemes() -> None:
+    """AccentPhraseLabel に含まれる音素系列をテスト"""
+    outputs_hello = space_jointed_phonemes(accent_phrase_hello)
+    outputs_hiho = space_jointed_phonemes(accent_phrase_hiho)
+    assert outputs_hello == "k o N n i ch i w a"
+    assert outputs_hiho == "h i h o d e s U"
+
+
+def test_accentphrase_features() -> None:
+    """AccentPhraseLabel に含まれる features をテスト"""
+    expects = test_case_hello_hiho
+    assert features(accent_phrase_hello) == expects[1:10]
+    assert features(accent_phrase_hiho) == expects[11:19]
+
+
+breath_group_hello = BreathGroupLabel.from_labels(labels_hello_hiho[1:10])
+breath_group_hiho = BreathGroupLabel.from_labels(labels_hello_hiho[11:19])
+
+
+def test_breathgroup_phonemes() -> None:
+    """BreathGroupLabel に含まれる音素系列をテスト"""
+    outputs_hello = space_jointed_phonemes(breath_group_hello)
+    outputs_hiho = space_jointed_phonemes(breath_group_hiho)
+    assert outputs_hello == "k o N n i ch i w a"
+    assert outputs_hiho == "h i h o d e s U"
+
+
+def test_breathgroup_features() -> None:
+    """BreathGroupLabel に含まれる features をテスト"""
+    expects = test_case_hello_hiho
+    assert features(breath_group_hello) == expects[1:10]
+    assert features(breath_group_hiho) == expects[11:19]
+
+
+utterance_hello_hiho = UtteranceLabel.from_labels(labels_hello_hiho)
+
+
+def test_utterance_phonemes() -> None:
+    """UtteranceLabel に含まれる音素系列をテスト"""
+    outputs_hello_hiho = space_jointed_phonemes(utterance_hello_hiho)
+    expects_hello_hiho = "sil k o N n i ch i w a pau h i h o d e s U sil"
+    assert outputs_hello_hiho == expects_hello_hiho
+
+
+def test_utterance_features() -> None:
+    """UtteranceLabel に含まれる features をテスト"""
+    assert features(utterance_hello_hiho) == test_case_hello_hiho
+
+
+def test_voice() -> None:
+    assert mora_to_text("a") == "ア"
+    assert mora_to_text("i") == "イ"
+    assert mora_to_text("ka") == "カ"
+    assert mora_to_text("N") == "ン"
+    assert mora_to_text("cl") == "ッ"
+    assert mora_to_text("gye") == "ギェ"
+    assert mora_to_text("ye") == "イェ"
+    assert mora_to_text("wo") == "ウォ"
+
+
+def test_unvoice() -> None:
+    assert mora_to_text("A") == "ア"
+    assert mora_to_text("I") == "イ"
+    assert mora_to_text("kA") == "カ"
+    assert mora_to_text("gyE") == "ギェ"
+    assert mora_to_text("yE") == "イェ"
+    assert mora_to_text("wO") == "ウォ"
+
+
+def test_invalid_mora() -> None:
+    """変なモーラが来ても例外を投げない"""
+    assert mora_to_text("x") == "x"
+    assert mora_to_text("") == ""
 
 
 def _gen_mora(text: str, consonant: str | None, vowel: str) -> Mora:


### PR DESCRIPTION
## 内容
tts pipeline テストを pytest 化してリファクタリングすることを提案します。  

## 関連 Issue
無し