### PR TITLE
整理: Workflow での Python バージョンハードコードを変数化

### DIFF
--- a/.github/workflows/test-engine-container.yml
+++ b/.github/workflows/test-engine-container.yml
@@ -18,6 +18,7 @@ on:
 
 env:
   IMAGE_NAME: ${{ vars.DOCKERHUB_USERNAME }}/voicevox_engine
+  PYTHON_VERSION: "3.11.3"
   VERSION: |- # version指定時はversionを、それ以外はタグ名を使用
     ${{ (github.event.inputs || inputs).version }}
 
@@ -43,7 +44,7 @@ jobs:
       - name: <Setup> Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11.3"
+          python-version: ${{ env.PYTHON_VERSION }}
           cache: pip
 
       - name: <Setup> Install Python dependencies

--- a/.github/workflows/test-engine-package.yml
+++ b/.github/workflows/test-engine-package.yml
@@ -21,12 +21,12 @@ on:
         required: false
 
 env:
+  PYTHON_VERSION: "3.11.3"
   REPO_URL:
     |- # repo_url指定時はrepo_urlを、それ以外はgithubのリポジトリURLを使用
     ${{ (github.event.inputs || inputs).repo_url || format('{0}/{1}', github.server_url, github.repository) }}
   VERSION: |- # version指定時はversionを、それ以外はタグ名を使用
     ${{ (github.event.inputs || inputs).version }}
-
 defaults:
   run:
     shell: bash
@@ -65,7 +65,7 @@ jobs:
       - name: <Setup> Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11.3"
+          python-version: ${{ env.PYTHON_VERSION }}
           cache: pip
 
       - name: <Setup> Download ENGINE package

--- a/.github/workflows/test-engine-package.yml
+++ b/.github/workflows/test-engine-package.yml
@@ -27,6 +27,7 @@ env:
     ${{ (github.event.inputs || inputs).repo_url || format('{0}/{1}', github.server_url, github.repository) }}
   VERSION: |- # version指定時はversionを、それ以外はタグ名を使用
     ${{ (github.event.inputs || inputs).version }}
+
 defaults:
   run:
     shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,13 +11,15 @@ defaults:
   run:
     shell: bash
 
+env:
+  PYTHON_VERSION: "3.11.3"
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-20.04, macos-latest, windows-latest]
-        python: ["3.11.3"]
 
     steps:
       - name: <Setup> Check out the repository
@@ -26,7 +28,7 @@ jobs:
       - name: <Setup> Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python }}
+          python-version: ${{ env.PYTHON_VERSION }}
           cache: pip
 
       - name: <Setup> Install Python dependencies


### PR DESCRIPTION
## 内容
一部の workflow ファイルは Python バージョンをハードコードして指定している。  
これは Python バージョンアップ時の変更忘れを招く危険性がある。  
GitHub Actions は `env` 機能により workflow ファイル冒頭で環境変数的に値を指定できる。これを用いれば全ての workflow ファイルで同じ形式のPython バージョン指定が可能であり、変更忘れの確率を大きく下げられる。  

このような背景から、Workflow での Python バージョンハードコードを変数化するリファクタリングを提案します。  

なお、この実装過程で不要な matrix 化が発見されたため `env` で代替した。  

## 関連 Issue
無し