### PR TITLE
整理: workflow の冗長な記述を削除

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -25,19 +25,16 @@ jobs:
         uses: actions/checkout@v4
 
       - name: <Setup> Set up Python
-        id: setup-python
         uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: pip
 
       - name: <Setup> Install Python dependencies
-        run: |
-          pip install -r requirements.txt
+        run: pip install -r requirements.txt
 
       - name: <Build> Make documents
-        run: |
-          PYTHONPATH=. python build_util/make_docs.py
+        run: PYTHONPATH=. python build_util/make_docs.py
 
       - name: <Deploy> Deploy documents to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/build-engine-package.yml
+++ b/.github/workflows/build-engine-package.yml
@@ -107,8 +107,7 @@ jobs:
     steps:
       - name: <Setup> Declare variables
         id: vars
-        run: |
-          echo "package_name=voicevox_engine-${{ matrix.target }}-${{ needs.config.outputs.version }}" >> "$GITHUB_OUTPUT"
+        run: echo "package_name=voicevox_engine-${{ matrix.target }}-${{ needs.config.outputs.version }}" >> "$GITHUB_OUTPUT"
 
       - name: <Setup> Check out the repository
         uses: actions/checkout@v4
@@ -118,8 +117,7 @@ jobs:
       #       so you need to install GNU 'sed' and 'split'.
       - name: <Setup> Install dependencies (macOS)
         if: startsWith(matrix.os, 'macos-')
-        run: |
-          brew install gnu-sed coreutils
+        run: brew install gnu-sed coreutils
 
       # ONNX Runtime providersとCUDA周りをリンクするために使う
       - name: <Setup> Install ONNX Runtime dependencies (Linux)
@@ -282,7 +280,6 @@ jobs:
 
       # Python install path of windows: C:/hostedtoolcache/windows/Python
       - name: <Setup> Set up Python
-        id: setup-python
         uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
@@ -552,21 +549,18 @@ jobs:
 
       - name: <Setup> Set @rpath to @executable_path
         if: startsWith(matrix.os, 'macos-')
-        run: |
-          install_name_tool -add_rpath @executable_path/. dist/run/run
+        run: install_name_tool -add_rpath @executable_path/. dist/run/run
 
       - name: <Build> Code signing
         if: github.event.inputs.code_signing == 'true' && startsWith(matrix.os, 'windows-')
-        run: |
-          bash build_util/codesign.bash "dist/run/run.exe"
+        run: bash build_util/codesign.bash "dist/run/run.exe"
         env:
           ESIGNERCKA_USERNAME: ${{ secrets.ESIGNERCKA_USERNAME }}
           ESIGNERCKA_PASSWORD: ${{ secrets.ESIGNERCKA_PASSWORD }}
           ESIGNERCKA_TOTP_SECRET: ${{ secrets.ESIGNERCKA_TOTP_SECRET }}
 
       - name: <Build> Rename artifact directory to archive
-        run: |
-          mv dist/run/ "${{ matrix.target }}/"
+        run: mv dist/run/ "${{ matrix.target }}/"
 
       # 7z archives
       - name: <Build> Create 7z archives
@@ -599,8 +593,7 @@ jobs:
           commit: ${{ github.sha }}
 
       - name: <Setup> Clean 7z archives to reduce disk usage
-        run: |
-          rm -f ${{ steps.vars.outputs.package_name }}.7z.*
+        run: rm -f ${{ steps.vars.outputs.package_name }}.7z.*
 
       # VVPP archives
       - name: <Build> Create VVPP archives

--- a/.github/workflows/test-engine-container.yml
+++ b/.github/workflows/test-engine-container.yml
@@ -47,8 +47,7 @@ jobs:
           cache: pip
 
       - name: <Setup> Install Python dependencies
-        run: |
-          pip install -r requirements-test.txt
+        run: pip install -r requirements-test.txt
 
       - name: <Setup> Declare variables
         id: docker_vars

--- a/.github/workflows/test-engine-package.yml
+++ b/.github/workflows/test-engine-package.yml
@@ -81,8 +81,7 @@ jobs:
         run: chmod +x dist/run
 
       - name: <Setup> Install Python test dependencies
-        run: |
-          pip install -r requirements-test.txt
+        run: pip install -r requirements-test.txt
 
       - name: <Test> Test ENGINE package
         run: python build_util/check_release_build.py --dist_dir dist/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,11 +1,6 @@
 name: test
 
-on:
-  push:
-  pull_request:
-    branches:
-      - "**"
-  workflow_dispatch:
+on: [push, pull_request, workflow_dispatch]
 
 defaults:
   run:
@@ -60,6 +55,7 @@ jobs:
 
       - name: <Test> Test codes and coverage
         run: coverage run --omit=test/* -m pytest
+
       - name: <Deploy> Submit coverage results to Coveralls
         if: matrix.os == 'ubuntu-20.04'
         run: coveralls --service=github
@@ -67,7 +63,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check licenses
-        shell: bash
         run: |
           OUTPUT_LICENSE_JSON_PATH=/dev/null \
           bash build_util/create_venv_and_generate_licenses.bash
@@ -94,4 +89,3 @@ jobs:
         run: |
           bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
           ./actionlint
-        shell: bash


### PR DESCRIPTION
## 内容
workflow の冗長な記述の削除するリファクタリングを提案します。  

削除対象となった記述と理由は以下である：  

- ワンライナーの `run: |` : bash 最小化の方向性であるため、複数行を前提とする必要無し
- `id: setup-python` : 参照されない ID は不要
- `branches:` : 全PR受け入れなら条件文は冗長
- `on: [ ... ]` : テストは全条件で実行されるため、条件文を想定して ` xxx:` 記法とする必要無し

## 関連 Issue
無し