### PR TITLE
廃止: CI pip 環境更新を削除

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,9 +30,7 @@ jobs:
           cache: pip
 
       - name: <Setup> Install Python dependencies
-        run: |
-          python -m pip install --upgrade pip setuptools wheel
-          python -m pip install -r requirements-test.txt
+        run: python -m pip install -r requirements-test.txt
 
       - name: <Test> Validate poetry.lock
         run: |


### PR DESCRIPTION
## 内容
CI での Python 依存パッケージインストールにおいて、pip 環境の更新（`python -m pip install --upgrade pip setuptools wheel`）をおこなうケースが 1 箇所だけ存在する。  
CI は固定環境での安定したテスト・ビルドが目的であるため、`pip` / `setuptools` / `wheel` であってもバージョン指定無しにアップグレードを掛けるべきではない。  

このような背景から、CI pip 環境更新コマンドを削除して環境更新を廃止することを提案します。  

## 関連 Issue
無し