### PR TITLE
整理: Pythonセットアップのアーキテクチャ指定を削除

### DIFF
--- a/.github/workflows/build-engine-package.yml
+++ b/.github/workflows/build-engine-package.yml
@@ -286,7 +286,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-          architecture: ${{ matrix.architecture }}
           cache: pip
 
       - name: <Setup> Install Python dependencies


### PR DESCRIPTION
## 内容
概要: Pythonセットアップのアーキテクチャ指定を削除してリファクタリング  

ビルド CI において Python 環境の導入には [`actions/setup-python`](https://github.com/actions/setup-python) が用いられている。  
この Action は `architecture` 引数によって x86 と x64 を選択でき、ENGINE のビルド CI では `matrix.architecture` 変数でこの引数を指定している。  
しかし `matrix.architecture` は全条件で `x64` であり、恐らく今後も `x86` 指定は増えない。  
ゆえにこの引数は冗長であり、削除できる。削除すれば他箇所の `actions/setup-python` 利用と統一でき、コード見通しが改善する。また将来的な共通 composite action 化に繋がる。  

このような背景から、Pythonセットアップのアーキテクチャ指定を削除するリファクタリングを提案します。  

## 関連 Issue
無し