### PR TITLE
整理:  無効化されていた query テストを有効化

### DIFF
--- a/test/e2e/single_api/tts_pipeline/__snapshots__/test_audio_query_from_preset/test_post_audio_query_from_preset_200.json
+++ b/test/e2e/single_api/tts_pipeline/__snapshots__/test_audio_query_from_preset/test_post_audio_query_from_preset_200.json
@@ -1,0 +1,60 @@
+{
+  "accent_phrases": [
+    {
+      "accent": 1,
+      "is_interrogative": false,
+      "moras": [
+        {
+          "consonant": "t",
+          "consonant_length": 10001.31,
+          "pitch": 10002.38,
+          "text": "テ",
+          "vowel": "e",
+          "vowel_length": 9999.88
+        },
+        {
+          "consonant": "s",
+          "consonant_length": 10001.19,
+          "pitch": 0.0,
+          "text": "ス",
+          "vowel": "U",
+          "vowel_length": 9999.38
+        },
+        {
+          "consonant": "t",
+          "consonant_length": 10001.31,
+          "pitch": 10003.19,
+          "text": "ト",
+          "vowel": "o",
+          "vowel_length": 10000.88
+        },
+        {
+          "consonant": "d",
+          "consonant_length": 9999.75,
+          "pitch": 10000.62,
+          "text": "デ",
+          "vowel": "e",
+          "vowel_length": 9999.88
+        },
+        {
+          "consonant": "s",
+          "consonant_length": 10001.19,
+          "pitch": 0.0,
+          "text": "ス",
+          "vowel": "U",
+          "vowel_length": 9999.38
+        }
+      ],
+      "pause_mora": null
+    }
+  ],
+  "intonationScale": 1.2,
+  "kana": "テ'_ストデ_ス",
+  "outputSamplingRate": 24000,
+  "outputStereo": false,
+  "pitchScale": 0.9,
+  "postPhonemeLength": 5.0,
+  "prePhonemeLength": 20.0,
+  "speedScale": 1.1,
+  "volumeScale": 1.3
+}

--- a/test/e2e/single_api/tts_pipeline/test_audio_query_from_preset.py
+++ b/test/e2e/single_api/tts_pipeline/test_audio_query_from_preset.py
@@ -4,7 +4,6 @@
 
 from test.utility import round_floats
 
-import pytest
 from fastapi.testclient import TestClient
 from syrupy.assertion import SnapshotAssertion
 

--- a/test/e2e/single_api/tts_pipeline/test_audio_query_from_preset.py
+++ b/test/e2e/single_api/tts_pipeline/test_audio_query_from_preset.py
@@ -9,12 +9,28 @@ from fastapi.testclient import TestClient
 from syrupy.assertion import SnapshotAssertion
 
 
-@pytest.mark.skip(reason="200の前提として別APIを要するプリセット登録が必要だから")
 def test_post_audio_query_from_preset_200(
     client: TestClient, snapshot_json: SnapshotAssertion
 ) -> None:
+    # Setup
+    # NOTE: 事前準備用のプリセット API が壊れた場合、このテストが偽陽性で failed になる可能性がある
+    preset = {
+        "id": 8888,
+        "name": "test_preset",
+        "speaker_uuid": "123-456-789-234",
+        "style_id": 9999,
+        "speedScale": 1.1,
+        "pitchScale": 0.9,
+        "intonationScale": 1.2,
+        "volumeScale": 1.3,
+        "prePhonemeLength": 20,
+        "postPhonemeLength": 5,
+    }
+    client.post("/add_preset", params={}, json=preset)
+
+    # Test
     response = client.post(
-        "/audio_query_from_preset", params={"text": "テストです", "preset_id": 0}
+        "/audio_query_from_preset", params={"text": "テストです", "preset_id": 8888}
     )
     assert response.status_code == 200
     assert snapshot_json == round_floats(response.json(), 2)


### PR DESCRIPTION
## 内容
現在の一部テストでは E2E single API テスト中に事前準備として他 API を呼び出す必要がある。これを避けるためにテストを無効化している API もある。  
理想形は DI で事前準備を完了させる形である。しかし理想形になるまで妥協せずテストスキップしておくと、かえって全体利益を最大化できないのも事実である。  
今回対象とした query API は事前準備にプリセット API が必要となるが、このプリセット API はすでに E2E single API テストで動作確認が取れている。理想形ではないが、プリセット API を呼び出して偽陽性 failed を起こす危険性は非常に低い。すなわち、有効化してもメリットがデメリットを上回る。  

このような背景から、無効化されていた query テストを有効化することを提案します。  

## 関連 Issue
無し