### PR TITLE
整理: 合成系の `HTTPException` をドメインから移動

### DIFF
--- a/voicevox_engine/app/routers/tts_pipeline.py
+++ b/voicevox_engine/app/routers/tts_pipeline.py
@@ -30,7 +30,10 @@ from voicevox_engine.tts_pipeline.connect_base64_waves import (
     connect_base64_waves,
 )
 from voicevox_engine.tts_pipeline.kana_converter import create_kana, parse_kana
-from voicevox_engine.tts_pipeline.tts_engine import SingInvalidInput, TTSEngineManager
+from voicevox_engine.tts_pipeline.tts_engine import (
+    TalkSingInvalidInputError,
+    TTSEngineManager,
+)
 from voicevox_engine.utility.path_utility import delete_file
 
 
@@ -340,7 +343,7 @@ def generate_tts_pipeline_router(
             phonemes, f0, volume = engine.create_sing_phoneme_and_f0_and_volume(
                 score, style_id
             )
-        except SingInvalidInput as e:
+        except TalkSingInvalidInputError as e:
             raise HTTPException(status_code=400, detail=str(e))
 
         return FrameAudioQuery(
@@ -368,7 +371,7 @@ def generate_tts_pipeline_router(
             return engine.create_sing_volume_from_phoneme_and_f0(
                 score, frame_audio_query.phonemes, frame_audio_query.f0, style_id
             )
-        except SingInvalidInput as e:
+        except TalkSingInvalidInputError as e:
             raise HTTPException(status_code=400, detail=str(e))
 
     @router.post(
@@ -394,7 +397,7 @@ def generate_tts_pipeline_router(
         engine = tts_engines.get_engine(core_version)
         try:
             wave = engine.frame_synthsize_wave(query, style_id)
-        except SingInvalidInput as e:
+        except TalkSingInvalidInputError as e:
             raise HTTPException(status_code=400, detail=str(e))
 
         with NamedTemporaryFile(delete=False) as f:

--- a/voicevox_engine/cancellable_engine.py
+++ b/voicevox_engine/cancellable_engine.py
@@ -12,14 +12,18 @@ from pathlib import Path
 from tempfile import NamedTemporaryFile
 
 import soundfile
-
-# FIXME: remove FastAPI dependency
-from fastapi import HTTPException, Request
+from fastapi import Request
 
 from .core.core_initializer import initialize_cores
 from .metas.Metas import StyleId
 from .model import AudioQuery
 from .tts_pipeline.tts_engine import make_tts_engines_from_cores
+
+
+class CancellableEngineInternalError(Exception):
+    """キャンセル可能エンジンの内部エラー"""
+
+    pass
 
 
 class CancellableEngine:
@@ -173,11 +177,9 @@ class CancellableEngine:
                 audio_file_name = f_name
             else:
                 # ここには来ないはず
-                raise HTTPException(status_code=500, detail="不正な値が生成されました")
+                raise CancellableEngineInternalError("不正な値が生成されました")
         except EOFError:
-            raise HTTPException(
-                status_code=500, detail="既にサブプロセスは終了されています"
-            )
+            raise CancellableEngineInternalError("既にサブプロセスは終了されています")
         except Exception:
             self.finalize_con(request, proc, sub_proc_con1)
             raise

--- a/voicevox_engine/tts_pipeline/tts_engine.py
+++ b/voicevox_engine/tts_pipeline/tts_engine.py
@@ -31,8 +31,8 @@ UPSPEAK_PITCH_ADD = 0.3
 UPSPEAK_PITCH_MAX = 6.5
 
 
-class SingInvalidInput(Exception):
-    """Sing の不正な入力エラー"""
+class TalkSingInvalidInputError(Exception):
+    """Talk と Sing の不正な入力エラー"""
 
     pass
 
@@ -272,7 +272,7 @@ def calc_phoneme_lengths(
             # 最初のノートは子音長が0の、pauである必要がある
             if i == 0 and consonant_lengths[i] != 0:
                 msg = f"consonant_lengths[0] must be 0, but {consonant_lengths[0]}"
-                raise SingInvalidInput(msg)
+                raise TalkSingInvalidInputError(msg)
 
             next_consonant_length = consonant_lengths[i + 1]
             note_duration = note_durations[i]
@@ -339,7 +339,7 @@ def notes_to_keys_and_phonemes(
         if note.lyric == "":
             if note.key is not None:
                 msg = "lyricが空文字列の場合、keyはnullである必要があります。"
-                raise SingInvalidInput(msg)
+                raise TalkSingInvalidInputError(msg)
             note_lengths.append(note.frame_length)
             note_consonants.append(-1)
             note_vowels.append(0)  # pau
@@ -348,7 +348,7 @@ def notes_to_keys_and_phonemes(
         else:
             if note.key is None:
                 msg = "keyがnullの場合、lyricは空文字列である必要があります。"
-                raise SingInvalidInput(msg)
+                raise TalkSingInvalidInputError(msg)
 
             # TODO: 1ノートに複数のモーラがある場合の処理
             mora_phonemes = mora_kana_to_mora_phonemes.get(
@@ -358,7 +358,7 @@ def notes_to_keys_and_phonemes(
             )
             if mora_phonemes is None:
                 msg = f"lyricが不正です: {note.lyric}"
-                raise SingInvalidInput(msg)
+                raise TalkSingInvalidInputError(msg)
 
             consonant, vowel = mora_phonemes
             if consonant is None:
@@ -404,7 +404,7 @@ def frame_query_to_sf_decoder_feature(
     for phoneme in query.phonemes:
         if phoneme.phoneme not in Phoneme._PHONEME_LIST:
             msg = f"phoneme {phoneme.phoneme} is not valid"
-            raise SingInvalidInput(msg)
+            raise TalkSingInvalidInputError(msg)
 
         phonemes.append(Phoneme(phoneme.phoneme).id)
         phoneme_lengths.append(phoneme.frame_length)
@@ -647,7 +647,7 @@ class TTSEngine:
 
         if not all_equals:
             msg = "Scoreから抽出した音素列とFrameAudioQueryから抽出した音素列が一致しません。"
-            raise SingInvalidInput(msg)
+            raise TalkSingInvalidInputError(msg)
 
         # 時間スケールを変更する（音素 → フレーム）
         frame_phonemes = np.repeat(phonemes_array, phoneme_lengths)


### PR DESCRIPTION
## 内容
概要: 合成系の `HTTPException` をドメインから移動してリファクタリング

Sing 機能はリリース優先で実装された経緯があり、現在の ENGINE の実装規約に則っていない箇所が複数ある。  
`HTTPException` のドメインミスマッチはその一例であり、現在でもその状況が続いている。  
Sing に閉じたエラーであるため、Sing 用エラーを定義しこれを router でキャッチすれば最小実装でドメインから `HTTPException` を分離できる。  

また CancellableEngine はごく初期からの実装であり、`HTTPException` のドメイン分離規約がない時代の実装が残っている。これもキャンセル可能合成に閉じたエラーであるため、専用エラーと router キャッチで分離が可能である。  

このような背景から、合成系の `HTTPException` をドメインから移動するリファクタリングを提案します。  

## 関連 Issue
無し