### PR TITLE
整理: latest version 関連を簡略化

### DIFF
--- a/build_util/make_docs.py
+++ b/build_util/make_docs.py
@@ -45,7 +45,6 @@ if __name__ == "__main__":
     app = generate_app(
         tts_engines=tts_engines,
         core_manager=core_manager,
-        latest_core_version="mock",
         setting_loader=SettingHandler(USER_SETTING_PATH),
         preset_manager=PresetManager(  # FIXME: impl MockPresetManager
             preset_path=engine_root() / "presets.yaml",

--- a/run.py
+++ b/run.py
@@ -270,7 +270,6 @@ def main() -> None:
     )
     tts_engines = make_tts_engines_from_cores(core_manager)
     assert len(tts_engines.versions()) != 0, "音声合成エンジンがありません。"
-    latest_core_version = tts_engines.latest_version()
 
     # Cancellable Engine
     enable_cancellable_synthesis: bool = args.enable_cancellable_synthesis
@@ -329,7 +328,6 @@ def main() -> None:
     app = generate_app(
         tts_engines,
         core_manager,
-        latest_core_version,
         setting_loader,
         preset_manager,
         use_dict,

--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -18,7 +18,6 @@ from voicevox_engine.user_dict.user_dict import UserDictionary
 def app_params(tmp_path: Path) -> dict[str, Any]:
     core_manager = initialize_cores(use_gpu=False, enable_mock=True)
     tts_engines = make_tts_engines_from_cores(core_manager)
-    latest_core_version = tts_engines.latest_version()
     setting_loader = SettingHandler(Path("./not_exist.yaml"))
 
     # 隔離されたプリセットの生成
@@ -31,7 +30,6 @@ def app_params(tmp_path: Path) -> dict[str, Any]:
     return {
         "tts_engines": tts_engines,
         "core_manager": core_manager,
-        "latest_core_version": latest_core_version,
         "setting_loader": setting_loader,
         "preset_manager": preset_manager,
         "user_dict": user_dict,

--- a/test/test_core_initializer.py
+++ b/test/test_core_initializer.py
@@ -35,21 +35,6 @@ def test_cores_versions() -> None:
     assert true_versions == versions
 
 
-def test_cores_latest_version() -> None:
-    """CoreManager.latest_version() で最新バージョンを取得できる。"""
-    # Inputs
-    core_manager = CoreManager()
-    core_manager.register_core(CoreAdapter(MockCoreWrapper()), "0.0.1")
-    core_manager.register_core(CoreAdapter(MockCoreWrapper()), "0.0.2")
-    # Expects
-    true_latest_version = "0.0.2"
-    # Outputs
-    latest_version = core_manager.latest_version()
-
-    # Test
-    assert true_latest_version == latest_version
-
-
 def test_cores_get_core_specified() -> None:
     """CoreManager.get_core() で登録済みコアをバージョン指定して取得できる。"""
     # Inputs

--- a/test/tts_pipeline/test_tts_engines.py
+++ b/test/tts_pipeline/test_tts_engines.py
@@ -31,21 +31,6 @@ def test_tts_engines_versions() -> None:
     assert true_versions == versions
 
 
-def test_tts_engines_latest_version() -> None:
-    """TTSEngineManager.latest_version() で最新バージョンを取得できる。"""
-    # Inputs
-    tts_engines = TTSEngineManager()
-    tts_engines.register_engine(MockTTSEngine(), "0.0.1")
-    tts_engines.register_engine(MockTTSEngine(), "0.0.2")
-    # Expects
-    true_latest_version = "0.0.2"
-    # Outputs
-    latest_version = tts_engines.latest_version()
-
-    # Test
-    assert true_latest_version == latest_version
-
-
 def test_tts_engines_get_engine_specified() -> None:
     """TTSEngineManager.get_engine() で登録済み TTS エンジンをバージョン指定して取得できる。"""
     # Inputs

--- a/voicevox_engine/app/application.py
+++ b/voicevox_engine/app/application.py
@@ -30,7 +30,6 @@ from voicevox_engine.utility.path_utility import engine_root, get_save_dir
 def generate_app(
     tts_engines: TTSEngineManager,
     core_manager: CoreManager,
-    latest_core_version: str,
     setting_loader: SettingHandler,
     preset_manager: PresetManager,
     user_dict: UserDictionary,

--- a/voicevox_engine/core/core_initializer.py
+++ b/voicevox_engine/core/core_initializer.py
@@ -30,10 +30,6 @@ class CoreManager:
         """登録されたコアのバージョン一覧を取得する。"""
         return list(self._cores.keys())
 
-    def latest_version(self) -> str:
-        """登録された最新版コアのバージョンを取得する。"""
-        return get_latest_version(self.versions())
-
     def register_core(self, core: CoreAdapter, version: str) -> None:
         """コアを登録する。"""
         self._cores[version] = core
@@ -41,7 +37,7 @@ class CoreManager:
     def get_core(self, version: str | None = None) -> CoreAdapter:
         """指定バージョンのコアを取得する。指定が無い場合、最新バージョンを返す。"""
         if version is None:
-            return self._cores[self.latest_version()]
+            return self._cores[get_latest_version(self.versions())]
         elif version in self._cores:
             return self._cores[version]
 

--- a/voicevox_engine/tts_pipeline/tts_engine.py
+++ b/voicevox_engine/tts_pipeline/tts_engine.py
@@ -694,10 +694,6 @@ class TTSEngineManager:
         """登録されたエンジンのバージョン一覧を取得する。"""
         return list(self._engines.keys())
 
-    def latest_version(self) -> str:
-        """登録された最新版エンジンのバージョンを取得する。"""
-        return get_latest_version(self.versions())
-
     def register_engine(self, engine: TTSEngine, version: str) -> None:
         """エンジンを登録する。"""
         self._engines[version] = engine
@@ -705,7 +701,7 @@ class TTSEngineManager:
     def get_engine(self, version: str | None = None) -> TTSEngine:
         """指定バージョンのエンジンを取得する。指定が無い場合、最新バージョンを返す。"""
         if version is None:
-            return self._engines[self.latest_version()]
+            return self._engines[get_latest_version(self.versions())]
         elif version in self._engines:
             return self._engines[version]
 


### PR DESCRIPTION
## 内容
概要: latest version 関連を簡略化するリファクタリング  

`CoreManager` と `TTSEngineManager` の実装により、`generate_app()` の `latest_core_version` 引数が不要になった。  
これに伴い、`latest_core_version` 取得も不要となり、これが更に `CoreManager` と `TTSEngineManager` の `.latest_version()` 自体を不要にする。  
すなわち、これまでのリファクタリングに基づいて latest version 関連コードの大半を削除可能になった。  

このような背景から、latest version 関連を簡略化するリファクタリングを提案します。  

## 関連 Issue
無し