### PR TITLE
整理: 最新版コア・エンジンの暗示的取得を削除

### DIFF
--- a/run.py
+++ b/run.py
@@ -272,7 +272,7 @@ def main() -> None:
     )
     tts_engines = make_tts_engines_from_cores(core_manager)
     assert len(tts_engines.versions()) != 0, "音声合成エンジンがありません。"
-    latest_core_version = tts_engines.latest_version()
+    latest_core_version = core_manager.latest_version()
 
     # Cancellable Engine
     enable_cancellable_synthesis: bool = args.enable_cancellable_synthesis

--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -18,7 +18,7 @@ from voicevox_engine.user_dict.user_dict import UserDictionary
 def app_params(tmp_path: Path) -> dict[str, Any]:
     core_manager = initialize_cores(use_gpu=False, enable_mock=True)
     tts_engines = make_tts_engines_from_cores(core_manager)
-    latest_core_version = tts_engines.latest_version()
+    latest_core_version = core_manager.latest_version()
     setting_loader = SettingHandler(Path("./not_exist.yaml"))
 
     # 隔離されたプリセットの生成

--- a/test/test_core_initializer.py
+++ b/test/test_core_initializer.py
@@ -97,23 +97,6 @@ def test_cores_get_core_existing() -> None:
     assert true_acquired_core == acquired_core
 
 
-def test_cores_get_core_latest() -> None:
-    """CoreManager.get_core() で最新版コアをバージョン未指定で取得できる。"""
-    # Inputs
-    core_manager = CoreManager()
-    core1 = CoreAdapter(MockCoreWrapper())
-    core2 = CoreAdapter(MockCoreWrapper())
-    core_manager.register_core(core1, "0.0.1")
-    core_manager.register_core(core2, "0.0.2")
-    # Expects
-    true_acquired_core = core2
-    # Outputs
-    acquired_core = core_manager.get_core()
-
-    # Test
-    assert true_acquired_core == acquired_core
-
-
 def test_cores_get_core_missing() -> None:
     """CoreManager.get_core() で存在しないコアを取得しようとするとエラーになる。"""
     # Inputs

--- a/test/test_core_initializer.py
+++ b/test/test_core_initializer.py
@@ -50,8 +50,38 @@ def test_cores_latest_version() -> None:
     assert true_latest_version == latest_version
 
 
-def test_cores_get_core_specified() -> None:
-    """CoreManager.get_core() で登録済みコアをバージョン指定して取得できる。"""
+def test_cores_convert_version_format_non_latest() -> None:
+    """CoreManager.convert_version_format() で明示的バージョンが維持される。"""
+    # Inputs
+    core_manager = CoreManager()
+    api_format_version = "0.0.2"
+    # Expects
+    true_version = "0.0.2"
+    # Outputs
+    version = core_manager.convert_version_format(api_format_version)
+
+    # Test
+    assert true_version == version
+
+
+def test_cores_convert_version_format_latest() -> None:
+    """CoreManager.convert_version_format() で latest 表現が変換される。"""
+    # Inputs
+    core_manager = CoreManager()
+    core_manager.register_core(CoreAdapter(MockCoreWrapper()), "0.0.1")
+    core_manager.register_core(CoreAdapter(MockCoreWrapper()), "0.0.2")
+    api_format_version = None
+    # Expects
+    true_version = "0.0.2"
+    # Outputs
+    version = core_manager.convert_version_format(api_format_version)
+
+    # Test
+    assert true_version == version
+
+
+def test_cores_get_core_existing() -> None:
+    """CoreManager.get_core() で登録済みコアを取得できる。"""
     # Inputs
     core_manager = CoreManager()
     core1 = CoreAdapter(MockCoreWrapper())

--- a/test/tts_pipeline/test_tts_engines.py
+++ b/test/tts_pipeline/test_tts_engines.py
@@ -31,23 +31,8 @@ def test_tts_engines_versions() -> None:
     assert true_versions == versions
 
 
-def test_tts_engines_latest_version() -> None:
-    """TTSEngineManager.latest_version() で最新バージョンを取得できる。"""
-    # Inputs
-    tts_engines = TTSEngineManager()
-    tts_engines.register_engine(MockTTSEngine(), "0.0.1")
-    tts_engines.register_engine(MockTTSEngine(), "0.0.2")
-    # Expects
-    true_latest_version = "0.0.2"
-    # Outputs
-    latest_version = tts_engines.latest_version()
-
-    # Test
-    assert true_latest_version == latest_version
-
-
-def test_tts_engines_get_engine_specified() -> None:
-    """TTSEngineManager.get_engine() で登録済み TTS エンジンをバージョン指定して取得できる。"""
+def test_tts_engines_get_engine_existing() -> None:
+    """TTSEngineManager.get_engine() で登録済み TTS エンジンを取得できる。"""
     # Inputs
     tts_engines = TTSEngineManager()
     tts_engine1 = MockTTSEngine()
@@ -58,23 +43,6 @@ def test_tts_engines_get_engine_specified() -> None:
     true_acquired_tts_engine = tts_engine2
     # Outputs
     acquired_tts_engine = tts_engines.get_engine("0.0.2")
-
-    # Test
-    assert true_acquired_tts_engine == acquired_tts_engine
-
-
-def test_tts_engines_get_engine_latest() -> None:
-    """TTSEngineManager.get_engine() で最新版 TTS エンジンをバージョン未指定で取得できる。"""
-    # Inputs
-    tts_engines = TTSEngineManager()
-    tts_engine1 = MockTTSEngine()
-    tts_engine2 = MockTTSEngine()
-    tts_engines.register_engine(tts_engine1, "0.0.1")
-    tts_engines.register_engine(tts_engine2, "0.0.2")
-    # Expects
-    true_acquired_tts_engine = tts_engine2
-    # Outputs
-    acquired_tts_engine = tts_engines.get_engine()
 
     # Test
     assert true_acquired_tts_engine == acquired_tts_engine

--- a/voicevox_engine/app/routers/engine_info.py
+++ b/voicevox_engine/app/routers/engine_info.py
@@ -34,7 +34,8 @@ def generate_engine_info_router(
     )
     def supported_devices(core_version: str | None = None) -> Response:
         """対応デバイスの一覧を取得します。"""
-        supported_devices = core_manager.get_core(core_version).supported_devices
+        version = core_manager.convert_version_format(core_version)
+        supported_devices = core_manager.get_core(version).supported_devices
         if supported_devices is None:
             raise HTTPException(status_code=422, detail="非対応の機能です。")
         return Response(

--- a/voicevox_engine/app/routers/morphing.py
+++ b/voicevox_engine/app/routers/morphing.py
@@ -52,7 +52,8 @@ def generate_morphing_router(
         プロパティが存在しない場合は、モーフィングが許可されているとみなします。
         返り値のスタイルIDはstring型なので注意。
         """
-        core = core_manager.get_core(core_version)
+        version = core_manager.convert_version_format(core_version)
+        core = core_manager.get_core(version)
 
         try:
             speakers = metas_store.load_combined_metas(core=core)
@@ -94,8 +95,9 @@ def generate_morphing_router(
         指定された2種類のスタイルで音声を合成、指定した割合でモーフィングした音声を得ます。
         モーフィングの割合は`morph_rate`で指定でき、0.0でベースのスタイル、1.0でターゲットのスタイルに近づきます。
         """
-        engine = tts_engines.get_engine(core_version)
-        core = core_manager.get_core(core_version)
+        version = core_manager.convert_version_format(core_version)
+        engine = tts_engines.get_engine(version)
+        core = core_manager.get_core(version)
 
         try:
             speakers = metas_store.load_combined_metas(core=core)

--- a/voicevox_engine/app/routers/speaker.py
+++ b/voicevox_engine/app/routers/speaker.py
@@ -30,7 +30,8 @@ def generate_speaker_router(
     def speakers(
         core_version: str | None = None,
     ) -> list[Speaker]:
-        speakers = metas_store.load_combined_metas(core_manager.get_core(core_version))
+        version = core_manager.convert_version_format(core_version)
+        speakers = metas_store.load_combined_metas(core_manager.get_core(version))
         return filter_speakers_and_styles(speakers, "speaker")
 
     @router.get("/speaker_info", tags=["その他"])
@@ -77,9 +78,11 @@ def generate_speaker_router(
         #       {speaker_uuid_1}/
         #           ...
 
+        version = core_manager.convert_version_format(core_version)
+
         # 該当話者の検索
         speakers = parse_obj_as(
-            list[Speaker], json.loads(core_manager.get_core(core_version).speakers)
+            list[Speaker], json.loads(core_manager.get_core(version).speakers)
         )
         speakers = filter_speakers_and_styles(speakers, speaker_or_singer)
         for i in range(len(speakers)):
@@ -147,7 +150,8 @@ def generate_speaker_router(
     def singers(
         core_version: str | None = None,
     ) -> list[Speaker]:
-        singers = metas_store.load_combined_metas(core_manager.get_core(core_version))
+        version = core_manager.convert_version_format(core_version)
+        singers = metas_store.load_combined_metas(core_manager.get_core(version))
         return filter_speakers_and_styles(singers, "singer")
 
     @router.get("/singer_info", tags=["その他"])
@@ -180,7 +184,8 @@ def generate_speaker_router(
         指定されたスタイルを初期化します。
         実行しなくても他のAPIは使用できますが、初回実行時に時間がかかることがあります。
         """
-        core = core_manager.get_core(core_version)
+        version = core_manager.convert_version_format(core_version)
+        core = core_manager.get_core(version)
         core.initialize_style_id_synthesis(style_id, skip_reinit=skip_reinit)
 
     @router.get("/is_initialized_speaker", tags=["その他"])
@@ -191,7 +196,8 @@ def generate_speaker_router(
         """
         指定されたスタイルが初期化されているかどうかを返します。
         """
-        core = core_manager.get_core(core_version)
+        version = core_manager.convert_version_format(core_version)
+        core = core_manager.get_core(version)
         return core.is_initialized_style_id_synthesis(style_id)
 
     return router

--- a/voicevox_engine/app/routers/tts_pipeline.py
+++ b/voicevox_engine/app/routers/tts_pipeline.py
@@ -53,8 +53,9 @@ def generate_tts_pipeline_router(
         """
         音声合成用のクエリの初期値を得ます。ここで得られたクエリはそのまま音声合成に利用できます。各値の意味は`Schemas`を参照してください。
         """
-        engine = tts_engines.get_engine(core_version)
-        core = core_manager.get_core(core_version)
+        version = core_manager.convert_version_format(core_version)
+        engine = tts_engines.get_engine(version)
+        core = core_manager.get_core(version)
         accent_phrases = engine.create_accent_phrases(text, style_id)
         return AudioQuery(
             accent_phrases=accent_phrases,
@@ -82,8 +83,9 @@ def generate_tts_pipeline_router(
         """
         音声合成用のクエリの初期値を得ます。ここで得られたクエリはそのまま音声合成に利用できます。各値の意味は`Schemas`を参照してください。
         """
-        engine = tts_engines.get_engine(core_version)
-        core = core_manager.get_core(core_version)
+        version = core_manager.convert_version_format(core_version)
+        engine = tts_engines.get_engine(version)
+        core = core_manager.get_core(version)
         try:
             presets = preset_manager.load_presets()
         except PresetInputError as err:
@@ -139,7 +141,8 @@ def generate_tts_pipeline_router(
         * アクセント位置を`'`で指定する。全てのアクセント句にはアクセント位置を1つ指定する必要がある。
         * アクセント句末に`？`(全角)を入れることにより疑問文の発音ができる。
         """
-        engine = tts_engines.get_engine(core_version)
+        version = core_manager.convert_version_format(core_version)
+        engine = tts_engines.get_engine(version)
         if is_kana:
             try:
                 return engine.create_accent_phrases_from_kana(text, style_id)
@@ -160,7 +163,8 @@ def generate_tts_pipeline_router(
         style_id: Annotated[StyleId, Query(alias="speaker")],
         core_version: str | None = None,
     ) -> list[AccentPhrase]:
-        engine = tts_engines.get_engine(core_version)
+        version = core_manager.convert_version_format(core_version)
+        engine = tts_engines.get_engine(version)
         return engine.update_length_and_pitch(accent_phrases, style_id)
 
     @router.post(
@@ -173,7 +177,8 @@ def generate_tts_pipeline_router(
         style_id: Annotated[StyleId, Query(alias="speaker")],
         core_version: str | None = None,
     ) -> list[AccentPhrase]:
-        engine = tts_engines.get_engine(core_version)
+        version = core_manager.convert_version_format(core_version)
+        engine = tts_engines.get_engine(version)
         return engine.update_length(accent_phrases, style_id)
 
     @router.post(
@@ -186,7 +191,8 @@ def generate_tts_pipeline_router(
         style_id: Annotated[StyleId, Query(alias="speaker")],
         core_version: str | None = None,
     ) -> list[AccentPhrase]:
-        engine = tts_engines.get_engine(core_version)
+        version = core_manager.convert_version_format(core_version)
+        engine = tts_engines.get_engine(version)
         return engine.update_pitch(accent_phrases, style_id)
 
     @router.post(
@@ -213,7 +219,8 @@ def generate_tts_pipeline_router(
         ] = True,
         core_version: str | None = None,
     ) -> FileResponse:
-        engine = tts_engines.get_engine(core_version)
+        version = core_manager.convert_version_format(core_version)
+        engine = tts_engines.get_engine(version)
         wave = engine.synthesize_wave(
             query, style_id, enable_interrogative_upspeak=enable_interrogative_upspeak
         )
@@ -253,8 +260,9 @@ def generate_tts_pipeline_router(
                 status_code=404,
                 detail="実験的機能はデフォルトで無効になっています。使用するには引数を指定してください。",
             )
+        version = core_manager.convert_version_format(core_version)
         f_name = cancellable_engine._synthesis_impl(
-            query, style_id, request, core_version=core_version
+            query, style_id, request, version=version
         )
         if f_name == "":
             raise HTTPException(status_code=422, detail="不明なバージョンです")
@@ -285,7 +293,8 @@ def generate_tts_pipeline_router(
         style_id: Annotated[StyleId, Query(alias="speaker")],
         core_version: str | None = None,
     ) -> FileResponse:
-        engine = tts_engines.get_engine(core_version)
+        version = core_manager.convert_version_format(core_version)
+        engine = tts_engines.get_engine(version)
         sampling_rate = queries[0].outputSamplingRate
 
         with NamedTemporaryFile(delete=False) as f:
@@ -327,8 +336,9 @@ def generate_tts_pipeline_router(
         """
         歌唱音声合成用のクエリの初期値を得ます。ここで得られたクエリはそのまま歌唱音声合成に利用できます。各値の意味は`Schemas`を参照してください。
         """
-        engine = tts_engines.get_engine(core_version)
-        core = core_manager.get_core(core_version)
+        version = core_manager.convert_version_format(core_version)
+        engine = tts_engines.get_engine(version)
+        core = core_manager.get_core(version)
         phonemes, f0, volume = engine.create_sing_phoneme_and_f0_and_volume(
             score, style_id
         )
@@ -353,7 +363,8 @@ def generate_tts_pipeline_router(
         style_id: Annotated[StyleId, Query(alias="speaker")],
         core_version: str | None = None,
     ) -> list[float]:
-        engine = tts_engines.get_engine(core_version)
+        version = core_manager.convert_version_format(core_version)
+        engine = tts_engines.get_engine(version)
         return engine.create_sing_volume_from_phoneme_and_f0(
             score, frame_audio_query.phonemes, frame_audio_query.f0, style_id
         )
@@ -378,7 +389,8 @@ def generate_tts_pipeline_router(
         """
         歌唱音声合成を行います。
         """
-        engine = tts_engines.get_engine(core_version)
+        version = core_manager.convert_version_format(core_version)
+        engine = tts_engines.get_engine(version)
         wave = engine.frame_synthsize_wave(query, style_id)
 
         with NamedTemporaryFile(delete=False) as f:

--- a/voicevox_engine/core/core_initializer.py
+++ b/voicevox_engine/core/core_initializer.py
@@ -2,6 +2,7 @@ import json
 import os
 import sys
 from pathlib import Path
+from typing import TypeAlias
 
 from fastapi import HTTPException
 
@@ -20,6 +21,10 @@ def get_half_logical_cores() -> int:
     return logical_cores // 2
 
 
+APICoreVersion: TypeAlias = str | None
+CoreVersion: TypeAlias = str
+
+
 class CoreManager:
     """コアの集まりを一括管理するマネージャー"""
 
@@ -33,6 +38,18 @@ class CoreManager:
     def latest_version(self) -> str:
         """登録された最新版コアのバージョンを取得する。"""
         return get_latest_version(self.versions())
+
+    def convert_version_format(self, version: APICoreVersion) -> CoreVersion:
+        """
+        バージョンの形式を API 形式から ENGINE 形式へ変換する。
+
+        API 形式は latest を指定でき、それは `None` で表現される。
+        ENGINE 形式は latest を指定できず、ゆえに `None` を持たない。
+        """
+        if version is None:
+            return self.latest_version()
+        else:
+            return version
 
     def register_core(self, core: CoreAdapter, version: str) -> None:
         """コアを登録する。"""

--- a/voicevox_engine/core/core_initializer.py
+++ b/voicevox_engine/core/core_initializer.py
@@ -55,11 +55,9 @@ class CoreManager:
         """コアを登録する。"""
         self._cores[version] = core
 
-    def get_core(self, version: str | None = None) -> CoreAdapter:
-        """指定バージョンのコアを取得する。指定が無い場合、最新バージョンを返す。"""
-        if version is None:
-            return self._cores[self.latest_version()]
-        elif version in self._cores:
+    def get_core(self, version: str) -> CoreAdapter:
+        """指定バージョンのコアを取得する。"""
+        if version in self._cores:
             return self._cores[version]
 
         # FIXME: ドメインがずれているのでこのエラーは routers へ持っていく

--- a/voicevox_engine/tts_pipeline/tts_engine.py
+++ b/voicevox_engine/tts_pipeline/tts_engine.py
@@ -19,7 +19,6 @@ from ..model import (
     Note,
     Score,
 )
-from ..utility.core_version_utility import get_latest_version
 from .kana_converter import parse_kana
 from .mora_mapping import mora_kana_to_mora_phonemes, mora_phonemes_to_mora_kana
 from .phoneme import Phoneme
@@ -694,19 +693,13 @@ class TTSEngineManager:
         """登録されたエンジンのバージョン一覧を取得する。"""
         return list(self._engines.keys())
 
-    def latest_version(self) -> str:
-        """登録された最新版エンジンのバージョンを取得する。"""
-        return get_latest_version(self.versions())
-
     def register_engine(self, engine: TTSEngine, version: str) -> None:
         """エンジンを登録する。"""
         self._engines[version] = engine
 
-    def get_engine(self, version: str | None = None) -> TTSEngine:
-        """指定バージョンのエンジンを取得する。指定が無い場合、最新バージョンを返す。"""
-        if version is None:
-            return self._engines[self.latest_version()]
-        elif version in self._engines:
+    def get_engine(self, version: str) -> TTSEngine:
+        """指定バージョンのエンジンを取得する。"""
+        if version in self._engines:
             return self._engines[version]
 
         raise HTTPException(status_code=422, detail="不明なバージョンです")


### PR DESCRIPTION
## 内容
`get_core()` / `get_engine()` における最新版暗示的取得を削除するリファクタリングを提案します。  

`CoreManager.convert_version_format()` を新設し、`core_version=None` を明示的に変換します。  
`get_core()` / `get_engine()` はこの明示化されたバージョンのみを受け取ります。  
このリファクタリングの結果、`TTSEngineManager.latest_version()` が不要となったため削除します。  

## 関連 Issue
ref https://github.com/VOICEVOX/voicevox_engine/pull/1234#discussion_r1610202550