### PR TITLE
廃止: `UserDictWord` 値への二重型チェックを削除

### DIFF
--- a/voicevox_engine/user_dict/user_dict.py
+++ b/voicevox_engine/user_dict/user_dict.py
@@ -332,7 +332,6 @@ class UserDictionary:
         # インポートする辞書データのバリデーション
         for word_uuid, word in dict_data.items():
             UUID(word_uuid)
-            assert isinstance(word, UserDictWord)
             for pos_detail in part_of_speech_data.values():
                 if word.context_id == pos_detail.context_id:
                     assert word.part_of_speech == pos_detail.part_of_speech


### PR DESCRIPTION
## 内容
静的型解析で型を保証された `UserDictWord` 値に対する動的クラス検査を削除することを提案します。  

## 関連 Issue
無し