### PR TITLE
整理: マニフェストパス生成関数を追加

### DIFF
--- a/build_util/make_docs.py
+++ b/build_util/make_docs.py
@@ -11,7 +11,7 @@ from voicevox_engine.preset.PresetManager import PresetManager
 from voicevox_engine.setting.Setting import USER_SETTING_PATH, SettingHandler
 from voicevox_engine.tts_pipeline.tts_engine import TTSEngineManager
 from voicevox_engine.user_dict.user_dict import UserDictionary
-from voicevox_engine.utility.path_utility import engine_root
+from voicevox_engine.utility.path_utility import engine_root, engine_manifest_path
 
 
 def generate_api_docs_html(schema: str) -> str:
@@ -52,7 +52,7 @@ if __name__ == "__main__":
             preset_path=engine_root() / "presets.yaml",
         ),
         user_dict=UserDictionary(),
-        engine_manifest=load_manifest(engine_root() / "engine_manifest.json"),
+        engine_manifest=load_manifest(engine_manifest_path()),
     )
     api_schema = json.dumps(app.openapi())
 

--- a/build_util/make_docs.py
+++ b/build_util/make_docs.py
@@ -11,7 +11,7 @@ from voicevox_engine.preset.PresetManager import PresetManager
 from voicevox_engine.setting.Setting import USER_SETTING_PATH, SettingHandler
 from voicevox_engine.tts_pipeline.tts_engine import TTSEngineManager
 from voicevox_engine.user_dict.user_dict import UserDictionary
-from voicevox_engine.utility.path_utility import engine_root, engine_manifest_path
+from voicevox_engine.utility.path_utility import engine_manifest_path, engine_root
 
 
 def generate_api_docs_html(schema: str) -> str:

--- a/run.py
+++ b/run.py
@@ -23,7 +23,7 @@ from voicevox_engine.setting.Setting import (
 )
 from voicevox_engine.tts_pipeline.tts_engine import make_tts_engines_from_cores
 from voicevox_engine.user_dict.user_dict import UserDictionary
-from voicevox_engine.utility.path_utility import engine_root, engine_manifest_path
+from voicevox_engine.utility.path_utility import engine_manifest_path, engine_root
 
 
 def decide_boolean_from_env(env_name: str) -> bool:

--- a/run.py
+++ b/run.py
@@ -23,7 +23,7 @@ from voicevox_engine.setting.Setting import (
 )
 from voicevox_engine.tts_pipeline.tts_engine import make_tts_engines_from_cores
 from voicevox_engine.user_dict.user_dict import UserDictionary
-from voicevox_engine.utility.path_utility import engine_root
+from voicevox_engine.utility.path_utility import engine_root, engine_manifest_path
 
 
 def decide_boolean_from_env(env_name: str) -> bool:
@@ -323,7 +323,7 @@ def main() -> None:
 
     use_dict = UserDictionary()
 
-    engine_manifest = load_manifest(engine_root() / "engine_manifest.json")
+    engine_manifest = load_manifest(engine_manifest_path())
 
     if arg_disable_mutable_api:
         disable_mutable_api = True

--- a/test/benchmark/engine_preparation.py
+++ b/test/benchmark/engine_preparation.py
@@ -15,7 +15,7 @@ from voicevox_engine.setting.Setting import SettingHandler
 from voicevox_engine.tts_pipeline.tts_engine import make_tts_engines_from_cores
 from voicevox_engine.user_dict.user_dict import UserDictionary
 from voicevox_engine.utility.core_version_utility import get_latest_version
-from voicevox_engine.utility.path_utility import engine_root
+from voicevox_engine.utility.path_utility import engine_manifest_path
 
 
 def _generate_engine_fake_server(root_dir: Path) -> TestClient:
@@ -27,7 +27,7 @@ def _generate_engine_fake_server(root_dir: Path) -> TestClient:
     setting_loader = SettingHandler(Path("./not_exist.yaml"))
     preset_manager = PresetManager(Path("./presets.yaml"))
     user_dict = UserDictionary()
-    engine_manifest = load_manifest(engine_root() / "engine_manifest.json")
+    engine_manifest = load_manifest(engine_manifest_path())
 
     app = generate_app(
         tts_engines=tts_engines,

--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -13,7 +13,7 @@ from voicevox_engine.preset.PresetManager import PresetManager
 from voicevox_engine.setting.Setting import SettingHandler
 from voicevox_engine.tts_pipeline.tts_engine import make_tts_engines_from_cores
 from voicevox_engine.user_dict.user_dict import UserDictionary
-from voicevox_engine.utility.path_utility import engine_root
+from voicevox_engine.utility.path_utility import engine_manifest_path
 
 
 @pytest.fixture()
@@ -30,7 +30,7 @@ def app_params(tmp_path: Path) -> dict[str, Any]:
     preset_manager = PresetManager(preset_path)
 
     user_dict = UserDictionary()
-    engine_manifest = load_manifest(engine_root() / "engine_manifest.json")
+    engine_manifest = load_manifest(engine_manifest_path())
 
     return {
         "tts_engines": tts_engines,

--- a/voicevox_engine/utility/path_utility.py
+++ b/voicevox_engine/utility/path_utility.py
@@ -24,6 +24,12 @@ def resource_root() -> Path:
     return engine_root() / "resources"
 
 
+def engine_manifest_path() -> Path:
+    """エンジンマニフェストのパスを取得する。"""
+    # NOTE: VOICEVOX API の規定によりエンジンマニフェストファイルは必ず `<engine_root>/engine_manifest.json` に存在する
+    return engine_root() / "engine_manifest.json"
+
+
 def _is_development() -> bool:
     """
     動作環境が開発版であるか否かを返す。


### PR DESCRIPTION
## 内容
概要: `engine_manifest.json` パス制約をマニフェストパス生成関数で表現するリファクタリング  

`engine_manifest.json` はエンジンルート下に必ず存在する（#1259）。  
しかし現在の実装はマニフェストファイルパスを各実装箇所で個別にハードコードしており、任意のマニフェストパスを指定可能に見える。これは fork 先のマルチエンジンがファイル名やパスを変更して仕様に反するリスクを高める。  
コードは仕様を表現すべきである。  

このような背景から、`engine_manifest.json` パス制約をコードで表現したマニフェストパス生成関数を追加するリファクタリングを提案します。  

## 関連 Issue
- alternative of #1305  
- ref https://github.com/VOICEVOX/voicevox_engine/pull/1230#discussion_r1605355528
- ref #1259