### PR TITLE
整理: UUID を置換してスナップショットテストを有効化

### DIFF
--- a/test/e2e/single_api/user_dict/__snapshots__/test_user_dict_word/test_post_user_dict_word_200.json
+++ b/test/e2e/single_api/user_dict/__snapshots__/test_user_dict_word/test_post_user_dict_word_200.json
@@ -1,0 +1,1 @@
+"<uuid_placeholder>"

--- a/test/e2e/single_api/user_dict/test_user_dict_word.py
+++ b/test/e2e/single_api/user_dict/test_user_dict_word.py
@@ -3,11 +3,14 @@
 """
 
 import re
+
 from fastapi.testclient import TestClient
 from syrupy.assertion import SnapshotAssertion
 
 
-def test_post_user_dict_word_200(client: TestClient,  snapshot_json: SnapshotAssertion) -> None:
+def test_post_user_dict_word_200(
+    client: TestClient, snapshot_json: SnapshotAssertion
+) -> None:
     params: dict[str, str | int] = {
         "surface": "test",
         "pronunciation": "テスト",

--- a/test/e2e/single_api/user_dict/test_user_dict_word.py
+++ b/test/e2e/single_api/user_dict/test_user_dict_word.py
@@ -2,11 +2,12 @@
 ユーザー辞書の言葉のAPIのテスト
 """
 
+import re
 from fastapi.testclient import TestClient
 from syrupy.assertion import SnapshotAssertion
 
 
-def test_post_user_dict_word_200(client: TestClient) -> None:
+def test_post_user_dict_word_200(client: TestClient,  snapshot_json: SnapshotAssertion) -> None:
     params: dict[str, str | int] = {
         "surface": "test",
         "pronunciation": "テスト",
@@ -16,7 +17,14 @@ def test_post_user_dict_word_200(client: TestClient) -> None:
     }
     response = client.post("/user_dict_word", params=params)
     assert response.status_code == 200
-    # UUID はランダム付与のためスナップショット不可
+
+    # NOTE: ランダム付与される UUID を固定値へ置換する
+    response_json = response.json()
+    assert isinstance(response_json, str)
+    uuidv4_pattern = r"[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[0-9a-f]{4}-[0-9a-f]{12}"
+    response_json = re.sub(uuidv4_pattern, "<uuid_placeholder>", response_json)
+
+    assert snapshot_json == response_json
 
 
 def test_post_user_dict_word_422(


### PR DESCRIPTION
## 内容
概要: UUID 置換によりスナップショットテストを有効化してリファクタリング  

一部のテストではランダム値に起因してスナップショットが無効化されている。  
UUID を使ったランダム値はランダムではあるが形式が一定であるため、正規表現による置き換えが可能である。  
これによりランダム値を固定値 placeholder で置換したスナップショットテストが可能になる。  

このような背景から、UUID 置換によりスナップショットテストを有効化するリファクタリングを提案します。  

## 関連 Issue
ref https://github.com/VOICEVOX/voicevox_engine/pull/1242#discussion_r1617864892
