### PR TITLE
整理: 内部型 `ManifestContainer` を追加

### DIFF
--- a/test/test_manifest.py
+++ b/test/test_manifest.py
@@ -1,0 +1,18 @@
+"""マニフェストのテスト"""
+
+from pathlib import Path
+
+from voicevox_engine.engine_manifest import ManifestContainer
+
+
+def test_ManifestContainer_init() -> None:
+    """`ManifestContainer.from_file()` でインスタンスが生成される。"""
+    ManifestContainer.from_file(Path("engine_manifest.json"))
+    assert True
+
+
+def test_ManifestContainer_relative_path() -> None:
+    """`ManifestContainer.root` を用いてマニフェスト内の相対パスが解決できる。"""
+    container = ManifestContainer.from_file(Path("engine_manifest.json"))
+    tos_path = container.root / container.terms_of_service
+    assert tos_path.exists()

--- a/voicevox_engine/app/application.py
+++ b/voicevox_engine/app/application.py
@@ -18,7 +18,7 @@ from voicevox_engine.app.routers.tts_pipeline import generate_tts_pipeline_route
 from voicevox_engine.app.routers.user_dict import generate_user_dict_router
 from voicevox_engine.cancellable_engine import CancellableEngine
 from voicevox_engine.core.core_initializer import CoreManager
-from voicevox_engine.engine_manifest import EngineManifest
+from voicevox_engine.engine_manifest import ManifestContainer
 from voicevox_engine.library_manager import LibraryManager
 from voicevox_engine.metas.MetasStore import MetasStore
 from voicevox_engine.preset.Preset import PresetManager
@@ -35,7 +35,7 @@ def generate_app(
     setting_loader: SettingHandler,
     preset_manager: PresetManager,
     user_dict: UserDictionary,
-    engine_manifest: EngineManifest,
+    engine_manifest: ManifestContainer,
     cancellable_engine: CancellableEngine | None = None,
     speaker_info_dir: Path | None = None,
     cors_policy_mode: CorsPolicyMode = CorsPolicyMode.localapps,
@@ -59,7 +59,7 @@ def generate_app(
 
     library_manager = LibraryManager(
         get_save_dir() / "installed_libraries",
-        engine_manifest.supported_vvlib_manifest_version,
+        None,
         engine_manifest.brand_name,
         engine_manifest.name,
         engine_manifest.uuid,
@@ -77,7 +77,7 @@ def generate_app(
     app.include_router(
         generate_speaker_router(core_manager, metas_store, speaker_info_dir)
     )
-    if engine_manifest.supported_features.manage_library:
+    if engine_manifest.supported_features.manage_library.value:
         app.include_router(generate_library_router(engine_manifest, library_manager))
     app.include_router(generate_user_dict_router(user_dict))
     app.include_router(generate_engine_info_router(core_manager, engine_manifest))

--- a/voicevox_engine/app/routers/engine_info.py
+++ b/voicevox_engine/app/routers/engine_info.py
@@ -9,7 +9,11 @@ from pydantic import BaseModel, Field
 from voicevox_engine import __version__
 from voicevox_engine.core.core_adapter import DeviceSupport
 from voicevox_engine.core.core_initializer import CoreManager
-from voicevox_engine.engine_manifest import EngineManifest
+from voicevox_engine.engine_manifest import (
+    EngineManifest,
+    ManifestContainer,
+    generate_api_manifest,
+)
 
 
 class SupportedDevicesInfo(BaseModel):
@@ -32,7 +36,7 @@ class SupportedDevicesInfo(BaseModel):
 
 
 def generate_engine_info_router(
-    core_manager: CoreManager, engine_manifest_data: EngineManifest
+    core_manager: CoreManager, engine_manifest_data: ManifestContainer
 ) -> APIRouter:
     """エンジン情報 API Router を生成する"""
     router = APIRouter(tags=["その他"])
@@ -61,6 +65,6 @@ def generate_engine_info_router(
     @router.get("/engine_manifest", response_model=EngineManifest)
     async def engine_manifest() -> EngineManifest:
         """エンジンマニフェストを取得します。"""
-        return engine_manifest_data
+        return generate_api_manifest(engine_manifest_data)
 
     return router

--- a/voicevox_engine/app/routers/library.py
+++ b/voicevox_engine/app/routers/library.py
@@ -6,7 +6,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Request
 
-from voicevox_engine.engine_manifest import EngineManifest
+from voicevox_engine.engine_manifest import ManifestContainer
 from voicevox_engine.library_manager import LibraryManager
 from voicevox_engine.model import DownloadableLibraryInfo, InstalledLibraryInfo
 
@@ -14,7 +14,7 @@ from ..dependencies import check_disabled_mutable_api
 
 
 def generate_library_router(
-    engine_manifest_data: EngineManifest, library_manager: LibraryManager
+    engine_manifest_data: ManifestContainer, library_manager: LibraryManager
 ) -> APIRouter:
     """音声ライブラリ API Router を生成する"""
     router = APIRouter(tags=["音声ライブラリ管理"])
@@ -27,7 +27,7 @@ def generate_library_router(
         """
         ダウンロード可能な音声ライブラリの情報を返します。
         """
-        if not engine_manifest_data.supported_features.manage_library:
+        if not engine_manifest_data.supported_features.manage_library.value:
             raise HTTPException(status_code=404, detail="この機能は実装されていません")
         return library_manager.downloadable_libraries()
 
@@ -39,7 +39,7 @@ def generate_library_router(
         """
         インストールした音声ライブラリの情報を返します。
         """
-        if not engine_manifest_data.supported_features.manage_library:
+        if not engine_manifest_data.supported_features.manage_library.value:
             raise HTTPException(status_code=404, detail="この機能は実装されていません")
         return library_manager.installed_libraries()
 
@@ -56,7 +56,7 @@ def generate_library_router(
         音声ライブラリをインストールします。
         音声ライブラリのZIPファイルをリクエストボディとして送信してください。
         """
-        if not engine_manifest_data.supported_features.manage_library:
+        if not engine_manifest_data.supported_features.manage_library.value:
             raise HTTPException(status_code=404, detail="この機能は実装されていません")
         archive = BytesIO(await request.body())
         loop = asyncio.get_event_loop()
@@ -75,7 +75,7 @@ def generate_library_router(
         """
         音声ライブラリをアンインストールします。
         """
-        if not engine_manifest_data.supported_features.manage_library:
+        if not engine_manifest_data.supported_features.manage_library.value:
             raise HTTPException(status_code=404, detail="この機能は実装されていません")
         library_manager.uninstall_library(library_uuid)
 


### PR DESCRIPTION
## 内容
概要: 内部型 `ManifestContainer` を追加してリファクタリング  

現在の VOICEVOX ENGINE はエンジンマニフェストに関して API 定義クラスと内部型を共有している（`EngineManifest`）。  
その結果「マニフェストファイルに存在している、かつ、 `GET /engine_manifest` API では返らない」情報をエンジン内部で使えなくなっている。つまり API を優先してエンジン内部向け情報を早々に捨ててしまっている。エンジンバージョン情報がその一例である。  
これは共有デメリットの典型であり（c.f. #1249）、マニフェストに関して内部型を独立させるタイミングが来たといえる。  

このような背景から、内部型 `ManifestContainer` を追加するリファクタリングを提案します。  

本 PR は `__version__` 廃止（c.f. #1232）の先行 PR となります。

## 関連 Issue
無し