### PR TITLE
整理: 不使用の `latest_core_version` 引数を削除

### DIFF
--- a/build_util/make_docs.py
+++ b/build_util/make_docs.py
@@ -46,7 +46,6 @@ if __name__ == "__main__":
     app = generate_app(
         tts_engines=tts_engines,
         core_manager=core_manager,
-        latest_core_version="mock",
         setting_loader=SettingHandler(USER_SETTING_PATH),
         preset_manager=PresetManager(  # FIXME: impl MockPresetManager
             preset_path=engine_root() / "presets.yaml",

--- a/run.py
+++ b/run.py
@@ -277,7 +277,6 @@ def main() -> None:
     )
     tts_engines = make_tts_engines_from_cores(core_manager)
     assert len(tts_engines.versions()) != 0, "音声合成エンジンがありません。"
-    latest_core_version = tts_engines.latest_version()
 
     # Cancellable Engine
     enable_cancellable_synthesis: bool = args.enable_cancellable_synthesis
@@ -340,7 +339,6 @@ def main() -> None:
     app = generate_app(
         tts_engines,
         core_manager,
-        latest_core_version,
         setting_loader,
         preset_manager,
         use_dict,

--- a/test/benchmark/engine_preparation.py
+++ b/test/benchmark/engine_preparation.py
@@ -14,7 +14,6 @@ from voicevox_engine.preset.PresetManager import PresetManager
 from voicevox_engine.setting.Setting import SettingHandler
 from voicevox_engine.tts_pipeline.tts_engine import make_tts_engines_from_cores
 from voicevox_engine.user_dict.user_dict import UserDictionary
-from voicevox_engine.utility.core_version_utility import get_latest_version
 from voicevox_engine.utility.path_utility import engine_manifest_path
 
 

--- a/test/benchmark/engine_preparation.py
+++ b/test/benchmark/engine_preparation.py
@@ -23,7 +23,6 @@ def _generate_engine_fake_server(root_dir: Path) -> TestClient:
         voicevox_dir=root_dir, use_gpu=False, enable_mock=False
     )
     tts_engines = make_tts_engines_from_cores(core_manager)
-    latest_core_version = get_latest_version(tts_engines.versions())
     setting_loader = SettingHandler(Path("./not_exist.yaml"))
     preset_manager = PresetManager(Path("./presets.yaml"))
     user_dict = UserDictionary()
@@ -32,7 +31,6 @@ def _generate_engine_fake_server(root_dir: Path) -> TestClient:
     app = generate_app(
         tts_engines=tts_engines,
         core_manager=core_manager,
-        latest_core_version=latest_core_version,
         setting_loader=setting_loader,
         preset_manager=preset_manager,
         speaker_info_dir=root_dir / "speaker_info",

--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -28,7 +28,6 @@ def _copy_under_dir(file_path: Path, dir_path: Path) -> Path:
 def app_params(tmp_path: Path) -> dict[str, Any]:
     core_manager = initialize_cores(use_gpu=False, enable_mock=True)
     tts_engines = make_tts_engines_from_cores(core_manager)
-    latest_core_version = tts_engines.latest_version()
     setting_loader = SettingHandler(Path("./not_exist.yaml"))
 
     # テスト用に隔離されたプリセットを生成する
@@ -47,7 +46,6 @@ def app_params(tmp_path: Path) -> dict[str, Any]:
     return {
         "tts_engines": tts_engines,
         "core_manager": core_manager,
-        "latest_core_version": latest_core_version,
         "setting_loader": setting_loader,
         "preset_manager": preset_manager,
         "user_dict": user_dict,

--- a/voicevox_engine/app/application.py
+++ b/voicevox_engine/app/application.py
@@ -31,7 +31,6 @@ from voicevox_engine.utility.path_utility import engine_root, get_save_dir
 def generate_app(
     tts_engines: TTSEngineManager,
     core_manager: CoreManager,
-    latest_core_version: str,
     setting_loader: SettingHandler,
     preset_manager: PresetManager,
     user_dict: UserDictionary,


### PR DESCRIPTION
## 内容
概要: 不使用の `latest_core_version` 引数を削除してリファクタリング  

昨今のリファクタリングにより `generate_app()` の `latest_core_version` が不使用となった。  
しかし引数として残っている。これは不要である。  

このような背景から、不使用の `latest_core_version` 引数を削除するリファクタリングを提案します。  

## 関連 Issue
無し