### PR TITLE
整理: `CoreSpeaker` の強制 `Speaker` 化を削除

### DIFF
--- a/voicevox_engine/app/routers/speaker.py
+++ b/voicevox_engine/app/routers/speaker.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from typing import Annotated, Literal
 
 from fastapi import APIRouter, HTTPException, Query
-from pydantic import parse_obj_as
 
 from voicevox_engine.core.core_initializer import CoreManager
 from voicevox_engine.metas.Metas import StyleId
@@ -74,9 +73,7 @@ def generate_speaker_router(
         #           ...
 
         # 該当話者を検索する
-        speakers = parse_obj_as(
-            list[Speaker], core_manager.get_core(core_version).speakers
-        )
+        speakers = metas_store.load_combined_metas(core_manager.get_core(core_version))
         speakers = filter_speakers_and_styles(speakers, speaker_or_singer)
         speaker = next(
             filter(lambda spk: spk.speaker_uuid == speaker_uuid, speakers), None


### PR DESCRIPTION
## 内容
概要: `CoreSpeaker` の強制 `Speaker` 化を削除してリファクタリング  

`CoreSpeaker` は `metas_store.load_combined_metas()` により `_EngineSpeaker` と融合し `Speaker` へ変換される。  
しかし現在の `_speaker_info()` では `CoreSpeaker` を `metas_store.load_combined_metas()` 無しに `Speaker` へ強制キャストしている。  

https://github.com/VOICEVOX/voicevox_engine/blob/9f0d403e1bd175be83b39a809370673a7df55acd/voicevox_engine/app/routers/speaker.py#L77-L79

一見すると壊れていそうだが、`Speaker` のデフォルト引数で placeholder `_EngineSpeaker` 値を代入しているので型のうえでは問題ない処理をしている。  

ただ、この処理は見るからにトリッキーである。  
意図コメントが無いので詳細は不明だが、combine する計算コストを抑える意図があったと推察する。  

しかし combine の計算コストはごく小さく、トリッキーさよる見通し悪化や各種リファクタリング時での扱いづらさなど、デメリットがメリットを上回っている。  

このような背景から、`CoreSpeaker` の強制 `Speaker` 化を削除するリファクタリングを提案します。  

## 関連 Issue
無し