### PR TITLE
整理: ファイルを操作するユーティリティを `file_utility` へ分離

### DIFF
--- a/voicevox_engine/app/routers/morphing.py
+++ b/voicevox_engine/app/routers/morphing.py
@@ -22,7 +22,7 @@ from voicevox_engine.morphing import (
     synthesis_morphing_parameter as _synthesis_morphing_parameter,
 )
 from voicevox_engine.tts_pipeline.tts_engine import TTSEngineManager
-from voicevox_engine.utility.path_utility import delete_file
+from voicevox_engine.utility.file_utility import delete_file
 
 # キャッシュを有効化
 # モジュール側でlru_cacheを指定するとキャッシュを制御しにくいため、HTTPサーバ側で指定する

--- a/voicevox_engine/app/routers/tts_pipeline.py
+++ b/voicevox_engine/app/routers/tts_pipeline.py
@@ -37,7 +37,7 @@ from voicevox_engine.tts_pipeline.tts_engine import (
     TalkSingInvalidInputError,
     TTSEngineManager,
 )
-from voicevox_engine.utility.path_utility import delete_file
+from voicevox_engine.utility.file_utility import delete_file
 
 
 def generate_tts_pipeline_router(

--- a/voicevox_engine/utility/file_utility.py
+++ b/voicevox_engine/utility/file_utility.py
@@ -1,0 +1,12 @@
+"""ファイル操作に関するユーティリティ"""
+
+import os
+import traceback
+
+
+def delete_file(file_path: str) -> None:
+    """指定されたファイルを削除する。"""
+    try:
+        os.remove(file_path)
+    except OSError:
+        traceback.print_exc()

--- a/voicevox_engine/utility/path_utility.py
+++ b/voicevox_engine/utility/path_utility.py
@@ -1,6 +1,4 @@
-import os
 import sys
-import traceback
 from pathlib import Path
 
 from platformdirs import user_data_dir
@@ -57,11 +55,3 @@ def get_save_dir() -> Path:
     else:
         app_name = "voicevox-engine"
     return Path(user_data_dir(app_name))
-
-
-def delete_file(file_path: str) -> None:
-    """指定されたファイルを削除する。"""
-    try:
-        os.remove(file_path)
-    except OSError:
-        traceback.print_exc()


### PR DESCRIPTION
## 内容
ファイル操作に関するユーティリティを `file_utility` モジュールへ分離するリファクタリングを提案します。  
`delete_file()` はパス定義やパス操作を担わないため、現在のモジュールは不適当と考えます。  

## 関連 Issue
無し