### PR TITLE
整理: ライブラリテストのユーティリティメソッドを関数へ切り出し

### DIFF
--- a/test/test_library_manager.py
+++ b/test/test_library_manager.py
@@ -12,7 +12,7 @@ from fastapi import HTTPException
 
 from voicevox_engine.library_manager import LibraryManager
 
-vvlib_manifest_name = "vvlib_manifest.json"
+VVLIB_MANIFEST_NAME = "vvlib_manifest.json"
 
 
 def create_vvlib_without_manifest(
@@ -25,7 +25,7 @@ def create_vvlib_without_manifest(
     ):
         for file_template in zf_template.infolist():
             buffer = zf_template.read(file_template.filename)
-            if file_template.filename != vvlib_manifest_name:
+            if file_template.filename != VVLIB_MANIFEST_NAME:
                 zf_new.writestr(file_template, buffer)
 
 
@@ -36,7 +36,7 @@ def append_any_as_manifest_to_vvlib(obj: Any, vvlib_path: str) -> None:
             obj_str = obj
         else:
             obj_str = json.dumps(obj)
-        zf.writestr(vvlib_manifest_name, obj_str)
+        zf.writestr(VVLIB_MANIFEST_NAME, obj_str)
 
 
 class TestLibraryManager(TestCase):
@@ -60,7 +60,7 @@ class TestLibraryManager(TestCase):
             speaker_infos = glob.glob("speaker_info/**", recursive=True)
             for info in speaker_infos:
                 zf.write(info)
-            zf.writestr(vvlib_manifest_name, json.dumps(self.vvlib_manifest))
+            zf.writestr(VVLIB_MANIFEST_NAME, json.dumps(self.vvlib_manifest))
         self.library_file = open(self.library_filename, "br")
 
     def tearDown(self) -> None:

--- a/test/test_library_manager.py
+++ b/test/test_library_manager.py
@@ -21,18 +21,16 @@ def create_vvlib_manifest(template_vvlib: Any, **kwargs: Any) -> dict[str, Any]:
     return {**vvlib_manifest, **kwargs}
 
 
-def create_vvlib_without_manifest(
-    new_vvlib_path: str, template_vvlib_path: Path
-) -> None:
+def create_vvlib_without_manifest(filename: str, template_vvlib_path: Path) -> None:
     """テンプレートの vvlib からマニフェストファイルを削除した、新たな vvlib ファイルを指定パスに生成する。"""
     with (
-        ZipFile(new_vvlib_path, "w") as zf_new,
-        ZipFile(template_vvlib_path, "r") as zf_template,
+        ZipFile(filename, "w") as zf_out,
+        ZipFile(template_vvlib_path, "r") as zf_in,
     ):
-        for file_template in zf_template.infolist():
-            buffer = zf_template.read(file_template.filename)
-            if file_template.filename != VVLIB_MANIFEST_NAME:
-                zf_new.writestr(file_template, buffer)
+        for file in zf_in.infolist():
+            buffer = zf_in.read(file.filename)
+            if file.filename != VVLIB_MANIFEST_NAME:
+                zf_out.writestr(file, buffer)
 
 
 def append_any_as_manifest_to_vvlib(obj: Any, vvlib_path: str) -> None:

--- a/test/test_library_manager.py
+++ b/test/test_library_manager.py
@@ -15,6 +15,12 @@ from voicevox_engine.library_manager import LibraryManager
 VVLIB_MANIFEST_NAME = "vvlib_manifest.json"
 
 
+def create_vvlib_manifest(template_vvlib: Any, **kwargs: Any) -> dict[str, Any]:
+    """テンプレートの vvlib から指定の属性を追加・上書きした、新たな vvlib オブジェクトを生成する。"""
+    vvlib_manifest = copy.deepcopy(template_vvlib)
+    return {**vvlib_manifest, **kwargs}
+
+
 def create_vvlib_without_manifest(
     new_vvlib_path: str, template_vvlib_path: Path
 ) -> None:
@@ -67,10 +73,6 @@ class TestLibraryManager(TestCase):
         self.tmp_dir.cleanup()
         self.library_file.close()
         self.library_filename.unlink()
-
-    def create_vvlib_manifest(self, **kwargs: Any) -> dict[str, Any]:
-        vvlib_manifest = copy.deepcopy(self.vvlib_manifest)
-        return {**vvlib_manifest, **kwargs}
 
     def test_installed_libraries(self) -> None:
         self.assertEqual(self.library_manger.installed_libraries(), {})
@@ -139,7 +141,9 @@ class TestLibraryManager(TestCase):
 
         # Inputs
         invalid_vvlib_name = "test/invalid.vvlib"
-        invalid_vvlib_manifest = self.create_vvlib_manifest(version=10)
+        invalid_vvlib_manifest = create_vvlib_manifest(
+            template_vvlib=self.vvlib_manifest, version=10
+        )
         create_vvlib_without_manifest(invalid_vvlib_name, self.library_filename)
         append_any_as_manifest_to_vvlib(invalid_vvlib_manifest, invalid_vvlib_name)
 
@@ -156,7 +160,9 @@ class TestLibraryManager(TestCase):
 
         # Inputs
         invalid_vvlib_name = "test/invalid.vvlib"
-        invalid_vvlib_manifest = self.create_vvlib_manifest(version="10")
+        invalid_vvlib_manifest = create_vvlib_manifest(
+            template_vvlib=self.vvlib_manifest, version="10"
+        )
         create_vvlib_without_manifest(invalid_vvlib_name, self.library_filename)
         append_any_as_manifest_to_vvlib(invalid_vvlib_manifest, invalid_vvlib_name)
 
@@ -173,7 +179,9 @@ class TestLibraryManager(TestCase):
 
         # Inputs
         invalid_vvlib_name = "test/invalid.vvlib"
-        invalid_vvlib_manifest = self.create_vvlib_manifest(manifest_version="10")
+        invalid_vvlib_manifest = create_vvlib_manifest(
+            template_vvlib=self.vvlib_manifest, manifest_version="10"
+        )
         create_vvlib_without_manifest(invalid_vvlib_name, self.library_filename)
         append_any_as_manifest_to_vvlib(invalid_vvlib_manifest, invalid_vvlib_name)
 
@@ -190,8 +198,8 @@ class TestLibraryManager(TestCase):
 
         # Inputs
         invalid_vvlib_name = "test/invalid.vvlib"
-        invalid_vvlib_manifest = self.create_vvlib_manifest(
-            manifest_version="999.999.999"
+        invalid_vvlib_manifest = create_vvlib_manifest(
+            template_vvlib=self.vvlib_manifest, manifest_version="999.999.999"
         )
         create_vvlib_without_manifest(invalid_vvlib_name, self.library_filename)
         append_any_as_manifest_to_vvlib(invalid_vvlib_manifest, invalid_vvlib_name)
@@ -209,8 +217,9 @@ class TestLibraryManager(TestCase):
 
         # Inputs
         invalid_vvlib_name = "test/invalid.vvlib"
-        invalid_vvlib_manifest = self.create_vvlib_manifest(
-            engine_uuid="26f7823b-20c6-40c5-bf86-6dd5d9d45c18"
+        invalid_vvlib_manifest = create_vvlib_manifest(
+            template_vvlib=self.vvlib_manifest,
+            engine_uuid="26f7823b-20c6-40c5-bf86-6dd5d9d45c18",
         )
         create_vvlib_without_manifest(invalid_vvlib_name, self.library_filename)
         append_any_as_manifest_to_vvlib(invalid_vvlib_manifest, invalid_vvlib_name)

--- a/test/test_library_manager.py
+++ b/test/test_library_manager.py
@@ -122,8 +122,9 @@ class TestLibraryManager(TestCase):
 
         # Inputs
         invalid_vvlib_name = "test/invalid.vvlib"
+        invalid_vvlib_manifest = "test"
         create_vvlib_without_manifest(invalid_vvlib_name, self.library_filename)
-        append_any_as_manifest_to_vvlib("test", invalid_vvlib_name)
+        append_any_as_manifest_to_vvlib(invalid_vvlib_manifest, invalid_vvlib_name)
 
         # Tests
         with open(invalid_vvlib_name, "br") as f, self.assertRaises(HTTPException) as e:


### PR DESCRIPTION
## 内容
ライブラリテストのユーティリティメソッドを関数へ切り出すリファクタリングを提案します。  
また、共通処理を関数として切り出すリファクタリングを提案します。  

本 PR は `unittest` → `pytest` 移行の途中ステップにあたります。  

## 関連 Issue
無し