### PR TITLE
整理: `TTSEngine` メソッド引数に `CoreAdapter` を追加

### DIFF
--- a/test/unit/test_mock_tts_engine.py
+++ b/test/unit/test_mock_tts_engine.py
@@ -46,19 +46,20 @@ def _gen_accent_phrases() -> list[AccentPhrase]:
 def test_update_length() -> None:
     """`.update_length()` がエラー無く生成をおこなう"""
     engine = MockTTSEngine()
-    engine.update_length(_gen_accent_phrases(), StyleId(0))
+    engine.update_length(engine._core, _gen_accent_phrases(), StyleId(0))
 
 
 def test_update_pitch() -> None:
     """`.update_pitch()` がエラー無く生成をおこなう"""
     engine = MockTTSEngine()
-    engine.update_pitch(_gen_accent_phrases(), StyleId(0))
+    engine.update_pitch(engine._core, _gen_accent_phrases(), StyleId(0))
 
 
 def test_synthesize_wave() -> None:
     """`.synthesize_wave()` がエラー無く生成をおこなう"""
     engine = MockTTSEngine()
     engine.synthesize_wave(
+        engine._core,
         AudioQuery(
             accent_phrases=_gen_accent_phrases(),
             speedScale=1,

--- a/test/unit/tts_pipeline/test_tts_engine.py
+++ b/test/unit/tts_pipeline/test_tts_engine.py
@@ -222,7 +222,7 @@ def test_update_length() -> None:
     # Inputs
     hello_hiho = _gen_hello_hiho_accent_phrases()
     # Indirect Outputs（yukarin_sに渡される値）
-    tts_engine.update_length(hello_hiho, StyleId(1))
+    tts_engine.update_length(tts_engine._core, hello_hiho, StyleId(1))
     yukarin_s_args = _yukarin_s_mock.call_args[1]
     list_length = yukarin_s_args["length"]
     phoneme_list = yukarin_s_args["phoneme_list"]
@@ -252,7 +252,7 @@ def test_update_pitch() -> None:
     # Inputs
     phrases: list = []
     # Outputs
-    result = tts_engine.update_pitch(phrases, StyleId(1))
+    result = tts_engine.update_pitch(tts_engine._core, phrases, StyleId(1))
     # Expects
     true_result: list = []
     # Tests
@@ -261,7 +261,7 @@ def test_update_pitch() -> None:
     # Inputs
     hello_hiho = _gen_hello_hiho_accent_phrases()
     # Indirect Outputs（yukarin_saに渡される値）
-    tts_engine.update_pitch(hello_hiho, StyleId(1))
+    tts_engine.update_pitch(tts_engine._core, hello_hiho, StyleId(1))
     yukarin_sa_args = _yukarin_sa_mock.call_args[1]
     list_length = yukarin_sa_args["length"]
     vowel_phoneme_list = yukarin_sa_args["vowel_phoneme_list"][0]
@@ -305,7 +305,9 @@ def test_create_accent_phrases_toward_unknown() -> None:
         "dummy", text_to_features=stub_unknown_features_koxx
     )
     with pytest.raises(ValueError) as e:
-        accent_phrases = engine.update_length_and_pitch(accent_phrases, StyleId(0))
+        accent_phrases = engine.update_length_and_pitch(
+            engine._core, accent_phrases, StyleId(0)
+        )
     assert str(e.value) == "tuple.index(x): x not in tuple"
 
 
@@ -315,7 +317,7 @@ def test_mocked_update_length_output(snapshot_json: SnapshotAssertion) -> None:
     tts_engine = TTSEngine(MockCoreWrapper())
     hello_hiho = _gen_hello_hiho_accent_phrases()
     # Outputs
-    result = tts_engine.update_length(hello_hiho, StyleId(1))
+    result = tts_engine.update_length(tts_engine._core, hello_hiho, StyleId(1))
     # Tests
     assert snapshot_json == round_floats(pydantic_to_native_type(result), round_value=2)
 
@@ -326,7 +328,7 @@ def test_mocked_update_pitch_output(snapshot_json: SnapshotAssertion) -> None:
     tts_engine = TTSEngine(MockCoreWrapper())
     hello_hiho = _gen_hello_hiho_accent_phrases()
     # Outputs
-    result = tts_engine.update_pitch(hello_hiho, StyleId(1))
+    result = tts_engine.update_pitch(tts_engine._core, hello_hiho, StyleId(1))
     # Tests
     assert snapshot_json == round_floats(pydantic_to_native_type(result), round_value=2)
 
@@ -339,7 +341,9 @@ def test_mocked_update_length_and_pitch_output(
     tts_engine = TTSEngine(MockCoreWrapper())
     hello_hiho = _gen_hello_hiho_accent_phrases()
     # Outputs
-    result = tts_engine.update_length_and_pitch(hello_hiho, StyleId(1))
+    result = tts_engine.update_length_and_pitch(
+        tts_engine._core, hello_hiho, StyleId(1)
+    )
     # Tests
     assert snapshot_json == round_floats(pydantic_to_native_type(result), round_value=2)
 
@@ -352,7 +356,7 @@ def test_mocked_create_accent_phrases_output(
     tts_engine = TTSEngine(MockCoreWrapper())
     hello_hiho = _gen_hello_hiho_text()
     # Outputs
-    result = tts_engine.create_accent_phrases(hello_hiho, StyleId(1))
+    result = tts_engine.create_accent_phrases(tts_engine._core, hello_hiho, StyleId(1))
     # Tests
     assert snapshot_json == round_floats(pydantic_to_native_type(result), round_value=2)
 
@@ -365,7 +369,9 @@ def test_mocked_create_accent_phrases_from_kana_output(
     tts_engine = TTSEngine(MockCoreWrapper())
     hello_hiho = _gen_hello_hiho_kana()
     # Outputs
-    result = tts_engine.create_accent_phrases_from_kana(hello_hiho, StyleId(1))
+    result = tts_engine.create_accent_phrases_from_kana(
+        tts_engine._core, hello_hiho, StyleId(1)
+    )
     # Tests
     assert snapshot_json == round_floats(pydantic_to_native_type(result), round_value=2)
 
@@ -376,7 +382,7 @@ def test_mocked_synthesize_wave_output(snapshot_json: SnapshotAssertion) -> None
     tts_engine = TTSEngine(MockCoreWrapper())
     hello_hiho = _gen_hello_hiho_query()
     # Outputs
-    result = tts_engine.synthesize_wave(hello_hiho, StyleId(1))
+    result = tts_engine.synthesize_wave(tts_engine._core, hello_hiho, StyleId(1))
     # Tests
     assert snapshot_json == round_floats(result.tolist(), round_value=2)
 
@@ -392,11 +398,11 @@ def test_mocked_create_sing_volume_from_phoneme_and_f0_output(
     tts_engine = TTSEngine(MockCoreWrapper())
     doremi_srore = _gen_doremi_score()
     phonemes, f0s, _ = tts_engine.create_sing_phoneme_and_f0_and_volume(
-        doremi_srore, StyleId(1)
+        tts_engine._core, doremi_srore, StyleId(1)
     )
     # Outputs
     result = tts_engine.create_sing_volume_from_phoneme_and_f0(
-        doremi_srore, phonemes, f0s, StyleId(1)
+        tts_engine._core, doremi_srore, phonemes, f0s, StyleId(1)
     )
     # Tests
     assert snapshot_json == round_floats(result, round_value=2)
@@ -413,7 +419,9 @@ def test_mocked_synthesize_wave_from_score_output(
     tts_engine = TTSEngine(MockCoreWrapper())
     doremi_srore = _gen_doremi_score()
     # Outputs
-    result = tts_engine.create_sing_phoneme_and_f0_and_volume(doremi_srore, StyleId(1))
+    result = tts_engine.create_sing_phoneme_and_f0_and_volume(
+        tts_engine._core, doremi_srore, StyleId(1)
+    )
     # Tests
     assert snapshot_json(name="query") == round_floats(
         pydantic_to_native_type(result), round_value=2
@@ -430,7 +438,9 @@ def test_mocked_synthesize_wave_from_score_output(
         outputStereo=False,
     )
     # Outputs
-    result_wave = tts_engine.frame_synthsize_wave(doremi_query, StyleId(1))
+    result_wave = tts_engine.frame_synthsize_wave(
+        tts_engine._core, doremi_query, StyleId(1)
+    )
     # Tests
     assert snapshot_json(name="wave") == round_floats(
         result_wave.tolist(), round_value=2
@@ -527,7 +537,7 @@ def create_synthesis_test_base(
     (https://github.com/VOICEVOX/voicevox_engine/issues/272#issuecomment-1022610866)
     """
     tts_engine = TTSEngine(core=MockCoreWrapper())
-    inputs = tts_engine.create_accent_phrases(text, StyleId(1))
+    inputs = tts_engine.create_accent_phrases(tts_engine._core, text, StyleId(1))
     outputs = apply_interrogative_upspeak(inputs, enable_interrogative_upspeak)
     assert expected == outputs, f"case(text:{text})"
 
@@ -540,7 +550,7 @@ def test_create_accent_phrases() -> None:
     text = "これはありますか？"
     expected = koreha_arimasuka_base_expected()
     expected[-1].is_interrogative = True
-    actual = tts_engine.create_accent_phrases(text, StyleId(1))
+    actual = tts_engine.create_accent_phrases(tts_engine._core, text, StyleId(1))
     assert expected == actual, f"case(text:{text})"
 
 

--- a/voicevox_engine/cancellable_engine.py
+++ b/voicevox_engine/cancellable_engine.py
@@ -255,7 +255,7 @@ def start_synthesis_subprocess(
                 continue
             # FIXME: enable_interrogative_upspeakフラグをWebAPIから受け渡してくる
             wave = _engine.synthesize_wave(
-                query, style_id, enable_interrogative_upspeak=False
+                _engine._core, query, style_id, enable_interrogative_upspeak=False
             )
             with NamedTemporaryFile(delete=False) as f:
                 soundfile.write(

--- a/voicevox_engine/dev/tts_engine/mock.py
+++ b/voicevox_engine/dev/tts_engine/mock.py
@@ -22,8 +22,8 @@ class MockTTSEngine(TTSEngine):
     def __init__(self) -> None:
         super().__init__(MockCoreWrapper())
 
+    @staticmethod
     def synthesize_wave(
-        self,
         core: CoreAdapter,
         query: AudioQuery,
         style_id: StyleId,
@@ -37,14 +37,15 @@ class MockTTSEngine(TTSEngine):
         flatten_moras = to_flatten_moras(query.accent_phrases)
         kana_text = "".join([mora.text for mora in flatten_moras])
 
-        wave = self.forward(kana_text)
+        wave = MockTTSEngine.forward(kana_text)
 
         # volume
         wave *= query.volumeScale
 
         return wave
 
-    def forward(self, text: str, **kwargs: dict[str, Any]) -> NDArray[np.float32]:
+    @staticmethod
+    def forward(text: str, **kwargs: dict[str, Any]) -> NDArray[np.float32]:
         """
         forward tts via pyopenjtalk.tts()
         参照→TTSEngine のdocstring [Mock]

--- a/voicevox_engine/dev/tts_engine/mock.py
+++ b/voicevox_engine/dev/tts_engine/mock.py
@@ -8,6 +8,8 @@ from numpy.typing import NDArray
 from pyopenjtalk import tts
 from soxr import resample
 
+from voicevox_engine.core.core_adapter import CoreAdapter
+
 from ...metas.Metas import StyleId
 from ...model import AudioQuery
 from ...tts_pipeline.tts_engine import TTSEngine, to_flatten_moras
@@ -22,6 +24,7 @@ class MockTTSEngine(TTSEngine):
 
     def synthesize_wave(
         self,
+        core: CoreAdapter,
         query: AudioQuery,
         style_id: StyleId,
         enable_interrogative_upspeak: bool = True,

--- a/voicevox_engine/morphing/morphing.py
+++ b/voicevox_engine/morphing/morphing.py
@@ -114,8 +114,12 @@ def synthesis_morphing_parameter(
     # WORLDに掛けるため合成はモノラルで行う
     query.outputStereo = False
 
-    base_wave = engine.synthesize_wave(query, base_style_id).astype(np.double)
-    target_wave = engine.synthesize_wave(query, target_style_id).astype(np.double)
+    base_wave = engine.synthesize_wave(engine._core, query, base_style_id).astype(
+        np.double
+    )
+    target_wave = engine.synthesize_wave(engine._core, query, target_style_id).astype(
+        np.double
+    )
 
     fs = query.outputSamplingRate
     frame_period = 1.0

--- a/voicevox_engine/tts_pipeline/tts_engine.py
+++ b/voicevox_engine/tts_pipeline/tts_engine.py
@@ -423,8 +423,9 @@ class TTSEngine:
         self._core = CoreAdapter(core)
         # NOTE: self._coreは将来的に消す予定
 
+    @staticmethod
     def update_length(
-        self, core: CoreAdapter, accent_phrases: list[AccentPhrase], style_id: StyleId
+        core: CoreAdapter, accent_phrases: list[AccentPhrase], style_id: StyleId
     ) -> list[AccentPhrase]:
         """アクセント句系列に含まれるモーラの音素長属性をスタイルに合わせて更新する"""
         # モーラ系列を抽出する
@@ -450,8 +451,9 @@ class TTSEngine:
 
         return accent_phrases
 
+    @staticmethod
     def update_pitch(
-        self, core: CoreAdapter, accent_phrases: list[AccentPhrase], style_id: StyleId
+        core: CoreAdapter, accent_phrases: list[AccentPhrase], style_id: StyleId
     ) -> list[AccentPhrase]:
         """アクセント句系列に含まれるモーラの音高属性をスタイルに合わせて更新する"""
         # 後続のnumpy.concatenateが空リストだとエラーになるので別処理
@@ -517,32 +519,39 @@ class TTSEngine:
 
         return accent_phrases
 
+    @staticmethod
     def update_length_and_pitch(
-        self, core: CoreAdapter, accent_phrases: list[AccentPhrase], style_id: StyleId
+        core: CoreAdapter, accent_phrases: list[AccentPhrase], style_id: StyleId
     ) -> list[AccentPhrase]:
         """アクセント句系列の音素長・モーラ音高をスタイルIDに基づいて更新する"""
-        accent_phrases = self.update_length(core, accent_phrases, style_id)
-        accent_phrases = self.update_pitch(core, accent_phrases, style_id)
+        accent_phrases = TTSEngine.update_length(core, accent_phrases, style_id)
+        accent_phrases = TTSEngine.update_pitch(core, accent_phrases, style_id)
         return accent_phrases
 
+    @staticmethod
     def create_accent_phrases(
-        self, core: CoreAdapter, text: str, style_id: StyleId
+        core: CoreAdapter, text: str, style_id: StyleId
     ) -> list[AccentPhrase]:
         """テキストからアクセント句系列を生成し、スタイルIDに基づいてその音素長・モーラ音高を更新する"""
         accent_phrases = text_to_accent_phrases(text)
-        accent_phrases = self.update_length_and_pitch(core, accent_phrases, style_id)
+        accent_phrases = TTSEngine.update_length_and_pitch(
+            core, accent_phrases, style_id
+        )
         return accent_phrases
 
+    @staticmethod
     def create_accent_phrases_from_kana(
-        self, core: CoreAdapter, kana: str, style_id: StyleId
+        core: CoreAdapter, kana: str, style_id: StyleId
     ) -> list[AccentPhrase]:
         """AquesTalk 風記法テキストからアクセント句系列を生成し、スタイルIDに基づいてその音素長・モーラ音高を更新する"""
         accent_phrases = parse_kana(kana)
-        accent_phrases = self.update_length_and_pitch(core, accent_phrases, style_id)
+        accent_phrases = TTSEngine.update_length_and_pitch(
+            core, accent_phrases, style_id
+        )
         return accent_phrases
 
+    @staticmethod
     def synthesize_wave(
-        self,
         core: CoreAdapter,
         query: AudioQuery,
         style_id: StyleId,
@@ -562,8 +571,8 @@ class TTSEngine:
 
     # FIXME: sing用のエンジンに移すかクラス名変える
     # 返す値の総称を考え、関数名を変更する
+    @staticmethod
     def create_sing_phoneme_and_f0_and_volume(
-        self,
         core: CoreAdapter,
         score: Score,
         style_id: StyleId,
@@ -610,8 +619,8 @@ class TTSEngine:
 
         return phoneme_data_list, f0s.tolist(), volumes.tolist()
 
+    @staticmethod
     def create_sing_volume_from_phoneme_and_f0(
-        self,
         core: CoreAdapter,
         score: Score,
         phonemes: list[FramePhoneme],
@@ -662,8 +671,8 @@ class TTSEngine:
 
         return volume_list
 
+    @staticmethod
     def frame_synthsize_wave(
-        self,
         core: CoreAdapter,
         query: FrameAudioQuery,
         style_id: StyleId,


### PR DESCRIPTION
## 内容
概要: `TTSEngine` メソッド引数に `CoreAdapter` を追加するリファクタリング

#1391 で提案されたとおり、`TTSEngine` は関数へ解体できる。  
現在の `TTSEngine` は内部に `._core` 変数を持っているため、メソッド引数由来のコアを利用するよう変更する必要がある。  
しかしこれを実装するには引数用のコアを用意するコードが必要であり、これにも着手すると `TTSEngine` 外の diff が大きくなる。  
よって、段階的に進めるためにまず第一段階として（トリッキーだが） `._core` をメソッド引数に渡す形を取る。すなわちメソッドコール時に `tts_engine.method_x(tts_engine._core, other_args)` としてコアを取得して渡す。  
こうすれば外部への影響を最小限にしながら、まず第一歩であるメソッドのコア引数を実現できる。  
また、`self._core` を間違って利用しないように各メソッドを static method へ変換すればより安全である。

このような形で `TTSEngine` メソッド引数に `CoreAdapter` を追加するリファクタリングを提案します。  

## 関連 Issue
part 1 of #1391