### PR TITLE
整理: `EngineManifestJson` の属性へ直接アクセス

### DIFF
--- a/voicevox_engine/engine_manifest.py
+++ b/voicevox_engine/engine_manifest.py
@@ -135,9 +135,7 @@ def load_manifest(manifest_path: Path) -> EngineManifest:
     """エンジンマニフェストを指定ファイルから読み込む。"""
 
     root_dir = manifest_path.parent
-    manifest = EngineManifestJson.model_validate_json(
-        manifest_path.read_bytes()
-    )
+    manifest = EngineManifestJson.model_validate_json(manifest_path.read_bytes())
     return EngineManifest(
         manifest_version=manifest.manifest_version,
         name=manifest.name,
@@ -162,6 +160,7 @@ def load_manifest(manifest_path: Path) -> EngineManifest:
             )
         ],
         supported_features={
-            key: item["value"] for key, item in manifest.supported_features.model_dump().items()
+            key: item["value"]
+            for key, item in manifest.supported_features.model_dump().items()
         },
     )

--- a/voicevox_engine/engine_manifest.py
+++ b/voicevox_engine/engine_manifest.py
@@ -137,35 +137,31 @@ def load_manifest(manifest_path: Path) -> EngineManifest:
     root_dir = manifest_path.parent
     manifest = EngineManifestJson.model_validate_json(
         manifest_path.read_bytes()
-    ).model_dump()
+    )
     return EngineManifest(
-        manifest_version=manifest["manifest_version"],
-        name=manifest["name"],
-        brand_name=manifest["brand_name"],
-        uuid=manifest["uuid"],
-        url=manifest["url"],
-        default_sampling_rate=manifest["default_sampling_rate"],
-        frame_rate=manifest["frame_rate"],
-        icon=b64encode((root_dir / manifest["icon"]).read_bytes()).decode("utf-8"),
-        terms_of_service=(root_dir / manifest["terms_of_service"]).read_text("utf-8"),
+        manifest_version=manifest.manifest_version,
+        name=manifest.name,
+        brand_name=manifest.brand_name,
+        uuid=manifest.uuid,
+        url=manifest.url,
+        default_sampling_rate=manifest.default_sampling_rate,
+        frame_rate=manifest.frame_rate,
+        icon=b64encode((root_dir / manifest.icon).read_bytes()).decode("utf-8"),
+        terms_of_service=(root_dir / manifest.terms_of_service).read_text("utf-8"),
         update_infos=[
             UpdateInfo(**update_info)
             for update_info in json.loads(
-                (root_dir / manifest["update_infos"]).read_text("utf-8")
+                (root_dir / manifest.update_infos).read_text("utf-8")
             )
         ],
-        # supported_vvlib_manifest_versionを持たないengine_manifestのために
-        # キーが存在しない場合はNoneを返すgetを使う
-        supported_vvlib_manifest_version=manifest.get(
-            "supported_vvlib_manifest_version"
-        ),
+        supported_vvlib_manifest_version=None,
         dependency_licenses=[
             LicenseInfo(**license_info)
             for license_info in json.loads(
-                (root_dir / manifest["dependency_licenses"]).read_text("utf-8")
+                (root_dir / manifest.dependency_licenses).read_text("utf-8")
             )
         ],
         supported_features={
-            key: item["value"] for key, item in manifest["supported_features"].items()
+            key: item["value"] for key, item in manifest.supported_features.model_dump().items()
         },
     )


### PR DESCRIPTION
## 内容
`EngineManifestJson` の属性アクセスを `.model_dump()` 経由から直接へ変更するリファクタリングを提案します。  
これにより型による安全性が向上します。  

## 関連 Issue
無し