### PR TITLE
整理: `Setting` をモジュール内に限局

### DIFF
--- a/run.py
+++ b/run.py
@@ -297,19 +297,19 @@ def main() -> None:
         )
 
     setting_loader = SettingHandler(args.setting_file)
-    settings = setting_loader.load()
+    setting_cors_policy_mode, setting_allow_origin_raw = setting_loader.load()
 
     # 複数方式で指定可能な場合、優先度は上から「引数」「環境変数」「設定ファイル」「デフォルト値」
 
     root_dir = select_first_not_none([voicevox_dir, engine_root()])
 
     cors_policy_mode = select_first_not_none(
-        [arg_cors_policy_mode, settings.cors_policy_mode]
+        [arg_cors_policy_mode, setting_cors_policy_mode]
     )
 
     setting_allow_origin = None
-    if settings.allow_origin is not None:
-        setting_allow_origin = settings.allow_origin.split(" ")
+    if setting_allow_origin_raw is not None:
+        setting_allow_origin = setting_allow_origin_raw.split(" ")
     allow_origin = select_first_not_none_or_none(
         [arg_allow_origin, setting_allow_origin]
     )

--- a/test/unit/setting/test_setting.py
+++ b/test/unit/setting/test_setting.py
@@ -11,13 +11,14 @@ def test_setting_handler_load_not_exist_file() -> None:
     """`SettingHandler` に存在しない設定ファイルのパスを渡すとデフォルト値になる。"""
     # Inputs
     setting_loader = SettingHandler(Path("not_exist.yaml"))
-    settings = setting_loader.load()
     # Expects
-    true_setting = {"allow_origin": None, "cors_policy_mode": CorsPolicyMode.localapps}
+    true_cors_policy_mode = CorsPolicyMode.localapps
+    true_allow_origin = None
     # Outputs
-    setting = settings.model_dump()
+    cors_policy_mode, allow_origin = setting_loader.load()
     # Test
-    assert true_setting == setting
+    assert true_cors_policy_mode == cors_policy_mode
+    assert true_allow_origin == allow_origin
 
 
 def test_setting_handler_load_exist_file_1() -> None:
@@ -25,13 +26,14 @@ def test_setting_handler_load_exist_file_1() -> None:
     # Inputs
     setting_path = Path("test/unit/setting/setting-test-load-1.yaml")
     setting_loader = SettingHandler(setting_path)
-    settings = setting_loader.load()
     # Expects
-    true_setting = {"allow_origin": None, "cors_policy_mode": CorsPolicyMode.localapps}
+    true_cors_policy_mode = CorsPolicyMode.localapps
+    true_allow_origin = None
     # Outputs
-    setting = settings.model_dump()
+    cors_policy_mode, allow_origin = setting_loader.load()
     # Test
-    assert true_setting == setting
+    assert true_cors_policy_mode == cors_policy_mode
+    assert true_allow_origin == allow_origin
 
 
 def test_setting_handler_load_exist_file_2() -> None:
@@ -39,13 +41,15 @@ def test_setting_handler_load_exist_file_2() -> None:
     # Inputs
     setting_path = Path("test/unit/setting/setting-test-load-2.yaml")
     setting_loader = SettingHandler(setting_path)
-    settings = setting_loader.load()
+    cors_policy_mode, allow_origin = setting_loader.load()
     # Expects
-    true_setting = {"allow_origin": None, "cors_policy_mode": "all"}
+    true_cors_policy_mode = CorsPolicyMode.all
+    true_allow_origin = None
     # Outputs
-    setting = settings.model_dump()
+    cors_policy_mode, allow_origin = setting_loader.load()
     # Test
-    assert true_setting == setting
+    assert true_cors_policy_mode == cors_policy_mode
+    assert true_allow_origin == allow_origin
 
 
 def test_setting_handler_load_exist_file_3() -> None:
@@ -53,16 +57,15 @@ def test_setting_handler_load_exist_file_3() -> None:
     # Inputs
     setting_path = Path("test/unit/setting/setting-test-load-3.yaml")
     setting_loader = SettingHandler(setting_path)
-    settings = setting_loader.load()
+    cors_policy_mode, allow_origin = setting_loader.load()
     # Expects
-    true_setting = {
-        "allow_origin": "192.168.254.255 192.168.255.255",
-        "cors_policy_mode": CorsPolicyMode.localapps,
-    }
+    true_cors_policy_mode = CorsPolicyMode.localapps
+    true_allow_origin = "192.168.254.255 192.168.255.255"
     # Outputs
-    setting = settings.model_dump()
+    cors_policy_mode, allow_origin = setting_loader.load()
     # Test
-    assert true_setting == setting
+    assert true_cors_policy_mode == cors_policy_mode
+    assert true_allow_origin == allow_origin
 
 
 def test_setting_handler_save(tmp_path: Path) -> None:
@@ -70,15 +73,18 @@ def test_setting_handler_save(tmp_path: Path) -> None:
     # Inputs
     setting_path = tmp_path / "setting-test-dump.yaml"
     setting_loader = SettingHandler(setting_path)
-    new_setting = Setting(cors_policy_mode=CorsPolicyMode.localapps)
+    new_setting_cors = CorsPolicyMode.localapps
+    new_setting_origin = None
     # Expects
-    true_setting = {"allow_origin": None, "cors_policy_mode": CorsPolicyMode.localapps}
+    true_cors_policy_mode = CorsPolicyMode.localapps
+    true_allow_origin = None
     # Outputs
-    setting_loader.save(new_setting)
+    setting_loader.save(new_setting_cors, new_setting_origin)
     # NOTE: `.load()` の正常動作を前提とする
-    setting = setting_loader.load().model_dump()
+    cors_policy_mode, allow_origin = setting_loader.load()
     # Test
-    assert true_setting == setting
+    assert true_cors_policy_mode == cors_policy_mode
+    assert true_allow_origin == allow_origin
 
 
 def test_setting_invalid_input() -> None:

--- a/test/unit/setting/test_setting.py
+++ b/test/unit/setting/test_setting.py
@@ -4,7 +4,7 @@ import pytest
 from pydantic import ValidationError
 
 from voicevox_engine.setting.model import CorsPolicyMode
-from voicevox_engine.setting.setting_manager import Setting, SettingHandler
+from voicevox_engine.setting.setting_manager import _Setting, SettingHandler
 
 
 def test_setting_handler_load_not_exist_file() -> None:
@@ -91,4 +91,4 @@ def test_setting_invalid_input() -> None:
     """`Setting` は不正な入力に対してエラーを送出する。"""
     # Test
     with pytest.raises(ValidationError) as _:
-        Setting(cors_policy_mode="invalid_value", allow_origin="*")
+        _Setting(cors_policy_mode="invalid_value", allow_origin="*")

--- a/test/unit/setting/test_setting.py
+++ b/test/unit/setting/test_setting.py
@@ -4,7 +4,7 @@ import pytest
 from pydantic import ValidationError
 
 from voicevox_engine.setting.model import CorsPolicyMode
-from voicevox_engine.setting.setting_manager import _Setting, SettingHandler
+from voicevox_engine.setting.setting_manager import SettingHandler, _Setting
 
 
 def test_setting_handler_load_not_exist_file() -> None:

--- a/voicevox_engine/app/routers/setting.py
+++ b/voicevox_engine/app/routers/setting.py
@@ -8,7 +8,7 @@ from pydantic.json_schema import SkipJsonSchema
 
 from voicevox_engine.engine_manifest import BrandName
 from voicevox_engine.setting.model import CorsPolicyMode
-from voicevox_engine.setting.setting_manager import Setting, SettingHandler
+from voicevox_engine.setting.setting_manager import SettingHandler
 from voicevox_engine.utility.path_utility import resource_root
 
 from ..dependencies import check_disabled_mutable_api
@@ -31,10 +31,7 @@ def generate_setting_router(
         """
         設定ページを返します。
         """
-        settings = setting_loader.load()
-
-        cors_policy_mode = settings.cors_policy_mode
-        allow_origin = settings.allow_origin
+        cors_policy_mode, allow_origin = setting_loader.load()
 
         if allow_origin is None:
             allow_origin = ""
@@ -56,15 +53,7 @@ def generate_setting_router(
         cors_policy_mode: Annotated[CorsPolicyMode, Form()],
         allow_origin: Annotated[str | SkipJsonSchema[None], Form()] = None,
     ) -> None:
-        """
-        設定を更新します。
-        """
-        settings = Setting(
-            cors_policy_mode=cors_policy_mode,
-            allow_origin=allow_origin,
-        )
-
-        # 更新した設定へ上書き
-        setting_loader.save(settings)
+        """設定を更新します。"""
+        setting_loader.save(cors_policy_mode, allow_origin)
 
     return router

--- a/voicevox_engine/setting/setting_manager.py
+++ b/voicevox_engine/setting/setting_manager.py
@@ -10,7 +10,6 @@ from pydantic import BaseModel
 from ..utility.path_utility import get_save_dir
 from .model import CorsPolicyMode
 
-
 _AllowOrigin: TypeAlias = str | None
 
 
@@ -48,7 +47,9 @@ class SettingHandler:
         setting_obj = _Setting.model_validate(setting)
         return setting_obj.cors_policy_mode, setting_obj.allow_origin
 
-    def save(self, cors_policy_mode: CorsPolicyMode, allow_origin: _AllowOrigin) -> None:
+    def save(
+        self, cors_policy_mode: CorsPolicyMode, allow_origin: _AllowOrigin
+    ) -> None:
         """設定値をファイルへ書き込む。"""
         settings_dict = _Setting(
             cors_policy_mode=cors_policy_mode, allow_origin=allow_origin

--- a/voicevox_engine/setting/setting_manager.py
+++ b/voicevox_engine/setting/setting_manager.py
@@ -4,19 +4,17 @@ from enum import Enum
 from pathlib import Path
 
 import yaml
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 from ..utility.path_utility import get_save_dir
 from .model import CorsPolicyMode
 
 
-class Setting(BaseModel):
-    """
-    エンジンの設定情報
-    """
+class _Setting(BaseModel):
+    """エンジンの設定情報"""
 
-    cors_policy_mode: CorsPolicyMode = Field(title="リソース共有ポリシー")
-    allow_origin: str | None = Field(default=None, title="許可するオリジン")
+    cors_policy_mode: CorsPolicyMode  # リソース共有ポリシー
+    allow_origin: str | None  # 許可するオリジン
 
 
 USER_SETTING_PATH: Path = get_save_dir() / "setting.yml"
@@ -43,7 +41,7 @@ class SettingHandler:
             # FIXME: 型チェックと例外処理を追加する
             setting = yaml.safe_load(self.setting_file_path.read_text(encoding="utf-8"))
 
-        setting_obj = Setting(
+        setting_obj = _Setting(
             cors_policy_mode=setting["cors_policy_mode"],
             allow_origin=setting["allow_origin"],
         )
@@ -51,7 +49,7 @@ class SettingHandler:
 
     def save(self, cors_policy_mode: CorsPolicyMode, allow_origin: str | None) -> None:
         """設定値をファイルへ書き込む。"""
-        settings_dict = Setting(
+        settings_dict = _Setting(
             cors_policy_mode=cors_policy_mode, allow_origin=allow_origin
         ).model_dump()
 

--- a/voicevox_engine/setting/setting_manager.py
+++ b/voicevox_engine/setting/setting_manager.py
@@ -2,6 +2,7 @@
 
 from enum import Enum
 from pathlib import Path
+from typing import TypeAlias
 
 import yaml
 from pydantic import BaseModel
@@ -10,11 +11,14 @@ from ..utility.path_utility import get_save_dir
 from .model import CorsPolicyMode
 
 
+_AllowOrigin: TypeAlias = str | None
+
+
 class _Setting(BaseModel):
     """エンジンの設定情報"""
 
     cors_policy_mode: CorsPolicyMode  # リソース共有ポリシー
-    allow_origin: str | None  # 許可するオリジン
+    allow_origin: _AllowOrigin  # 許可するオリジン
 
 
 USER_SETTING_PATH: Path = get_save_dir() / "setting.yml"
@@ -31,7 +35,7 @@ class SettingHandler:
         """
         self.setting_file_path = setting_file_path
 
-    def load(self) -> tuple[CorsPolicyMode, str | None]:
+    def load(self) -> tuple[CorsPolicyMode, _AllowOrigin]:
         """設定値をファイルから読み込む。"""
         if not self.setting_file_path.is_file():
             # 設定ファイルが存在しないためデフォルト値を取得
@@ -47,7 +51,7 @@ class SettingHandler:
         )
         return setting_obj.cors_policy_mode, setting_obj.allow_origin
 
-    def save(self, cors_policy_mode: CorsPolicyMode, allow_origin: str | None) -> None:
+    def save(self, cors_policy_mode: CorsPolicyMode, allow_origin: _AllowOrigin) -> None:
         """設定値をファイルへ書き込む。"""
         settings_dict = _Setting(
             cors_policy_mode=cors_policy_mode, allow_origin=allow_origin

--- a/voicevox_engine/setting/setting_manager.py
+++ b/voicevox_engine/setting/setting_manager.py
@@ -42,13 +42,10 @@ class SettingHandler:
             setting = {"allow_origin": None, "cors_policy_mode": "localapps"}
         else:
             # 指定された設定ファイルから値を取得
-            # FIXME: 型チェックと例外処理を追加する
+            # FIXME: 例外処理を追加する
             setting = yaml.safe_load(self.setting_file_path.read_text(encoding="utf-8"))
 
-        setting_obj = _Setting(
-            cors_policy_mode=setting["cors_policy_mode"],
-            allow_origin=setting["allow_origin"],
-        )
+        setting_obj = _Setting.model_validate(setting)
         return setting_obj.cors_policy_mode, setting_obj.allow_origin
 
     def save(self, cors_policy_mode: CorsPolicyMode, allow_origin: _AllowOrigin) -> None:

--- a/voicevox_engine/setting/setting_manager.py
+++ b/voicevox_engine/setting/setting_manager.py
@@ -33,7 +33,7 @@ class SettingHandler:
         """
         self.setting_file_path = setting_file_path
 
-    def load(self) -> Setting:
+    def load(self) -> tuple[CorsPolicyMode, str | None]:
         """設定値をファイルから読み込む。"""
         if not self.setting_file_path.is_file():
             # 設定ファイルが存在しないためデフォルト値を取得
@@ -43,14 +43,17 @@ class SettingHandler:
             # FIXME: 型チェックと例外処理を追加する
             setting = yaml.safe_load(self.setting_file_path.read_text(encoding="utf-8"))
 
-        return Setting(
+        setting_obj = Setting(
             cors_policy_mode=setting["cors_policy_mode"],
             allow_origin=setting["allow_origin"],
         )
+        return setting_obj.cors_policy_mode, setting_obj.allow_origin
 
-    def save(self, settings: Setting) -> None:
+    def save(self, cors_policy_mode: CorsPolicyMode, allow_origin: str | None) -> None:
         """設定値をファイルへ書き込む。"""
-        settings_dict = settings.model_dump()
+        settings_dict = Setting(
+            cors_policy_mode=cors_policy_mode, allow_origin=allow_origin
+        ).model_dump()
 
         if isinstance(settings_dict["cors_policy_mode"], Enum):
             settings_dict["cors_policy_mode"] = settings_dict["cors_policy_mode"].value


### PR DESCRIPTION
## 内容
概要: `Setting` をモジュール内に限局してリファクタリング  

`Setting` はエンジンの設定（CORS 設定と origin 設定）をもつ BaseModel である。  
router でも利用されており一見すると API モデルに見えるが、実際には内部向け構造体である。router ではコンテナ的に値を出し入れする役割を果たしているに過ぎず、BaseModel 由来の機能は YAML ファイル I/O 用のダンプ・バリデーションで使われている。  
ゆえに API では CORS 設定と origin 設定を直接扱って問題ない。そして `setting_manager` モジュール内でのみ `Setting` 構造体を利用し影響範囲を適切に限局させるべきである。  

このような背景から、`Setting` をモジュール内に限局するリファクタリングを提案します。  

## 関連 Issue
無し