### PR TITLE
FIX: `Jinja2Templates`の`DeprecationWarning`を解消

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ uvicorn = "^0.29.0"
 soundfile = "^0.12.1"
 pyyaml = "^6.0.1"
 pyworld = "^0.3.0"
-jinja2 = "^3.1.3" # NOTE: required by fastapi
+jinja2 = "^3.1.3"
 pyopenjtalk = { git = "https://github.com/VOICEVOX/pyopenjtalk", rev = "b35fc89fe42948a28e33aed886ea145a51113f88" }
 semver = "^3.0.0"
 platformdirs = "^4.2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ uvicorn = "^0.29.0"
 soundfile = "^0.12.1"
 pyyaml = "^6.0.1"
 pyworld = "^0.3.0"
-jinja2 = "^3.1.3"
+jinja2 = "^3.1.3" # NOTE: required by fastapi
 pyopenjtalk = { git = "https://github.com/VOICEVOX/pyopenjtalk", rev = "b35fc89fe42948a28e33aed886ea145a51113f88" }
 semver = "^3.0.0"
 platformdirs = "^4.2.0"

--- a/voicevox_engine/app/routers/setting.py
+++ b/voicevox_engine/app/routers/setting.py
@@ -4,6 +4,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, Form, Request, Response
 from fastapi.templating import Jinja2Templates
+from jinja2 import Environment, FileSystemLoader
 from pydantic.json_schema import SkipJsonSchema
 
 from voicevox_engine.engine_manifest import BrandName
@@ -14,9 +15,11 @@ from voicevox_engine.utility.path_utility import resource_root
 from ..dependencies import check_disabled_mutable_api
 
 _setting_ui_template = Jinja2Templates(
-    directory=resource_root(),
-    variable_start_string="<JINJA_PRE>",
-    variable_end_string="<JINJA_POST>",
+    env=Environment(
+        variable_start_string="<JINJA_PRE>",
+        variable_end_string="<JINJA_POST>",
+        loader=FileSystemLoader(resource_root()),
+    ),
 )
 
 
@@ -40,9 +43,9 @@ def generate_setting_router(
             allow_origin = ""
 
         return _setting_ui_template.TemplateResponse(
-            "setting_ui_template.html",
-            {
-                "request": request,
+            request=request,
+            name="setting_ui_template.html",
+            context={
                 "brand_name": brand_name,
                 "cors_policy_mode": cors_policy_mode.value,
                 "allow_origin": allow_origin,


### PR DESCRIPTION
## 内容

`Jinja2Templates`周りの`DeprecationWarning`を解消します。

- ref: https://fastapi.tiangolo.com/advanced/templates/#using-jinja2templates
>Before FastAPI 0.108.0, Starlette 0.29.0, the name was the first parameter.
>
>Also, before that, in previous versions, the request object was passed as part of the key-value pairs in the context for Jinja2.
- ref: https://www.starlette.io/templates/
