### PR TITLE
FIX: Pydanticモデルの`title`漏れを修正

### DIFF
--- a/test/e2e/__snapshots__/test_openapi/test_OpenAPIの形が変わっていないことを確認.json
+++ b/test/e2e/__snapshots__/test_openapi/test_OpenAPIの形が変わっていないことを確認.json
@@ -707,15 +707,15 @@
             "title": "話者の対応機能"
           },
           "version": {
-            "default": "話者のバージョン",
-            "title": "Version",
+            "title": "話者のバージョン",
             "type": "string"
           }
         },
         "required": [
           "name",
           "speaker_uuid",
-          "styles"
+          "styles",
+          "version"
         ],
         "title": "Speaker",
         "type": "object"

--- a/test/unit/test_metas_store.py
+++ b/test/unit/test_metas_store.py
@@ -16,6 +16,7 @@ def _gen_speaker(style_types: list[StyleType]) -> Speaker:
             )
             for style_type in style_types
         ],
+        version="",
     )
 
 

--- a/voicevox_engine/core/core_adapter.py
+++ b/voicevox_engine/core/core_adapter.py
@@ -34,7 +34,7 @@ class CoreSpeaker(BaseModel):
     name: str
     speaker_uuid: str
     styles: list[CoreSpeakerStyle]
-    version: str = Field("話者のバージョン")
+    version: str = Field(title="話者のバージョン")
 
 
 @dataclass(frozen=True)

--- a/voicevox_engine/metas/Metas.py
+++ b/voicevox_engine/metas/Metas.py
@@ -60,7 +60,7 @@ class Speaker(BaseModel):
     name: str = Field(title="名前")
     speaker_uuid: str = Field(title="話者のUUID")
     styles: list[SpeakerStyle] = Field(title="スタイルの一覧")
-    version: str = Field("話者のバージョン")
+    version: str = Field(title="話者のバージョン")
     supported_features: SpeakerSupportedFeatures = Field(
         title="話者の対応機能", default_factory=SpeakerSupportedFeatures
     )


### PR DESCRIPTION
## 内容

Pydanticモデルの`Speaker`と`CoreSpeaker`の`version`フィールドのデフォルト値が`"話者のバージョン"`になっていました。
これは名前付き引数の`title=`を忘れたためだと思います。