### PR TITLE
整理: `Setting` を `dataclass` へ変更

### DIFF
--- a/test/unit/setting/test_setting.py
+++ b/test/unit/setting/test_setting.py
@@ -1,8 +1,5 @@
 from pathlib import Path
 
-import pytest
-from pydantic import ValidationError
-
 from voicevox_engine.setting.model import CorsPolicyMode
 from voicevox_engine.setting.setting_manager import (
     Setting,
@@ -83,10 +80,3 @@ def test_setting_handler_save(tmp_path: Path) -> None:
     setting = _setting_adapter.dump_python(setting_loader.load())
     # Test
     assert true_setting == setting
-
-
-def test_setting_invalid_input() -> None:
-    """`Setting` は不正な入力に対してエラーを送出する。"""
-    # Test
-    with pytest.raises(ValidationError) as _:
-        Setting(cors_policy_mode="invalid_value", allow_origin="*")

--- a/test/unit/setting/test_setting.py
+++ b/test/unit/setting/test_setting.py
@@ -4,7 +4,11 @@ import pytest
 from pydantic import ValidationError
 
 from voicevox_engine.setting.model import CorsPolicyMode
-from voicevox_engine.setting.setting_manager import Setting, SettingHandler
+from voicevox_engine.setting.setting_manager import (
+    Setting,
+    SettingHandler,
+    _setting_adapter,
+)
 
 
 def test_setting_handler_load_not_exist_file() -> None:
@@ -15,7 +19,7 @@ def test_setting_handler_load_not_exist_file() -> None:
     # Expects
     true_setting = {"allow_origin": None, "cors_policy_mode": CorsPolicyMode.localapps}
     # Outputs
-    setting = settings.model_dump()
+    setting = _setting_adapter.dump_python(settings)
     # Test
     assert true_setting == setting
 
@@ -29,7 +33,7 @@ def test_setting_handler_load_exist_file_1() -> None:
     # Expects
     true_setting = {"allow_origin": None, "cors_policy_mode": CorsPolicyMode.localapps}
     # Outputs
-    setting = settings.model_dump()
+    setting = _setting_adapter.dump_python(settings)
     # Test
     assert true_setting == setting
 
@@ -43,7 +47,7 @@ def test_setting_handler_load_exist_file_2() -> None:
     # Expects
     true_setting = {"allow_origin": None, "cors_policy_mode": "all"}
     # Outputs
-    setting = settings.model_dump()
+    setting = _setting_adapter.dump_python(settings)
     # Test
     assert true_setting == setting
 
@@ -60,7 +64,7 @@ def test_setting_handler_load_exist_file_3() -> None:
         "cors_policy_mode": CorsPolicyMode.localapps,
     }
     # Outputs
-    setting = settings.model_dump()
+    setting = _setting_adapter.dump_python(settings)
     # Test
     assert true_setting == setting
 
@@ -76,7 +80,7 @@ def test_setting_handler_save(tmp_path: Path) -> None:
     # Outputs
     setting_loader.save(new_setting)
     # NOTE: `.load()` の正常動作を前提とする
-    setting = setting_loader.load().model_dump()
+    setting = _setting_adapter.dump_python(setting_loader.load())
     # Test
     assert true_setting == setting
 

--- a/voicevox_engine/setting/setting_manager.py
+++ b/voicevox_engine/setting/setting_manager.py
@@ -1,22 +1,26 @@
 """エンジン設定関連の処理"""
 
+from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
+from typing import Any
 
 import yaml
-from pydantic import BaseModel, Field
+from pydantic import TypeAdapter
 
 from ..utility.path_utility import get_save_dir
 from .model import CorsPolicyMode
 
 
-class Setting(BaseModel):
-    """
-    エンジンの設定情報
-    """
+@dataclass(frozen=True)
+class Setting:
+    """エンジンの設定情報"""
 
-    cors_policy_mode: CorsPolicyMode = Field(title="リソース共有ポリシー")
-    allow_origin: str | None = Field(default=None, title="許可するオリジン")
+    cors_policy_mode: CorsPolicyMode  # リソース共有ポリシー
+    allow_origin: str | None = None  # 許可するオリジン
+
+
+_setting_adapter = TypeAdapter(Setting)
 
 
 USER_SETTING_PATH: Path = get_save_dir() / "setting.yml"
@@ -40,17 +44,14 @@ class SettingHandler:
             setting = {"allow_origin": None, "cors_policy_mode": "localapps"}
         else:
             # 指定された設定ファイルから値を取得
-            # FIXME: 型チェックと例外処理を追加する
+            # FIXME: 例外処理を追加する
             setting = yaml.safe_load(self.setting_file_path.read_text(encoding="utf-8"))
 
-        return Setting(
-            cors_policy_mode=setting["cors_policy_mode"],
-            allow_origin=setting["allow_origin"],
-        )
+        return _setting_adapter.validate_python(setting)
 
     def save(self, settings: Setting) -> None:
         """設定値をファイルへ書き込む。"""
-        settings_dict = settings.model_dump()
+        settings_dict: dict[str, Any] = _setting_adapter.dump_python(settings)
 
         if isinstance(settings_dict["cors_policy_mode"], Enum):
             settings_dict["cors_policy_mode"] = settings_dict["cors_policy_mode"].value


### PR DESCRIPTION
## 内容
#1405 に基づき `Setting` を `dataclass` へ変更するリファクタリングを提案します。

`test_setting_invalid_input` はもともと過剰なテストであったため削除します。  

## 関連 Issue
part of #1405