### PR TITLE
整理: `CoreSpeaker` を `dataclass` へ変更 + リネーム

### DIFF
--- a/voicevox_engine/app/routers/morphing.py
+++ b/voicevox_engine/app/routers/morphing.py
@@ -57,7 +57,7 @@ def generate_morphing_router(
         version = core_version or core_manager.latest_version()
         core = core_manager.get_core(version)
 
-        speakers = metas_store.load_combined_metas(core.speakers)
+        speakers = metas_store.load_combined_metas(core.characters)
         try:
             morphable_targets = get_morphable_targets(speakers, base_style_ids)
         except StyleIdNotFoundError as e:
@@ -97,7 +97,7 @@ def generate_morphing_router(
         core = core_manager.get_core(version)
 
         # モーフィングが許可されないキャラクターペアを拒否する
-        speakers = metas_store.load_combined_metas(core.speakers)
+        speakers = metas_store.load_combined_metas(core.characters)
         try:
             morphable = is_morphable(speakers, base_style_id, target_style_id)
         except StyleIdNotFoundError as e:

--- a/voicevox_engine/app/routers/speaker.py
+++ b/voicevox_engine/app/routers/speaker.py
@@ -29,7 +29,7 @@ def generate_speaker_router(
         """話者情報の一覧を取得します。"""
         version = core_version or core_manager.latest_version()
         core = core_manager.get_core(version)
-        speakers = metas_store.load_combined_metas(core.speakers)
+        speakers = metas_store.load_combined_metas(core.characters)
         return filter_speakers_and_styles(speakers, "speaker")
 
     @router.get("/speaker_info")
@@ -78,8 +78,8 @@ def generate_speaker_router(
         version = core_version or core_manager.latest_version()
 
         # 該当話者を検索する
-        core_speakers = core_manager.get_core(version).speakers
-        speakers = metas_store.load_combined_metas(core_speakers)
+        core_characters = core_manager.get_core(version).characters
+        speakers = metas_store.load_combined_metas(core_characters)
         speakers = filter_speakers_and_styles(speakers, speaker_or_singer)
         speaker = next(
             filter(lambda spk: spk.speaker_uuid == speaker_uuid, speakers), None
@@ -143,7 +143,7 @@ def generate_speaker_router(
         """歌手情報の一覧を取得します"""
         version = core_version or core_manager.latest_version()
         core = core_manager.get_core(version)
-        singers = metas_store.load_combined_metas(core.speakers)
+        singers = metas_store.load_combined_metas(core.characters)
         return filter_speakers_and_styles(singers, "singer")
 
     @router.get("/singer_info")

--- a/voicevox_engine/core/core_adapter.py
+++ b/voicevox_engine/core/core_adapter.py
@@ -32,7 +32,7 @@ class CoreCharacter:
     name: str
     speaker_uuid: str
     styles: list[CoreCharacterStyle]
-    version: str # 話者のバージョン
+    version: str  # 話者のバージョン
 
 
 _core_character_adapter = TypeAdapter(CoreCharacter)

--- a/voicevox_engine/core/core_adapter.py
+++ b/voicevox_engine/core/core_adapter.py
@@ -7,7 +7,7 @@ from typing import Any, Literal, NewType
 
 import numpy as np
 from numpy.typing import NDArray
-from pydantic import BaseModel, Field, TypeAdapter
+from pydantic import TypeAdapter
 
 from ..metas.Metas import StyleId
 from .core_wrapper import CoreWrapper, OldCoreError
@@ -32,7 +32,7 @@ class CoreCharacter:
     name: str
     speaker_uuid: str
     styles: list[CoreCharacterStyle]
-    version: str = Field(title="話者のバージョン")
+    version: str # 話者のバージョン
 
 
 _core_character_adapter = TypeAdapter(CoreCharacter)

--- a/voicevox_engine/core/core_adapter.py
+++ b/voicevox_engine/core/core_adapter.py
@@ -16,14 +16,13 @@ CoreStyleId = NewType("CoreStyleId", int)
 CoreStyleType = Literal["talk", "singing_teacher", "frame_decode", "sing"]
 
 
-class CoreSpeakerStyle(BaseModel):
-    """
-    話者のスタイル情報
-    """
+@dataclass(frozen=True)
+class CoreCharacterStyle:
+    """コアに含まれるキャラクターのスタイル情報"""
 
     name: str
     id: CoreStyleId
-    type: CoreStyleType | None = Field(default="talk")
+    type: CoreStyleType | None = "talk"
 
 
 @dataclass(frozen=True)
@@ -32,7 +31,7 @@ class CoreCharacter:
 
     name: str
     speaker_uuid: str
-    styles: list[CoreSpeakerStyle]
+    styles: list[CoreCharacterStyle]
     version: str = Field(title="話者のバージョン")
 
 

--- a/voicevox_engine/core/core_adapter.py
+++ b/voicevox_engine/core/core_adapter.py
@@ -63,8 +63,8 @@ class CoreAdapter:
         return self.core.default_sampling_rate
 
     @property
-    def speakers(self) -> list[CoreCharacter]:
-        """話者情報"""
+    def characters(self) -> list[CoreCharacter]:
+        """キャラクター情報"""
         metas: list[Any] = json.loads(self.core.metas())
         return list(map(_core_character_adapter.validate_python, metas))
 

--- a/voicevox_engine/metas/MetasStore.py
+++ b/voicevox_engine/metas/MetasStore.py
@@ -6,7 +6,7 @@ from typing import Final, Literal
 
 from pydantic import BaseModel, Field
 
-from voicevox_engine.core.core_adapter import CoreSpeaker, CoreSpeakerStyle
+from voicevox_engine.core.core_adapter import CoreCharacter, CoreSpeakerStyle
 from voicevox_engine.metas.Metas import (
     Speaker,
     SpeakerStyle,
@@ -53,7 +53,7 @@ class MetasStore:
             for folder in engine_speakers_path.iterdir()
         }
 
-    def load_combined_metas(self, core_metas: list[CoreSpeaker]) -> list[Speaker]:
+    def load_combined_metas(self, core_metas: list[CoreCharacter]) -> list[Speaker]:
         """コアとエンジンのメタ情報を統合する。"""
         return [
             Speaker(

--- a/voicevox_engine/metas/MetasStore.py
+++ b/voicevox_engine/metas/MetasStore.py
@@ -6,7 +6,7 @@ from typing import Final, Literal
 
 from pydantic import BaseModel, Field
 
-from voicevox_engine.core.core_adapter import CoreCharacter, CoreSpeakerStyle
+from voicevox_engine.core.core_adapter import CoreCharacter, CoreCharacterStyle
 from voicevox_engine.metas.Metas import (
     Speaker,
     SpeakerStyle,
@@ -15,7 +15,7 @@ from voicevox_engine.metas.Metas import (
 )
 
 
-def cast_styles(cores: list[CoreSpeakerStyle]) -> list[SpeakerStyle]:
+def cast_styles(cores: list[CoreCharacterStyle]) -> list[SpeakerStyle]:
     """コアから取得したスタイル情報をエンジン形式へキャストする。"""
     return [
         SpeakerStyle(name=core.name, id=StyleId(core.id), type=core.type)


### PR DESCRIPTION
## 内容
概要: `CoreSpeaker` を `dataclass` 化した上でリネームしリファクタリング  

#1405 に基づき `CoreSpeaker` / `CoreSpeakerStyle` を `dataclass` へ変更するリファクタリングを提案します。  
また #1313 に沿って `CoreSpeaker` / `CoreSpeakerStyle` / `CoreAdapter.speakers` を `CoreCharacter` / `CoreCharacterStyle` / `CoreAdapter.characters` へリネームするリファクタリングを提案します。  

## 関連 Issue
part of #1405  
part of #1313