### PR TITLE
整理: `SpeakerSupportPermittedSynthesisMorphing` Enum の `._missing_()` を廃止

### DIFF
--- a/voicevox_engine/metas/Metas.py
+++ b/voicevox_engine/metas/Metas.py
@@ -36,10 +36,6 @@ class SpeakerSupportPermittedSynthesisMorphing(str, Enum):
     SELF_ONLY = "SELF_ONLY"  # 同じ話者内でのみ許可
     NOTHING = "NOTHING"  # 全て禁止
 
-    @classmethod
-    def _missing_(cls, value: object) -> "SpeakerSupportPermittedSynthesisMorphing":
-        return SpeakerSupportPermittedSynthesisMorphing.ALL
-
 
 class SpeakerSupportedFeatures(BaseModel):
     """
@@ -48,7 +44,7 @@ class SpeakerSupportedFeatures(BaseModel):
 
     permitted_synthesis_morphing: SpeakerSupportPermittedSynthesisMorphing = Field(
         title="モーフィング機能への対応",
-        default=SpeakerSupportPermittedSynthesisMorphing(None),
+        default=SpeakerSupportPermittedSynthesisMorphing.ALL,
     )
 
 


### PR DESCRIPTION
## 内容
概要: `SpeakerSupportPermittedSynthesisMorphing` Enum の `._missing_()` を廃止してリファクタリング  

`SpeakerSupportPermittedSynthesisMorphing` Enum はモーフィング許可を表現する Enum である。  
このクラスは [`._missing_()` メソッド](https://docs.python.org/ja/3/library/enum.html#enum.Enum._missing_) をオーバーライドしている。このメソッドは不正な値が渡された際のフォールバック動作を定義している。現在の `SpeakerSupportPermittedSynthesisMorphing` はこれを用いて不正な値が来たら全て `ALL` 扱いするようにしている。  

https://github.com/VOICEVOX/voicevox_engine/blob/f26d12410d711c89a7d2861d27de2b96f47a939f/voicevox_engine/metas/Metas.py#L39-L41

現在の ENGINE 内では `SpeakerSupportPermittedSynthesisMorphing(None)` によってデフォルト値を作っており、不正な値である `None` を渡すことで `ALL` をデフォルト値にしている。   
設計意図は不明であるが、恐らくこの挙動を可能にするために `._missing_()` をオーバーライドしている。  

https://github.com/VOICEVOX/voicevox_engine/blob/f26d12410d711c89a7d2861d27de2b96f47a939f/voicevox_engine/metas/Metas.py#L49-L52

しかし `._missing_()` オーバーライドは危険である。タイポで `SpeakerSupportPermittedSynthesisMorphing("NOTHIMG")` とすると「全て禁止」が「全て許可」へ自動変換されてしまう。  
`permitted_synthesis_morphing` のデフォルト値であれば `._missing_()` オーバーライドを使わずとも実装可能である。  
ゆえに `._missing_()` はメリットよりデメリットが大きい。  

このような背景から、 `SpeakerSupportPermittedSynthesisMorphing` Enum の `._missing_()` を廃止するリファクタリングを提案します。  

## 関連 Issue
無し