### PR TITLE
整理: モック版 TTS の後処理を共通化

### DIFF
--- a/voicevox_engine/dev/tts_engine/mock.py
+++ b/voicevox_engine/dev/tts_engine/mock.py
@@ -29,7 +29,7 @@ class MockTTSEngine(TTSEngine):
         style_id: StyleId,
         enable_interrogative_upspeak: bool = True,
     ) -> NDArray[np.float32]:
-        """音声合成用のクエリに含まれる読み仮名に基づいてOpenJTalkで音声波形を生成する。調音は反映されない。"""
+        """音声合成用のクエリに含まれる読み仮名に基づいてOpenJTalkで音声波形を生成する。モーラごとの調整は反映されない。"""
         # モーフィング時などに同一参照のqueryで複数回呼ばれる可能性があるので、元の引数のqueryに破壊的変更を行わない
         query = copy.deepcopy(query)
 

--- a/voicevox_engine/dev/tts_engine/mock.py
+++ b/voicevox_engine/dev/tts_engine/mock.py
@@ -1,16 +1,19 @@
 """TTSEngine のモック"""
 
 import copy
-from typing import Any
+from typing import Final
 
 import numpy as np
 from numpy.typing import NDArray
 from pyopenjtalk import tts
-from soxr import resample
 
 from ...metas.Metas import StyleId
 from ...model import AudioQuery
-from ...tts_pipeline.tts_engine import TTSEngine, to_flatten_moras
+from ...tts_pipeline.tts_engine import (
+    TTSEngine,
+    raw_wave_to_output_wave,
+    to_flatten_moras,
+)
 from ..core.mock import MockCoreWrapper
 
 
@@ -26,7 +29,7 @@ class MockTTSEngine(TTSEngine):
         style_id: StyleId,
         enable_interrogative_upspeak: bool = True,
     ) -> NDArray[np.float32]:
-        """音声合成用のクエリに含まれる読み仮名に基づいてOpenJTalkで音声波形を生成する"""
+        """音声合成用のクエリに含まれる読み仮名に基づいてOpenJTalkで音声波形を生成する。調音は反映されない。"""
         # モーフィング時などに同一参照のqueryで複数回呼ばれる可能性があるので、元の引数のqueryに破壊的変更を行わない
         query = copy.deepcopy(query)
 
@@ -34,39 +37,14 @@ class MockTTSEngine(TTSEngine):
         flatten_moras = to_flatten_moras(query.accent_phrases)
         kana_text = "".join([mora.text for mora in flatten_moras])
 
-        wave = self.forward(kana_text)
-
-        # volume
-        wave *= query.volumeScale
-
+        raw_wave, sr_raw_wave = self.forward(kana_text)
+        wave = raw_wave_to_output_wave(query, raw_wave, sr_raw_wave)
         return wave
 
-    def forward(self, text: str, **kwargs: dict[str, Any]) -> NDArray[np.float32]:
-        """
-        forward tts via pyopenjtalk.tts()
-        参照→TTSEngine のdocstring [Mock]
-
-        Parameters
-        ----------
-        text : str
-            入力文字列（例：読み上げたい文章をカタカナにした文字列、等）
-
-        Returns
-        -------
-        wave [NDArray[np.float32]]
-            音声波形データをNumPy配列で返します
-
-        Note
-        -------
-        ここで行う音声合成では、調声（ピッチ等）を反映しない
-
-        # pyopenjtalk.tts()の出力仕様
-        dtype=np.float64, 16 bit, mono 48000 Hz
-
-        # resampleの説明
-        非モック実装（decode_forward）と合わせるために、出力を24kHz、32bit浮動小数に変換した。
-        """
-        wave, _ = tts(text)
-        wave /= 2**15
-        wave_resampled: NDArray[np.float64] = resample(wave, 48000, 24000)
-        return wave_resampled.astype(np.float32)
+    def forward(self, text: str) -> tuple[NDArray[np.float32], int]:
+        """文字列から pyopenjtalk を用いて音声を合成する。"""
+        OJT_SAMPLING_RATE: Final = 48000
+        OJT_AMPLITUDE_MAX: Final = 2 ** (16 - 1)
+        raw_wave: NDArray[np.float64] = tts(text)[0]
+        raw_wave /= OJT_AMPLITUDE_MAX
+        return raw_wave.astype(np.float32), OJT_SAMPLING_RATE


### PR DESCRIPTION
## 内容
概要: モック版 TTS の後処理を共通化してリファクタリング  

モック版の音声合成は `MockTTSEngine.synthesize_wave()` にて実装されている。ここではコアの代わりに `pyopenjtalk.tts()` が実合成を担っており、コアとの sampling rate 差などを吸収している。  
少し前のリファクタリングによって  `synthesize_wave()` 内の後処理（例: リサンプリング、音量調整）は `raw_wave_to_output_wave()` 関数へまとめられた。モック版ではこれを利用していなかったが、`MockTTSEngine.forward()` をコア呼び出しと見立てればそのまま `raw_wave_to_output_wave()` を利用できる。  
これにより製品版とモック版の差異を小さくし、またモック版の機能を充実させることができる。   

このような背景から、モック版 TTS の後処理を共通化するリファクタリングを提案します。  

その際、`.forward()` の docstring が過剰である（コードとして表現すべき内容を docstring で示している）ことがわかったため、`.forward()` のリファクタリングを同時におこなった。  

## 関連 Issue
無し