### PR TITLE
整理: talk/sing キャラクターの取得をメソッドへ移動

### DIFF
--- a/voicevox_engine/app/routers/character.py
+++ b/voicevox_engine/app/routers/character.py
@@ -29,8 +29,7 @@ def generate_speaker_router(
         """話者情報の一覧を取得します。"""
         version = core_version or core_manager.latest_version()
         core = core_manager.get_core(version)
-        characters = metas_store.load_combined_metas(core.characters)
-        return filter_characters_and_styles(characters, "speaker")
+        return metas_store.talk_characters(core.characters)
 
     @router.get("/speaker_info")
     def speaker_info(
@@ -143,8 +142,7 @@ def generate_speaker_router(
         """歌手情報の一覧を取得します"""
         version = core_version or core_manager.latest_version()
         core = core_manager.get_core(version)
-        characters = metas_store.load_combined_metas(core.characters)
-        return filter_characters_and_styles(characters, "singer")
+        return metas_store.sing_characters(core.characters)
 
     @router.get("/singer_info")
     def singer_info(

--- a/voicevox_engine/metas/MetasStore.py
+++ b/voicevox_engine/metas/MetasStore.py
@@ -110,6 +110,16 @@ class MetasStore:
             )
         return characters
 
+    def talk_characters(self, core_characters: list[CoreCharacter]) -> list[Speaker]:
+        """話せるキャラクターの情報の一覧を取得する。"""
+        characters = self.load_combined_metas(core_characters)
+        return filter_characters_and_styles(characters, "speaker")
+
+    def sing_characters(self, core_characters: list[CoreCharacter]) -> list[Speaker]:
+        """歌えるキャラクターの情報の一覧を取得する。"""
+        characters = self.load_combined_metas(core_characters)
+        return filter_characters_and_styles(characters, "singer")
+
 
 def filter_characters_and_styles(
     characters: list[Character],


### PR DESCRIPTION
## 内容
概要: talk/sing キャラクターの取得をメソッドへ移動してリファクタリング  

現在の ENGINE では talk/sing キャラクターの取得（全取得 + フィルタリング）は router で実装されている。  
sing 機能が後から追加された関係でこれらは router に実装されているが、本来は `MetasStore` に実装されるべきである。こうすれば `speaker`/`singer` といった literal 値を内部実装に閉じ込めておけるし、`filter_characters_and_styles()` の利用範囲をより限定できる。また #1391 での `CoreManager` 内部化をおこなうのであればメソッド化は必須である。  

このような背景から、talk/sing キャラクターの取得をメソッドへ移動するリファクタリングを提案します。

本 PR はコード移動に特化した PR です。

## 関連 Issue
ref #1391