### PR TITLE
FIX: `AudioQuery`の互換性の問題を修正

### DIFF
--- a/test/e2e/__snapshots__/test_openapi/test_OpenAPIの形が変わっていないことを確認.json
+++ b/test/e2e/__snapshots__/test_openapi/test_OpenAPIの形が変わっていないことを確認.json
@@ -67,6 +67,7 @@
             "type": "number"
           },
           "pauseLengthScale": {
+            "default": 1,
             "title": "句読点などの無音時間（倍率）",
             "type": "number"
           },
@@ -99,7 +100,6 @@
           "volumeScale",
           "prePhonemeLength",
           "postPhonemeLength",
-          "pauseLengthScale",
           "outputSamplingRate",
           "outputStereo"
         ],
@@ -615,6 +615,7 @@
             "type": "number"
           },
           "pauseLengthScale": {
+            "default": 1,
             "title": "句読点などの無音時間（倍率）",
             "type": "number"
           },
@@ -657,8 +658,7 @@
           "intonationScale",
           "volumeScale",
           "prePhonemeLength",
-          "postPhonemeLength",
-          "pauseLengthScale"
+          "postPhonemeLength"
         ],
         "title": "Preset",
         "type": "object"

--- a/voicevox_engine/model.py
+++ b/voicevox_engine/model.py
@@ -28,7 +28,7 @@ class AudioQuery(BaseModel):
     pauseLength: float | SkipJsonSchema[None] = Field(
         default=None, title="句読点などの無音時間"
     )
-    pauseLengthScale: float = Field(title="句読点などの無音時間（倍率）")
+    pauseLengthScale: float = Field(default=1, title="句読点などの無音時間（倍率）")
     outputSamplingRate: int = Field(title="音声データの出力サンプリングレート")
     outputStereo: bool = Field(title="音声データをステレオ出力するか否か")
     kana: str | SkipJsonSchema[None] = Field(

--- a/voicevox_engine/preset/model.py
+++ b/voicevox_engine/preset/model.py
@@ -28,4 +28,4 @@ class Preset(BaseModel):
     pauseLength: float | SkipJsonSchema[None] = Field(
         default=None, title="句読点などの無音時間"
     )
-    pauseLengthScale: float = Field(title="句読点などの無音時間（倍率）")
+    pauseLengthScale: float = Field(default=1, title="句読点などの無音時間（倍率）")


### PR DESCRIPTION
## 内容

`AudioQuery`に追加された`pauseLengthScale`が必須になっているため過去のクエリを保存していたり古いOpenAPIに基づいて生成したクライアントがモデル内で宣言していないキーを削除していた場合互換性の問題が発生します。

`pauseLengthScale`にデフォルト値を設定することで互換性を維持します。

## 関連 Issue

- fix: #1424

## その他

とりあえずエディタで動作することは確認しました。
一応テストも通ったので問題はないと思いますがこの辺りの変更に詳しくないので確認不足があるかもしれません。

また、テストも追加するべきかもしれません。