### PR TITLE
整理: 音声合成系テストの utils を統廃合

### DIFF
--- a/test/unit/tts_pipeline/test_tts_engine.py
+++ b/test/unit/tts_pipeline/test_tts_engine.py
@@ -140,14 +140,6 @@ def test_to_flatten_phonemes() -> None:
     assert true_phonemes == phonemes
 
 
-def _gen_hello_hiho_text() -> str:
-    return "こんにちは、ヒホです"
-
-
-def _gen_hello_hiho_kana() -> str:
-    return "コンニチワ'、ヒ'ホデ_ス"
-
-
 def _gen_hello_hiho_accent_phrases() -> list[AccentPhrase]:
     return [
         AccentPhrase(
@@ -187,7 +179,7 @@ def _gen_hello_hiho_query() -> AudioQuery:
         pauseLengthScale=0.8,
         outputSamplingRate=12000,
         outputStereo=True,
-        kana=_gen_hello_hiho_kana(),
+        kana="コンニチワ'、ヒ'ホデ_ス",
     )
 
 
@@ -352,7 +344,7 @@ def test_mocked_create_accent_phrases_output(
     """モックされた `TTSEngine.create_accent_phrases()` の出力スナップショットが一定である"""
     # Inputs
     tts_engine = TTSEngine(MockCoreWrapper())
-    hello_hiho = _gen_hello_hiho_text()
+    hello_hiho = "こんにちは、ヒホです"
     # Outputs
     result = tts_engine.create_accent_phrases(hello_hiho, StyleId(1))
     # Tests
@@ -365,7 +357,7 @@ def test_mocked_create_accent_phrases_from_kana_output(
     """モックされた `TTSEngine.create_accent_phrases_from_kana()` の出力スナップショットが一定である"""
     # Inputs
     tts_engine = TTSEngine(MockCoreWrapper())
-    hello_hiho = _gen_hello_hiho_kana()
+    hello_hiho = "コンニチワ'、ヒ'ホデ_ス"
     # Outputs
     result = tts_engine.create_accent_phrases_from_kana(hello_hiho, StyleId(1))
     # Tests

--- a/test/unit/tts_pipeline/test_tts_engine.py
+++ b/test/unit/tts_pipeline/test_tts_engine.py
@@ -26,6 +26,7 @@ from voicevox_engine.tts_pipeline.tts_engine import (
 )
 
 from .test_text_analyzer import stub_unknown_features_koxx
+from .tts_utils import gen_mora
 
 
 def yukarin_s_mock(
@@ -103,32 +104,13 @@ class MockCore:
         return True
 
 
-def _gen_mora(
-    text: str,
-    consonant: str | None,
-    consonant_length: float | None,
-    vowel: str,
-    vowel_length: float,
-    pitch: float,
-) -> Mora:
-    """Generate Mora with positional arguments for test simplicity."""
-    return Mora(
-        text=text,
-        consonant=consonant,
-        consonant_length=consonant_length,
-        vowel=vowel,
-        vowel_length=vowel_length,
-        pitch=pitch,
-    )
-
-
 def test_to_flatten_phonemes() -> None:
     """Test `to_flatten_phonemes`."""
     # Inputs
     moras = [
-        _gen_mora("　", None, None, "sil", 2 * 0.01067, 0.0),
-        _gen_mora("ヒ", "h", 2 * 0.01067, "i", 4 * 0.01067, 100.0),
-        _gen_mora("　", None, None, "sil", 6 * 0.01067, 0.0),
+        gen_mora("　", None, None, "sil", 2 * 0.01067, 0.0),
+        gen_mora("ヒ", "h", 2 * 0.01067, "i", 4 * 0.01067, 100.0),
+        gen_mora("　", None, None, "sil", 6 * 0.01067, 0.0),
     ]
 
     # Expects
@@ -144,21 +126,21 @@ def _gen_hello_hiho_accent_phrases() -> list[AccentPhrase]:
     return [
         AccentPhrase(
             moras=[
-                _gen_mora("コ", "k", 0.0, "o", 0.0, 0.0),
-                _gen_mora("ン", None, None, "N", 0.0, 0.0),
-                _gen_mora("ニ", "n", 0.0, "i", 0.0, 0.0),
-                _gen_mora("チ", "ch", 0.0, "i", 0.0, 0.0),
-                _gen_mora("ワ", "w", 0.0, "a", 0.0, 0.0),
+                gen_mora("コ", "k", 0.0, "o", 0.0, 0.0),
+                gen_mora("ン", None, None, "N", 0.0, 0.0),
+                gen_mora("ニ", "n", 0.0, "i", 0.0, 0.0),
+                gen_mora("チ", "ch", 0.0, "i", 0.0, 0.0),
+                gen_mora("ワ", "w", 0.0, "a", 0.0, 0.0),
             ],
             accent=5,
-            pause_mora=_gen_mora("、", None, None, "pau", 0.0, 0.0),
+            pause_mora=gen_mora("、", None, None, "pau", 0.0, 0.0),
         ),
         AccentPhrase(
             moras=[
-                _gen_mora("ヒ", "h", 0.0, "i", 0.0, 0.0),
-                _gen_mora("ホ", "h", 0.0, "o", 0.0, 0.0),
-                _gen_mora("デ", "d", 0.0, "e", 0.0, 0.0),
-                _gen_mora("ス", "s", 0.0, "U", 0.0, 0.0),
+                gen_mora("ヒ", "h", 0.0, "i", 0.0, 0.0),
+                gen_mora("ホ", "h", 0.0, "o", 0.0, 0.0),
+                gen_mora("デ", "d", 0.0, "e", 0.0, 0.0),
+                gen_mora("ス", "s", 0.0, "U", 0.0, 0.0),
             ],
             accent=1,
             pause_mora=None,

--- a/test/unit/tts_pipeline/test_wave_synthesizer.py
+++ b/test/unit/tts_pipeline/test_wave_synthesizer.py
@@ -3,7 +3,7 @@
 import numpy as np
 
 from voicevox_engine.model import AudioQuery
-from voicevox_engine.tts_pipeline.model import AccentPhrase, Mora
+from voicevox_engine.tts_pipeline.model import AccentPhrase
 from voicevox_engine.tts_pipeline.tts_engine import (
     apply_intonation_scale,
     apply_output_sampling_rate,

--- a/test/unit/tts_pipeline/test_wave_synthesizer.py
+++ b/test/unit/tts_pipeline/test_wave_synthesizer.py
@@ -17,6 +17,8 @@ from voicevox_engine.tts_pipeline.tts_engine import (
     raw_wave_to_output_wave,
 )
 
+from .tts_utils import gen_mora
+
 TRUE_NUM_PHONEME = 45
 
 
@@ -50,38 +52,19 @@ def _gen_query(
     )
 
 
-def _gen_mora(
-    text: str,
-    consonant: str | None,
-    consonant_length: float | None,
-    vowel: str,
-    vowel_length: float,
-    pitch: float,
-) -> Mora:
-    """Generate Mora with positional arguments for test simplicity."""
-    return Mora(
-        text=text,
-        consonant=consonant,
-        consonant_length=consonant_length,
-        vowel=vowel,
-        vowel_length=vowel_length,
-        pitch=pitch,
-    )
-
-
 def test_apply_prepost_silence() -> None:
     """Test `apply_prepost_silence`."""
     # Inputs
     query = _gen_query(prePhonemeLength=2 * 0.01067, postPhonemeLength=6 * 0.01067)
     moras = [
-        _gen_mora("ヒ", "h", 2 * 0.01067, "i", 4 * 0.01067, 100.0),
+        gen_mora("ヒ", "h", 2 * 0.01067, "i", 4 * 0.01067, 100.0),
     ]
 
     # Expects
     true_moras_with_silence = [
-        _gen_mora("　", None, None, "sil", 2 * 0.01067, 0.0),
-        _gen_mora("ヒ", "h", 2 * 0.01067, "i", 4 * 0.01067, 100.0),
-        _gen_mora("　", None, None, "sil", 6 * 0.01067, 0.0),
+        gen_mora("　", None, None, "sil", 2 * 0.01067, 0.0),
+        gen_mora("ヒ", "h", 2 * 0.01067, "i", 4 * 0.01067, 100.0),
+        gen_mora("　", None, None, "sil", 6 * 0.01067, 0.0),
     ]
 
     # Outputs
@@ -95,20 +78,20 @@ def test_apply_speed_scale() -> None:
     # Inputs
     query = _gen_query(speedScale=2.0)
     input_moras = [
-        _gen_mora("コ", "k", 2 * 0.01067, "o", 4 * 0.01067, 50.0),
-        _gen_mora("ン", None, None, "N", 4 * 0.01067, 50.0),
-        _gen_mora("、", None, None, "pau", 2 * 0.01067, 0.0),
-        _gen_mora("ヒ", "h", 2 * 0.01067, "i", 4 * 0.01067, 125.0),
-        _gen_mora("ホ", "h", 4 * 0.01067, "O", 2 * 0.01067, 0.0),
+        gen_mora("コ", "k", 2 * 0.01067, "o", 4 * 0.01067, 50.0),
+        gen_mora("ン", None, None, "N", 4 * 0.01067, 50.0),
+        gen_mora("、", None, None, "pau", 2 * 0.01067, 0.0),
+        gen_mora("ヒ", "h", 2 * 0.01067, "i", 4 * 0.01067, 125.0),
+        gen_mora("ホ", "h", 4 * 0.01067, "O", 2 * 0.01067, 0.0),
     ]
 
     # Expects - x2 fast
     true_moras = [
-        _gen_mora("コ", "k", 1 * 0.01067, "o", 2 * 0.01067, 50.0),
-        _gen_mora("ン", None, None, "N", 2 * 0.01067, 50.0),
-        _gen_mora("、", None, None, "pau", 1 * 0.01067, 0.0),
-        _gen_mora("ヒ", "h", 1 * 0.01067, "i", 2 * 0.01067, 125.0),
-        _gen_mora("ホ", "h", 2 * 0.01067, "O", 1 * 0.01067, 0.0),
+        gen_mora("コ", "k", 1 * 0.01067, "o", 2 * 0.01067, 50.0),
+        gen_mora("ン", None, None, "N", 2 * 0.01067, 50.0),
+        gen_mora("、", None, None, "pau", 1 * 0.01067, 0.0),
+        gen_mora("ヒ", "h", 1 * 0.01067, "i", 2 * 0.01067, 125.0),
+        gen_mora("ホ", "h", 2 * 0.01067, "O", 1 * 0.01067, 0.0),
     ]
 
     # Outputs
@@ -122,20 +105,20 @@ def test_apply_pitch_scale() -> None:
     # Inputs
     query = _gen_query(pitchScale=2.0)
     input_moras = [
-        _gen_mora("コ", "k", 0.0, "o", 0.0, 50.0),
-        _gen_mora("ン", None, None, "N", 0.0, 50.0),
-        _gen_mora("、", None, None, "pau", 0.0, 0.0),
-        _gen_mora("ヒ", "h", 0.0, "i", 0.0, 125.0),
-        _gen_mora("ホ", "h", 0.0, "O", 0.0, 0.0),
+        gen_mora("コ", "k", 0.0, "o", 0.0, 50.0),
+        gen_mora("ン", None, None, "N", 0.0, 50.0),
+        gen_mora("、", None, None, "pau", 0.0, 0.0),
+        gen_mora("ヒ", "h", 0.0, "i", 0.0, 125.0),
+        gen_mora("ホ", "h", 0.0, "O", 0.0, 0.0),
     ]
 
     # Expects - x4 value scaled
     true_moras = [
-        _gen_mora("コ", "k", 0.0, "o", 0.0, 200.0),
-        _gen_mora("ン", None, None, "N", 0.0, 200.0),
-        _gen_mora("、", None, None, "pau", 0.0, 0.0),
-        _gen_mora("ヒ", "h", 0.0, "i", 0.0, 500.0),
-        _gen_mora("ホ", "h", 0.0, "O", 0.0, 0.0),
+        gen_mora("コ", "k", 0.0, "o", 0.0, 200.0),
+        gen_mora("ン", None, None, "N", 0.0, 200.0),
+        gen_mora("、", None, None, "pau", 0.0, 0.0),
+        gen_mora("ヒ", "h", 0.0, "i", 0.0, 500.0),
+        gen_mora("ホ", "h", 0.0, "O", 0.0, 0.0),
     ]
 
     # Outputs
@@ -149,20 +132,20 @@ def test_apply_intonation_scale() -> None:
     # Inputs
     query = _gen_query(intonationScale=0.5)
     input_moras = [
-        _gen_mora("コ", "k", 0.0, "o", 0.0, 200.0),
-        _gen_mora("ン", None, None, "N", 0.0, 200.0),
-        _gen_mora("、", None, None, "pau", 0.0, 0.0),
-        _gen_mora("ヒ", "h", 0.0, "i", 0.0, 500.0),
-        _gen_mora("ホ", "h", 0.0, "O", 0.0, 0.0),
+        gen_mora("コ", "k", 0.0, "o", 0.0, 200.0),
+        gen_mora("ン", None, None, "N", 0.0, 200.0),
+        gen_mora("、", None, None, "pau", 0.0, 0.0),
+        gen_mora("ヒ", "h", 0.0, "i", 0.0, 500.0),
+        gen_mora("ホ", "h", 0.0, "O", 0.0, 0.0),
     ]
 
     # Expects - mean=300 var x0.5 intonation scaling
     true_moras = [
-        _gen_mora("コ", "k", 0.0, "o", 0.0, 250.0),
-        _gen_mora("ン", None, None, "N", 0.0, 250.0),
-        _gen_mora("、", None, None, "pau", 0.0, 0.0),
-        _gen_mora("ヒ", "h", 0.0, "i", 0.0, 400.0),
-        _gen_mora("ホ", "h", 0.0, "O", 0.0, 0.0),
+        gen_mora("コ", "k", 0.0, "o", 0.0, 250.0),
+        gen_mora("ン", None, None, "N", 0.0, 250.0),
+        gen_mora("、", None, None, "pau", 0.0, 0.0),
+        gen_mora("ヒ", "h", 0.0, "i", 0.0, 400.0),
+        gen_mora("ホ", "h", 0.0, "O", 0.0, 0.0),
     ]
 
     # Outputs
@@ -222,13 +205,13 @@ def test_count_frame_per_unit() -> None:
     """Test `count_frame_per_unit`."""
     # Inputs
     moras = [
-        _gen_mora("　", None, None, "　", 2 * 0.01067, 0.0),  # 0.01067 [sec/frame]
-        _gen_mora("コ", "k", 2 * 0.01067, "o", 4 * 0.01067, 0.0),
-        _gen_mora("ン", None, None, "N", 4 * 0.01067, 0.0),
-        _gen_mora("、", None, None, "pau", 2 * 0.01067, 0.0),
-        _gen_mora("ヒ", "h", 2 * 0.01067, "i", 4 * 0.01067, 0.0),
-        _gen_mora("ホ", "h", 4 * 0.01067, "O", 2 * 0.01067, 0.0),
-        _gen_mora("　", None, None, "　", 6 * 0.01067, 0.0),
+        gen_mora("　", None, None, "　", 2 * 0.01067, 0.0),  # 0.01067 [sec/frame]
+        gen_mora("コ", "k", 2 * 0.01067, "o", 4 * 0.01067, 0.0),
+        gen_mora("ン", None, None, "N", 4 * 0.01067, 0.0),
+        gen_mora("、", None, None, "pau", 2 * 0.01067, 0.0),
+        gen_mora("ヒ", "h", 2 * 0.01067, "i", 4 * 0.01067, 0.0),
+        gen_mora("ホ", "h", 4 * 0.01067, "O", 2 * 0.01067, 0.0),
+        gen_mora("　", None, None, "　", 6 * 0.01067, 0.0),
     ]
 
     # Expects
@@ -252,16 +235,16 @@ def test_query_to_decoder_feature() -> None:
     accent_phrases = [
         AccentPhrase(
             moras=[
-                _gen_mora("コ", "k", 2 * 0.01067, "o", 4 * 0.01067, 50.0),
-                _gen_mora("ン", None, None, "N", 4 * 0.01067, 50.0),
+                gen_mora("コ", "k", 2 * 0.01067, "o", 4 * 0.01067, 50.0),
+                gen_mora("ン", None, None, "N", 4 * 0.01067, 50.0),
             ],
             accent=1,
-            pause_mora=_gen_mora("、", None, None, "pau", 2 * 0.01067, 0.0),
+            pause_mora=gen_mora("、", None, None, "pau", 2 * 0.01067, 0.0),
         ),
         AccentPhrase(
             moras=[
-                _gen_mora("ヒ", "h", 2 * 0.01067, "i", 4 * 0.01067, 125.0),
-                _gen_mora("ホ", "h", 4 * 0.01067, "O", 2 * 0.01067, 0.0),
+                gen_mora("ヒ", "h", 2 * 0.01067, "i", 4 * 0.01067, 125.0),
+                gen_mora("ホ", "h", 4 * 0.01067, "O", 2 * 0.01067, 0.0),
             ],
             accent=1,
             pause_mora=None,

--- a/test/unit/tts_pipeline/tts_utils.py
+++ b/test/unit/tts_pipeline/tts_utils.py
@@ -1,0 +1,22 @@
+"""合成系テスト向けの utility"""
+
+from voicevox_engine.tts_pipeline.model import Mora
+
+
+def gen_mora(
+    text: str,
+    consonant: str | None,
+    consonant_length: float | None,
+    vowel: str,
+    vowel_length: float,
+    pitch: float,
+) -> Mora:
+    """Generate Mora with positional arguments for test simplicity."""
+    return Mora(
+        text=text,
+        consonant=consonant,
+        consonant_length=consonant_length,
+        vowel=vowel,
+        vowel_length=vowel_length,
+        pitch=pitch,
+    )


### PR DESCRIPTION
## 内容
概要: 音声合成系テストの utils を統廃合してリファクタリング

音声合成系テストは繰り返し処理を util 関数として切り出している。  
度重なるテストの更新により、一部の util は切り出す必要がなくなっている。逆に一部の util は複数ファイルでそれぞれ定義されており共通化すべき状態にある。  

このような背景から、音声合成系テストの utils を廃止・統合するリファクタリングを提案します。  

変更された utils は以下になります：  

- `_gen_mora()`: 複数ファイルで統一関数が定義（コピペ）されていたため、モジュールへ切り出しリネーム
- `_gen_hello_hiho_text()`: ベタ書きして削除
- `_gen_hello_hiho_kana()`: ベタ書きして削除

## 関連 Issue
無し