### PR TITLE
整理: `apply_interrogative_upspeak()` のテストを整理

### DIFF
--- a/test/unit/tts_pipeline/test_tts_engine.py
+++ b/test/unit/tts_pipeline/test_tts_engine.py
@@ -523,15 +523,15 @@ def koreha_arimasuka_base_expected() -> list[AccentPhrase]:
 
 
 def create_synthesis_test_base(
-    text: str, expected: list[AccentPhrase], enable_interrogative_upspeak: bool
-) -> None:
+    text: str, enable_interrogative_upspeak: bool
+) -> list[AccentPhrase]:
     """音声合成時に疑問文モーラ処理を行っているかどうかを検証
     (https://github.com/VOICEVOX/voicevox_engine/issues/272#issuecomment-1022610866)
     """
     tts_engine = TTSEngine(core=MockCoreWrapper())
     inputs = tts_engine.create_accent_phrases(text, StyleId(1))
     outputs = apply_interrogative_upspeak(inputs, enable_interrogative_upspeak)
-    assert expected == outputs, f"case(text:{text})"
+    return outputs
 
 
 def test_create_accent_phrases() -> None:
@@ -548,6 +548,7 @@ def test_create_accent_phrases() -> None:
 
 def test_upspeak_voiced_last_mora() -> None:
     # voiced + "？" + flagON -> upspeak
+    # Expects
     expected = koreha_arimasuka_base_expected()
     expected[-1].is_interrogative = True
     expected[-1].moras += [
@@ -560,28 +561,33 @@ def test_upspeak_voiced_last_mora() -> None:
             pitch=np.float32(expected[-1].moras[-1].pitch) + 0.3,
         )
     ]
-    create_synthesis_test_base(
-        text="これはありますか？",
-        expected=expected,
-        enable_interrogative_upspeak=True,
+    # Outputs
+    outputs = create_synthesis_test_base(
+        text="これはありますか？", enable_interrogative_upspeak=True
     )
+    # Test
+    assert expected == outputs
 
     # voiced + "？" + flagOFF -> non-upspeak
+    # Expects
     expected = koreha_arimasuka_base_expected()
     expected[-1].is_interrogative = True
-    create_synthesis_test_base(
-        text="これはありますか？",
-        expected=expected,
-        enable_interrogative_upspeak=False,
+    # Outputs
+    outputs = create_synthesis_test_base(
+        text="これはありますか？", enable_interrogative_upspeak=False
     )
+    # Test
+    assert expected == outputs
 
     # voiced + "" + flagON -> non-upspeak
+    # Expects
     expected = koreha_arimasuka_base_expected()
-    create_synthesis_test_base(
-        text="これはありますか",
-        expected=expected,
-        enable_interrogative_upspeak=True,
+    # Outputs
+    outputs = create_synthesis_test_base(
+        text="これはありますか", enable_interrogative_upspeak=True
     )
+    # Test
+    assert expected == outputs
 
 
 def test_upspeak_voiced_N_last_mora() -> None:
@@ -605,14 +611,15 @@ def test_upspeak_voiced_N_last_mora() -> None:
         ]
 
     # voiced + "" + flagON -> upspeak
+    # Expects
     expected = nn_base_expected()
-    create_synthesis_test_base(
-        text="ん",
-        expected=expected,
-        enable_interrogative_upspeak=True,
-    )
+    # Outputs
+    outputs = create_synthesis_test_base(text="ん", enable_interrogative_upspeak=True)
+    # Test
+    assert expected == outputs
 
     # voiced + "？" + flagON -> upspeak
+    # Expects
     expected = nn_base_expected()
     expected[-1].is_interrogative = True
     expected[-1].moras += [
@@ -625,20 +632,21 @@ def test_upspeak_voiced_N_last_mora() -> None:
             pitch=np.float32(expected[-1].moras[-1].pitch) + 0.3,
         )
     ]
-    create_synthesis_test_base(
-        text="ん？",
-        expected=expected,
-        enable_interrogative_upspeak=True,
-    )
+    # Outputs
+    outputs = create_synthesis_test_base(text="ん？", enable_interrogative_upspeak=True)
+    # Test
+    assert expected == outputs
 
     # voiced + "？" + flagOFF -> non-upspeak
+    # Expects
     expected = nn_base_expected()
     expected[-1].is_interrogative = True
-    create_synthesis_test_base(
-        text="ん？",
-        expected=expected,
-        enable_interrogative_upspeak=False,
+    # Outputs
+    outputs = create_synthesis_test_base(
+        text="ん？", enable_interrogative_upspeak=False
     )
+    # Test
+    assert expected == outputs
 
 
 def test_upspeak_unvoiced_last_mora() -> None:
@@ -662,30 +670,32 @@ def test_upspeak_unvoiced_last_mora() -> None:
         ]
 
     # unvoiced + "" + flagON -> non-upspeak
+    # Expects
     expected = ltu_base_expected()
-    create_synthesis_test_base(
-        text="っ",
-        expected=expected,
-        enable_interrogative_upspeak=True,
-    )
+    # Outputs
+    outputs = create_synthesis_test_base(text="っ", enable_interrogative_upspeak=True)
+    # Test
+    assert expected == outputs
 
     # unvoiced + "？" + flagON -> non-upspeak
+    # Expects
     expected = ltu_base_expected()
     expected[-1].is_interrogative = True
-    create_synthesis_test_base(
-        text="っ？",
-        expected=expected,
-        enable_interrogative_upspeak=True,
-    )
+    # Outputs
+    outputs = create_synthesis_test_base(text="っ？", enable_interrogative_upspeak=True)
+    # Test
+    assert expected == outputs
 
     # unvoiced + "？" + flagOFF -> non-upspeak
+    # Expects
     expected = ltu_base_expected()
     expected[-1].is_interrogative = True
-    create_synthesis_test_base(
-        text="っ？",
-        expected=expected,
-        enable_interrogative_upspeak=False,
+    # Outputs
+    outputs = create_synthesis_test_base(
+        text="っ？", enable_interrogative_upspeak=False
     )
+    # Test
+    assert expected == outputs
 
 
 def test_upspeak_voiced_u_last_mora() -> None:
@@ -709,14 +719,15 @@ def test_upspeak_voiced_u_last_mora() -> None:
         ]
 
     # voiced + "" + flagON -> non-upspeak
+    # Expects
     expected = su_base_expected()
-    create_synthesis_test_base(
-        text="す",
-        expected=expected,
-        enable_interrogative_upspeak=True,
-    )
+    # Outputs
+    outputs = create_synthesis_test_base(text="す", enable_interrogative_upspeak=True)
+    # Test
+    assert expected == outputs
 
     # voiced + "？" + flagON -> upspeak
+    # Expects
     expected = su_base_expected()
     expected[-1].is_interrogative = True
     expected[-1].moras += [
@@ -729,17 +740,18 @@ def test_upspeak_voiced_u_last_mora() -> None:
             pitch=expected[-1].moras[-1].pitch + 0.3,
         )
     ]
-    create_synthesis_test_base(
-        text="す？",
-        expected=expected,
-        enable_interrogative_upspeak=True,
-    )
+    # Outputs
+    outputs = create_synthesis_test_base(text="す？", enable_interrogative_upspeak=True)
+    # Test
+    assert expected == outputs
 
     # voiced + "？" + flagOFF -> non-upspeak
+    # Expects
     expected = su_base_expected()
     expected[-1].is_interrogative = True
-    create_synthesis_test_base(
-        text="す？",
-        expected=expected,
-        enable_interrogative_upspeak=False,
+    # Outputs
+    outputs = create_synthesis_test_base(
+        text="す？", enable_interrogative_upspeak=False
     )
+    # Test
+    assert expected == outputs

--- a/test/unit/tts_pipeline/test_tts_engine.py
+++ b/test/unit/tts_pipeline/test_tts_engine.py
@@ -522,16 +522,9 @@ def koreha_arimasuka_base_expected() -> list[AccentPhrase]:
     ]
 
 
-def create_synthesis_test_base(
-    text: str, enable_interrogative_upspeak: bool
-) -> list[AccentPhrase]:
-    """音声合成時に疑問文モーラ処理を行っているかどうかを検証
-    (https://github.com/VOICEVOX/voicevox_engine/issues/272#issuecomment-1022610866)
-    """
+def create_synthesis_test_base(text: str) -> list[AccentPhrase]:
     tts_engine = TTSEngine(core=MockCoreWrapper())
-    inputs = tts_engine.create_accent_phrases(text, StyleId(1))
-    outputs = apply_interrogative_upspeak(inputs, enable_interrogative_upspeak)
-    return outputs
+    return tts_engine.create_accent_phrases(text, StyleId(1))
 
 
 def test_create_accent_phrases() -> None:
@@ -548,6 +541,8 @@ def test_create_accent_phrases() -> None:
 
 def test_upspeak_voiced_last_mora() -> None:
     # voiced + "？" + flagON -> upspeak
+    # Inputs
+    inputs = create_synthesis_test_base(text="これはありますか？")
     # Expects
     expected = koreha_arimasuka_base_expected()
     expected[-1].is_interrogative = True
@@ -562,30 +557,28 @@ def test_upspeak_voiced_last_mora() -> None:
         )
     ]
     # Outputs
-    outputs = create_synthesis_test_base(
-        text="これはありますか？", enable_interrogative_upspeak=True
-    )
+    outputs = apply_interrogative_upspeak(inputs, True)
     # Test
     assert expected == outputs
 
     # voiced + "？" + flagOFF -> non-upspeak
+    # Inputs
+    inputs = create_synthesis_test_base(text="これはありますか？")
     # Expects
     expected = koreha_arimasuka_base_expected()
     expected[-1].is_interrogative = True
     # Outputs
-    outputs = create_synthesis_test_base(
-        text="これはありますか？", enable_interrogative_upspeak=False
-    )
+    outputs = apply_interrogative_upspeak(inputs, False)
     # Test
     assert expected == outputs
 
     # voiced + "" + flagON -> non-upspeak
+    # Inputs
+    inputs = create_synthesis_test_base(text="これはありますか")
     # Expects
     expected = koreha_arimasuka_base_expected()
     # Outputs
-    outputs = create_synthesis_test_base(
-        text="これはありますか", enable_interrogative_upspeak=True
-    )
+    outputs = apply_interrogative_upspeak(inputs, True)
     # Test
     assert expected == outputs
 
@@ -611,14 +604,18 @@ def test_upspeak_voiced_N_last_mora() -> None:
         ]
 
     # voiced + "" + flagON -> upspeak
+    # Inputs
+    inputs = create_synthesis_test_base(text="ん")
     # Expects
     expected = nn_base_expected()
     # Outputs
-    outputs = create_synthesis_test_base(text="ん", enable_interrogative_upspeak=True)
+    outputs = apply_interrogative_upspeak(inputs, True)
     # Test
     assert expected == outputs
 
     # voiced + "？" + flagON -> upspeak
+    # Inputs
+    inputs = create_synthesis_test_base(text="ん？")
     # Expects
     expected = nn_base_expected()
     expected[-1].is_interrogative = True
@@ -633,18 +630,18 @@ def test_upspeak_voiced_N_last_mora() -> None:
         )
     ]
     # Outputs
-    outputs = create_synthesis_test_base(text="ん？", enable_interrogative_upspeak=True)
+    outputs = apply_interrogative_upspeak(inputs, True)
     # Test
     assert expected == outputs
 
     # voiced + "？" + flagOFF -> non-upspeak
+    # Inputs
+    inputs = create_synthesis_test_base(text="ん？")
     # Expects
     expected = nn_base_expected()
     expected[-1].is_interrogative = True
     # Outputs
-    outputs = create_synthesis_test_base(
-        text="ん？", enable_interrogative_upspeak=False
-    )
+    outputs = apply_interrogative_upspeak(inputs, False)
     # Test
     assert expected == outputs
 
@@ -670,30 +667,34 @@ def test_upspeak_unvoiced_last_mora() -> None:
         ]
 
     # unvoiced + "" + flagON -> non-upspeak
+    # Inputs
+    inputs = create_synthesis_test_base(text="っ")
     # Expects
     expected = ltu_base_expected()
     # Outputs
-    outputs = create_synthesis_test_base(text="っ", enable_interrogative_upspeak=True)
+    outputs = apply_interrogative_upspeak(inputs, True)
     # Test
     assert expected == outputs
 
     # unvoiced + "？" + flagON -> non-upspeak
+    # Inputs
+    inputs = create_synthesis_test_base(text="っ？")
     # Expects
     expected = ltu_base_expected()
     expected[-1].is_interrogative = True
     # Outputs
-    outputs = create_synthesis_test_base(text="っ？", enable_interrogative_upspeak=True)
+    outputs = apply_interrogative_upspeak(inputs, True)
     # Test
     assert expected == outputs
 
     # unvoiced + "？" + flagOFF -> non-upspeak
+    # Inputs
+    inputs = create_synthesis_test_base(text="っ？")
     # Expects
     expected = ltu_base_expected()
     expected[-1].is_interrogative = True
     # Outputs
-    outputs = create_synthesis_test_base(
-        text="っ？", enable_interrogative_upspeak=False
-    )
+    outputs = apply_interrogative_upspeak(inputs, False)
     # Test
     assert expected == outputs
 
@@ -719,14 +720,18 @@ def test_upspeak_voiced_u_last_mora() -> None:
         ]
 
     # voiced + "" + flagON -> non-upspeak
+    # Inputs
+    inputs = create_synthesis_test_base(text="す")
     # Expects
     expected = su_base_expected()
     # Outputs
-    outputs = create_synthesis_test_base(text="す", enable_interrogative_upspeak=True)
+    outputs = apply_interrogative_upspeak(inputs, True)
     # Test
     assert expected == outputs
 
     # voiced + "？" + flagON -> upspeak
+    # Inputs
+    inputs = create_synthesis_test_base(text="す？")
     # Expects
     expected = su_base_expected()
     expected[-1].is_interrogative = True
@@ -741,17 +746,17 @@ def test_upspeak_voiced_u_last_mora() -> None:
         )
     ]
     # Outputs
-    outputs = create_synthesis_test_base(text="す？", enable_interrogative_upspeak=True)
+    outputs = apply_interrogative_upspeak(inputs, True)
     # Test
     assert expected == outputs
 
     # voiced + "？" + flagOFF -> non-upspeak
+    # Inputs
+    inputs = create_synthesis_test_base(text="す？")
     # Expects
     expected = su_base_expected()
     expected[-1].is_interrogative = True
     # Outputs
-    outputs = create_synthesis_test_base(
-        text="す？", enable_interrogative_upspeak=False
-    )
+    outputs = apply_interrogative_upspeak(inputs, False)
     # Test
     assert expected == outputs


### PR DESCRIPTION
## 内容
概要: `apply_interrogative_upspeak()` のテストを整理

`apply_interrogative_upspeak()` は擬似疑問形のために Mora 追加をおこなう関数である。  
この関数には過去にバグが出た関係で丁寧なテストが実装されている。しかしこのテストに改善の余地がある。  

現在 ENGINE に含まれる多くのテストは Inputs/Expects/Outputs/Test の形式に従っている。しかし upspeak 系テストでは `create_synthesis_test_base()` という関数が Inputs/Outputs/Test を担っている。ゆえにテストの body をパッとみただけだと assert が登場しない（`create_synthesis_test_base()` が並んでいるだけ）。また Expects を引数で渡す形になっており、理解が難しい。  

https://github.com/VOICEVOX/voicevox_engine/blob/620837924ce6f30a8eb5095b7a27fbc4a7e086b3/test/unit/tts_pipeline/test_tts_engine.py#L665-L673

これは `create_synthesis_test_base()` が Inputs/Outputs/Test を担っているため起きている。ゆえにこの関数の責務を減らすべきである。具体的には Inputs のみに役割を限定すべきである。こうすれば Expects を引数にわたす必要も無くなる。  

このような背景から、`apply_interrogative_upspeak()` のテストを整理するリファクタリングを提案します。  

## 関連 Issue
無し