### PR TITLE
追加：AudioQuery.pauseLengthのSkipJsonSchemaをなくす

### DIFF
--- a/test/e2e/__snapshots__/test_openapi/test_OpenAPIの形が変わっていないことを確認.json
+++ b/test/e2e/__snapshots__/test_openapi/test_OpenAPIの形が変わっていないことを確認.json
@@ -71,11 +71,11 @@
                 "type": "null"
               }
             ],
-            "title": "句読点などの無音時間"
+            "title": "句読点などの無音時間。nullのときは無視される。デフォルト値はnull"
           },
           "pauseLengthScale": {
             "default": 1,
-            "title": "句読点などの無音時間（倍率）",
+            "title": "句読点などの無音時間（倍率）。デフォルト値は1",
             "type": "number"
           },
           "pitchScale": {

--- a/test/e2e/__snapshots__/test_openapi/test_OpenAPIの形が変わっていないことを確認.json
+++ b/test/e2e/__snapshots__/test_openapi/test_OpenAPIの形が変わっていないことを確認.json
@@ -63,8 +63,15 @@
             "type": "boolean"
           },
           "pauseLength": {
-            "title": "句読点などの無音時間",
-            "type": "number"
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "句読点などの無音時間"
           },
           "pauseLengthScale": {
             "default": 1,

--- a/test/e2e/single_api/tts_pipeline/__snapshots__/test_synthesis.ambr
+++ b/test/e2e/single_api/tts_pipeline/__snapshots__/test_synthesis.ambr
@@ -2,3 +2,6 @@
 # name: test_post_synthesis_200
   'MD5:f7d42ce5787856549abc3d2d7561c06f'
 # ---
+# name: test_post_synthesis_old_audio_query_200
+  'MD5:f7d42ce5787856549abc3d2d7561c06f'
+# ---

--- a/test/e2e/single_api/tts_pipeline/test_synthesis.py
+++ b/test/e2e/single_api/tts_pipeline/test_synthesis.py
@@ -41,3 +41,37 @@ def test_post_synthesis_200(client: TestClient, snapshot: SnapshotAssertion) -> 
     # 音声波形が一致する
     assert response.headers["content-type"] == "audio/wav"
     assert snapshot == hash_wave_floats_from_wav_bytes(response.read())
+
+
+def test_post_synthesis_old_audio_query_200(
+    client: TestClient, snapshot: SnapshotAssertion
+) -> None:
+    """古いバージョンの audio_query でもエラーなく合成できる"""
+    query = {
+        "accent_phrases": [
+            {
+                "moras": [
+                    gen_mora("テ", "t", 2.3, "e", 0.8, 3.3),
+                    gen_mora("ス", "s", 2.1, "U", 0.3, 0.0),
+                    gen_mora("ト", "t", 2.3, "o", 1.8, 4.1),
+                ],
+                "accent": 1,
+                "pause_mora": None,
+                "is_interrogative": False,
+            }
+        ],
+        "speedScale": 1.0,
+        "pitchScale": 1.0,
+        "intonationScale": 1.0,
+        "volumeScale": 1.0,
+        "prePhonemeLength": 0.1,
+        "postPhonemeLength": 0.1,
+        "outputSamplingRate": 24000,
+        "outputStereo": False,
+    }
+    response = client.post("/synthesis", params={"speaker": 0}, json=query)
+    assert response.status_code == 200
+
+    # 音声波形が一致する
+    assert response.headers["content-type"] == "audio/wav"
+    assert snapshot == hash_wave_floats_from_wav_bytes(response.read())

--- a/voicevox_engine/model.py
+++ b/voicevox_engine/model.py
@@ -26,9 +26,12 @@ class AudioQuery(BaseModel):
     prePhonemeLength: float = Field(title="音声の前の無音時間")
     postPhonemeLength: float = Field(title="音声の後の無音時間")
     pauseLength: float | None = Field(
-        default=None, title="句読点などの無音時間。nullのときは無視される"
+        default=None,
+        title="句読点などの無音時間。nullのときは無視される。デフォルト値はnull",
     )
-    pauseLengthScale: float = Field(default=1, title="句読点などの無音時間（倍率）")
+    pauseLengthScale: float = Field(
+        default=1, title="句読点などの無音時間（倍率）。デフォルト値は1"
+    )
     outputSamplingRate: int = Field(title="音声データの出力サンプリングレート")
     outputStereo: bool = Field(title="音声データをステレオ出力するか否か")
     kana: str | SkipJsonSchema[None] = Field(

--- a/voicevox_engine/model.py
+++ b/voicevox_engine/model.py
@@ -25,7 +25,9 @@ class AudioQuery(BaseModel):
     volumeScale: float = Field(title="全体の音量")
     prePhonemeLength: float = Field(title="音声の前の無音時間")
     postPhonemeLength: float = Field(title="音声の後の無音時間")
-    pauseLength: float | None = Field(default=None, title="句読点などの無音時間")
+    pauseLength: float | None = Field(
+        default=None, title="句読点などの無音時間。nullのときは無視される"
+    )
     pauseLengthScale: float = Field(default=1, title="句読点などの無音時間（倍率）")
     outputSamplingRate: int = Field(title="音声データの出力サンプリングレート")
     outputStereo: bool = Field(title="音声データをステレオ出力するか否か")

--- a/voicevox_engine/model.py
+++ b/voicevox_engine/model.py
@@ -25,9 +25,7 @@ class AudioQuery(BaseModel):
     volumeScale: float = Field(title="全体の音量")
     prePhonemeLength: float = Field(title="音声の前の無音時間")
     postPhonemeLength: float = Field(title="音声の後の無音時間")
-    pauseLength: float | SkipJsonSchema[None] = Field(
-        default=None, title="句読点などの無音時間"
-    )
+    pauseLength: float | None = Field(default=None, title="句読点などの無音時間")
     pauseLengthScale: float = Field(default=1, title="句読点などの無音時間（倍率）")
     outputSamplingRate: int = Field(title="音声データの出力サンプリングレート")
     outputStereo: bool = Field(title="音声データをステレオ出力するか否か")


### PR DESCRIPTION
## 内容

AudioQueryの`pauseLength`は珍しくNone（null）を受け入れ可能なのですが、SkipJsonSchemaがついていてopenapi.jsonの型的に受付不可に見えてしまっています。
外して受付可能だということがわかるようにします。

ついでに、古いAudioQueryを使って音声合成APIを叩くテストも実装しました。



## 関連 Issue

- https://github.com/VOICEVOX/voicevox_engine/pull/1425#discussion_r1650950878
- https://github.com/VOICEVOX/voicevox_engine/issues/1424

## その他
