### PR TITLE
追加：エンジンマニフェストに無音時間を調整する能力`adjust_pause_length`を追加

### DIFF
--- a/engine_manifest.json
+++ b/engine_manifest.json
@@ -44,6 +44,11 @@
             "value": true,
             "name": "全体の音量の調整"
         },
+        "adjust_pause_length": {
+            "type": "bool",
+            "value": true,
+            "name": "句読点などの無音時間の調整"
+        },
         "interrogative_upspeak": {
             "type": "bool",
             "value": true,

--- a/test/e2e/__snapshots__/test_openapi/test_OpenAPIの形が変わっていないことを確認.json
+++ b/test/e2e/__snapshots__/test_openapi/test_OpenAPIの形が変わっていないことを確認.json
@@ -861,6 +861,10 @@
             "title": "モーラごとの音高の調整",
             "type": "boolean"
           },
+          "adjust_pause_length": {
+            "title": "句読点などの無音時間の調整",
+            "type": "boolean"
+          },
           "adjust_phoneme_length": {
             "title": "音素ごとの長さの調整",
             "type": "boolean"

--- a/test/e2e/single_api/engine_info/__snapshots__/test_engine_manifest/test_get_engine_manifest_200.json
+++ b/test/e2e/single_api/engine_info/__snapshots__/test_engine_manifest/test_get_engine_manifest_200.json
@@ -16,6 +16,7 @@
   "supported_features": {
     "adjust_intonation_scale": true,
     "adjust_mora_pitch": true,
+    "adjust_pause_length": true,
     "adjust_phoneme_length": true,
     "adjust_pitch_scale": true,
     "adjust_speed_scale": true,

--- a/voicevox_engine/engine_manifest.py
+++ b/voicevox_engine/engine_manifest.py
@@ -34,6 +34,7 @@ class SupportedFeaturesJson:
     adjust_pitch_scale: FeatureSupportJson
     adjust_intonation_scale: FeatureSupportJson
     adjust_volume_scale: FeatureSupportJson
+    adjust_pause_length: FeatureSupportJson
     interrogative_upspeak: FeatureSupportJson
     synthesis_morphing: FeatureSupportJson
     sing: FeatureSupportJson
@@ -103,6 +104,9 @@ class SupportedFeatures(BaseModel):
     adjust_pitch_scale: bool = Field(title="全体の音高の調整")
     adjust_intonation_scale: bool = Field(title="全体の抑揚の調整")
     adjust_volume_scale: bool = Field(title="全体の音量の調整")
+    adjust_pause_length: bool | SkipJsonSchema[None] = Field(
+        default=None, title="句読点などの無音時間の調整"
+    )
     interrogative_upspeak: bool = Field(title="疑問文の自動調整")
     synthesis_morphing: bool = Field(
         title="2種類のスタイルでモーフィングした音声を合成"


### PR DESCRIPTION
## 内容

エンジンマニフェストに`adjust_pause_length`を追加します。
`AudioQuery.pauseLength`と`AudioQuery.pauseLengthScale`のパラメータに従った音声を返せる場合、このフラグを true にして良い、という感じです。

- https://github.com/VOICEVOX/voicevox_engine/issues/1431

の解決プルリクエストです。

## 関連 Issue

close #1431 


## その他
