### PR TITLE
修正: Metas テストにおける styleID を固定値からインクリメントへ修正

### DIFF
--- a/test/unit/test_metas_store.py
+++ b/test/unit/test_metas_store.py
@@ -21,12 +21,12 @@ def _gen_character(style_types: list[StyleType]) -> Character:
         name="",
         uuid=str(uuid.uuid4()),
         talk_styles=[
-            SpeakerStyle(name="", id=StyleId(0), type=style_type)
-            for style_type in talk_styles
+            SpeakerStyle(name="", id=StyleId(0 + i), type=style_type)
+            for i, style_type in enumerate(talk_styles)
         ],
         sing_styles=[
-            SpeakerStyle(name="", id=StyleId(0), type=style_type)
-            for style_type in sing_styles
+            SpeakerStyle(name="", id=StyleId(6000 + i), type=style_type)
+            for i, style_type in enumerate(sing_styles)
         ],
         version="",
         supported_features=SpeakerSupportedFeatures(),


### PR DESCRIPTION
## 内容
https://github.com/VOICEVOX/voicevox_engine/pull/1414#discussion_r1649798268 に従い、 Metas テストにおける styleID を固定値からインクリメントへ修正することｗ提案します。  

## 関連 Issue
ref https://github.com/VOICEVOX/voicevox_engine/pull/1414#discussion_r1649798268