### PR TITLE
FIX: PyInstallerでビルドされているときのルートディレクトリ取得方法を修正

### DIFF
--- a/voicevox_engine/utility/path_utility.py
+++ b/voicevox_engine/utility/path_utility.py
@@ -14,7 +14,7 @@ def engine_root() -> Path:
         # git レポジトリのルートを指している
         root_dir = Path(__file__).parents[2]
     else:
-        root_dir = Path(sys.argv[0]).parent
+        root_dir = Path(sys.executable).parent
 
     return root_dir.resolve(strict=True)
 


### PR DESCRIPTION
## 内容

現在PyInstallerでビルドされているときにルートディレクトリを`sys.argv[0]`で取得しています。
しかしこの取得方法ではシンボリックリンクから起動した場合シンボリックリンクのファイルパスになってしまいます。
ref: https://pyinstaller.org/en/v5.13.1/runtime-information.html#using-sys-executable-and-sys-argv-0

この問題は #857 で修正しましたが後にrevertされています。 #1023

このPRでファイルパスの部分だけ再度修正します。

## 関連 Issue

- ref: #828

## その他

他に`Path(__file__).parents[2]`を使用して取得する方法がありますがこの方法だとPyinstaller v6に更新するとデフォルトでは`_internal`ディレクトリを参照するようになります。
#857 で`_internal`に入れると判断したファイルと実行ファイルのディレクトリに入れるファイルの両方がevert後に`resources`入っていることから`sys.executable`の方にしました。

