### PR TITLE
整理: `TypeAdapter` によるバリデーション・ダンプを共通化

### DIFF
--- a/run.py
+++ b/run.py
@@ -11,7 +11,6 @@ from pathlib import Path
 from typing import TextIO, TypeVar
 
 import uvicorn
-from pydantic import TypeAdapter
 
 from voicevox_engine.app.application import generate_app
 from voicevox_engine.cancellable_engine import CancellableEngine
@@ -28,6 +27,7 @@ from voicevox_engine.utility.path_utility import (
     engine_root,
     get_save_dir,
 )
+from voicevox_engine.utility.validation_utility import generate_obj_validator
 
 
 def decide_boolean_from_env(env_name: str) -> bool:
@@ -61,7 +61,7 @@ class Envs:
     disable_mutable_api: bool
 
 
-_env_adapter = TypeAdapter(Envs)
+_validate_obj_as_envs = generate_obj_validator(Envs)
 
 
 def read_environment_variables() -> Envs:
@@ -72,7 +72,7 @@ def read_environment_variables() -> Envs:
         env_preset_path=os.getenv("VV_PRESET_FILE"),
         disable_mutable_api=decide_boolean_from_env("VV_DISABLE_MUTABLE_API"),
     )
-    return _env_adapter.validate_python(asdict(envs))
+    return _validate_obj_as_envs(asdict(envs))
 
 
 def set_output_log_utf8() -> None:
@@ -156,7 +156,7 @@ class CLIArgs:
     disable_mutable_api: bool
 
 
-_cli_args_adapter = TypeAdapter(CLIArgs)
+_validate_obj_as_cli_args = generate_obj_validator(CLIArgs)
 
 
 def read_cli_arguments(envs: Envs) -> CLIArgs:
@@ -296,7 +296,7 @@ def read_cli_arguments(envs: Envs) -> CLIArgs:
     args_dict["runtime_dirs"] = args_dict.pop("runtime_dir")
     args_dict["allow_origins"] = args_dict.pop("allow_origin")
 
-    args = _cli_args_adapter.validate_python(args_dict)
+    args = _validate_obj_as_cli_args(args_dict)
 
     return args
 

--- a/test/e2e/test_characters.py
+++ b/test/e2e/test_characters.py
@@ -4,12 +4,16 @@ import hashlib
 from test.utility import hash_long_string
 
 from fastapi.testclient import TestClient
-from pydantic import TypeAdapter
 from syrupy.assertion import SnapshotAssertion
 
 from voicevox_engine.metas.Metas import Speaker, SpeakerInfo
+from voicevox_engine.utility.validation_utility import (
+    generate_bytes_validator,
+    generate_obj_validator,
+)
 
-_speaker_list_adapter = TypeAdapter(list[Speaker])
+_validate_obj_as_speakers = generate_obj_validator(list[Speaker])
+_validate_bytes_as_speakers = generate_bytes_validator(list[Speaker])
 
 
 def _hash_bytes(value: bytes) -> str:
@@ -39,7 +43,7 @@ def test_話者一覧が取得できる(
 def test_話者の情報を取得できる(
     client: TestClient, snapshot_json: SnapshotAssertion
 ) -> None:
-    talkers = _speaker_list_adapter.validate_python(client.get("/speakers").json())
+    talkers = _validate_obj_as_speakers(client.get("/speakers").json())
     for talker in talkers:
         response = client.get(
             "/speaker_info", params={"speaker_uuid": talker.speaker_uuid}
@@ -55,7 +59,7 @@ def test_話者の情報をURLで取得できる(
     def assert_resource_url(url: str, name: str) -> None:
         _assert_resource_url(client, snapshot, url, name)
 
-    speakers = _speaker_list_adapter.validate_json(client.get("/speakers").content)
+    speakers = _validate_bytes_as_speakers(client.get("/speakers").content)
     for speaker in speakers:
         speaker_id = speaker.speaker_uuid
         response = client.get(
@@ -88,7 +92,7 @@ def test_歌手一覧が取得できる(
 def test_歌手の情報を取得できる(
     client: TestClient, snapshot_json: SnapshotAssertion
 ) -> None:
-    singers = _speaker_list_adapter.validate_python(client.get("/singers").json())
+    singers = _validate_obj_as_speakers(client.get("/singers").json())
     for singer in singers:
         response = client.get(
             "/singer_info", params={"speaker_uuid": singer.speaker_uuid}
@@ -104,7 +108,7 @@ def test_歌手の情報をURLで取得できる(
     def assert_resource_url(url: str, name: str) -> None:
         _assert_resource_url(client, snapshot, url, name)
 
-    singers = _speaker_list_adapter.validate_json(client.get("/singers").content)
+    singers = _validate_bytes_as_speakers(client.get("/singers").content)
     for singer in singers:
         singer_id = singer.speaker_uuid
         response = client.get(

--- a/voicevox_engine/core/core_adapter.py
+++ b/voicevox_engine/core/core_adapter.py
@@ -7,7 +7,8 @@ from typing import Any, Literal, NewType
 
 import numpy as np
 from numpy.typing import NDArray
-from pydantic import TypeAdapter
+
+from voicevox_engine.utility.validation_utility import generate_obj_validator
 
 from ..metas.Metas import StyleId
 from .core_wrapper import CoreWrapper, OldCoreError
@@ -35,7 +36,7 @@ class CoreCharacter:
     version: str  # 話者のバージョン
 
 
-_core_character_adapter = TypeAdapter(CoreCharacter)
+_validate_obj_as_core_character = generate_obj_validator(CoreCharacter)
 
 
 @dataclass(frozen=True)
@@ -66,7 +67,7 @@ class CoreAdapter:
     def characters(self) -> list[CoreCharacter]:
         """キャラクター情報"""
         metas: list[Any] = json.loads(self.core.metas())
-        return list(map(_core_character_adapter.validate_python, metas))
+        return list(map(_validate_obj_as_core_character, metas))
 
     @property
     def supported_devices(self) -> DeviceSupport | None:

--- a/voicevox_engine/engine_manifest.py
+++ b/voicevox_engine/engine_manifest.py
@@ -11,8 +11,10 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import TypeAlias
 
-from pydantic import BaseModel, Field, TypeAdapter
+from pydantic import BaseModel, Field
 from pydantic.json_schema import SkipJsonSchema
+
+from voicevox_engine.utility.validation_utility import generate_bytes_validator
 
 
 @dataclass(frozen=True)
@@ -63,7 +65,7 @@ class EngineManifestJson:
     supported_features: SupportedFeaturesJson
 
 
-_manifest_json_adapter = TypeAdapter(EngineManifestJson)
+validate_bytes_as_manifest_json = generate_bytes_validator(EngineManifestJson)
 
 
 class UpdateInfo(BaseModel):
@@ -150,7 +152,7 @@ def load_manifest(manifest_path: Path) -> EngineManifest:
     """エンジンマニフェストを指定ファイルから読み込む。"""
 
     root_dir = manifest_path.parent
-    manifest = _manifest_json_adapter.validate_json(manifest_path.read_bytes())
+    manifest = validate_bytes_as_manifest_json(manifest_path.read_bytes())
     return EngineManifest(
         manifest_version=manifest.manifest_version,
         name=manifest.name,

--- a/voicevox_engine/preset/model.py
+++ b/voicevox_engine/preset/model.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, Field
 from pydantic.json_schema import SkipJsonSchema
 
 from voicevox_engine.metas.Metas import StyleId
+from voicevox_engine.utility.validation_utility import generate_obj_validator
 
 
 class Preset(BaseModel):
@@ -29,3 +30,6 @@ class Preset(BaseModel):
         default=None, title="句読点などの無音時間"
     )
     pauseLengthScale: float = Field(default=1, title="句読点などの無音時間（倍率）")
+
+
+validate_obj_as_presets = generate_obj_validator(list[Preset])

--- a/voicevox_engine/preset/preset_manager.py
+++ b/voicevox_engine/preset/preset_manager.py
@@ -3,9 +3,9 @@
 from pathlib import Path
 
 import yaml
-from pydantic import TypeAdapter, ValidationError
+from pydantic import ValidationError
 
-from .model import Preset
+from .model import Preset, validate_obj_as_presets
 
 
 class PresetInputError(Exception):
@@ -52,8 +52,7 @@ class PresetManager:
             if obj is None:
                 raise PresetInternalError("プリセットの設定ファイルが空の内容です")
         try:
-            preset_list_adapter = TypeAdapter(list[Preset])
-            _presets = preset_list_adapter.validate_python(obj)
+            _presets = validate_obj_as_presets(obj)
         except ValidationError:
             raise PresetInternalError("プリセットの設定ファイルにミスがあります")
 

--- a/voicevox_engine/setting/setting_manager.py
+++ b/voicevox_engine/setting/setting_manager.py
@@ -6,7 +6,11 @@ from pathlib import Path
 from typing import Any
 
 import yaml
-from pydantic import TypeAdapter
+
+from voicevox_engine.utility.validation_utility import (
+    generate_obj_dumper,
+    generate_obj_validator,
+)
 
 from ..utility.path_utility import get_save_dir
 from .model import CorsPolicyMode
@@ -20,7 +24,8 @@ class Setting:
     allow_origin: str | None = None  # 許可するオリジン
 
 
-_setting_adapter = TypeAdapter(Setting)
+_validate_obj_as_setting = generate_obj_validator(Setting)
+_dump_setting_as_obj = generate_obj_dumper(Setting)
 
 
 USER_SETTING_PATH: Path = get_save_dir() / "setting.yml"
@@ -47,11 +52,11 @@ class SettingHandler:
             # FIXME: 例外処理を追加する
             setting = yaml.safe_load(self.setting_file_path.read_text(encoding="utf-8"))
 
-        return _setting_adapter.validate_python(setting)
+        return _validate_obj_as_setting(setting)
 
     def save(self, settings: Setting) -> None:
         """設定値をファイルへ書き込む。"""
-        settings_dict: dict[str, Any] = _setting_adapter.dump_python(settings)
+        settings_dict: dict[str, Any] = _dump_setting_as_obj(settings)
 
         if isinstance(settings_dict["cors_policy_mode"], Enum):
             settings_dict["cors_policy_mode"] = settings_dict["cors_policy_mode"].value

--- a/voicevox_engine/utility/validation_utility.py
+++ b/voicevox_engine/utility/validation_utility.py
@@ -4,8 +4,8 @@ from typing import Any, Callable, TypeVar
 
 from pydantic import TypeAdapter
 
-
 T = TypeVar("T")
+
 
 def generate_obj_validator(type: type[T]) -> Callable[[Any], T]:
     x_adapter = TypeAdapter(type)
@@ -19,6 +19,7 @@ def generate_obj_validator(type: type[T]) -> Callable[[Any], T]:
 
 S = TypeVar("S")
 
+
 def generate_obj_dumper(type: type[S]) -> Callable[[S], Any]:
     x_adapter = TypeAdapter(type)
 
@@ -29,6 +30,7 @@ def generate_obj_dumper(type: type[S]) -> Callable[[S], Any]:
 
 
 U = TypeVar("U")
+
 
 def generate_bytes_validator(type: type[U]) -> Callable[[bytes], U]:
     x_adapter = TypeAdapter(type)
@@ -41,6 +43,7 @@ def generate_bytes_validator(type: type[U]) -> Callable[[bytes], U]:
 
 
 V = TypeVar("V")
+
 
 def generate_bytes_dumper(type: type[V]) -> Callable[[V], bytes]:
     x_adapter = TypeAdapter(type)

--- a/voicevox_engine/utility/validation_utility.py
+++ b/voicevox_engine/utility/validation_utility.py
@@ -1,0 +1,51 @@
+"""バリデーション・ダンプに関する utility"""
+
+from typing import Any, Callable, TypeVar
+
+from pydantic import TypeAdapter
+
+
+T = TypeVar("T")
+
+def generate_obj_validator(type: type[T]) -> Callable[[Any], T]:
+    x_adapter = TypeAdapter(type)
+
+    def validate_obj_as_x(obj: Any) -> T:
+        validated: T = x_adapter.validate_python(obj)
+        return validated
+
+    return validate_obj_as_x
+
+
+S = TypeVar("S")
+
+def generate_obj_dumper(type: type[S]) -> Callable[[S], Any]:
+    x_adapter = TypeAdapter(type)
+
+    def dump_x_as_obj(x: S) -> Any:
+        return x_adapter.dump_python(x)
+
+    return dump_x_as_obj
+
+
+U = TypeVar("U")
+
+def generate_bytes_validator(type: type[U]) -> Callable[[bytes], U]:
+    x_adapter = TypeAdapter(type)
+
+    def validate_bytes_as_x(byte: bytes) -> U:
+        validated: U = x_adapter.validate_json(byte)
+        return validated
+
+    return validate_bytes_as_x
+
+
+V = TypeVar("V")
+
+def generate_bytes_dumper(type: type[V]) -> Callable[[V], bytes]:
+    x_adapter = TypeAdapter(type)
+
+    def dump_x_as_bytes(x: V) -> bytes:
+        return x_adapter.dump_json(x)
+
+    return dump_x_as_bytes


### PR DESCRIPTION
## 内容
概要: `TypeAdapter` によるバリデーション・ダンプを共通化してリファクタリング  

現在の ENGINE では「外部由来の bytes/object ⇔ 内部向け構造体」の変換に `TypeAdapter` を利用している。各構造体向けにそれぞれ `TypeAdapter` インスタンスが作られ、メソッドを用いて変換（validation/dump）がおこなわれている。これにより安全な変換が可能になっている。    
この変換時に `TypeAdapter` インスタンスを直接利用しているため、各モジュールは pydantic に依存している。本質的にここではバリデーションとダンプがしたいのであり、pydantic は実装詳細に過ぎない。また pydantic 以外のライブラリであってもいい。  
幸いこれらの変換は内部向け構造体に依らず共通の処理をしている。ゆえに `validate_x()` / `dump_x()` のような関数を各構造体向けに生成しその内部で pydantic を利用すれば pydantic の影響範囲を小さく出来る。pydantic を差し替える際も生成関数 1 箇所に変更を加えるだけで済む。    

このような背景から、`TypeAdapter` によるバリデーション・ダンプを共通化するリファクタリングを提案します。  

## 関連 Issue
無し