### PR TITLE
FIX: PytestCollectionWarningを解消する

### DIFF
--- a/test/unit/user_dict/test_user_dict_model.py
+++ b/test/unit/user_dict/test_user_dict_model.py
@@ -7,7 +7,7 @@ from voicevox_engine.tts_pipeline.kana_converter import parse_kana
 from voicevox_engine.user_dict.model import UserDictWord
 
 
-class TestModel(TypedDict):
+class _TestModel(TypedDict):
     surface: str
     priority: int
     part_of_speech: str
@@ -24,7 +24,7 @@ class TestModel(TypedDict):
     accent_associative_rule: str
 
 
-def generate_model() -> TestModel:
+def generate_model() -> _TestModel:
     return {
         "surface": "テスト",
         "priority": 0,


### PR DESCRIPTION
## 内容

pytest実行時に`DeprecationWarning`が発生する問題を修正します。

## その他

`TestModel`というクラス名がテストコードであると判定されていることが原因でした。
とりあえず`_TestModel`にリネームして修正します。
https://docs.pytest.org/en/8.2.x/explanation/goodpractices.html#test-discovery