### PR TITLE
整理: 使用されていない `TTSEngineManager.has_engine()` を削除

### DIFF
--- a/test/unit/tts_pipeline/test_tts_engines.py
+++ b/test/unit/tts_pipeline/test_tts_engines.py
@@ -79,33 +79,3 @@ def test_tts_engines_get_engine_missing() -> None:
     # Test
     with pytest.raises(HTTPException) as _:
         tts_engines.get_engine("0.0.3")
-
-
-def test_tts_engines_has_engine_true() -> None:
-    """TTSEngineManager.has_engine() で TTS エンジンが登録されていることを確認できる。"""
-    # Inputs
-    tts_engines = TTSEngineManager()
-    tts_engines.register_engine(MockTTSEngine(), "0.0.1")
-    tts_engines.register_engine(MockTTSEngine(), "0.0.2")
-    # Expects
-    expected_has = True
-    # Outputs
-    has = tts_engines.has_engine("0.0.1")
-
-    # Test
-    assert expected_has == has
-
-
-def test_tts_engines_has_engine_false() -> None:
-    """TTSEngineManager.has_engine() で TTS エンジンが登録されていないことを確認できる。"""
-    # Inputs
-    tts_engines = TTSEngineManager()
-    tts_engines.register_engine(MockTTSEngine(), "0.0.1")
-    tts_engines.register_engine(MockTTSEngine(), "0.0.2")
-    # Expects
-    expected_has = False
-    # Outputs
-    has = tts_engines.has_engine("0.0.3")
-
-    # Test
-    assert expected_has == has

--- a/voicevox_engine/tts_pipeline/tts_engine.py
+++ b/voicevox_engine/tts_pipeline/tts_engine.py
@@ -730,10 +730,6 @@ class TTSEngineManager:
 
         raise HTTPException(status_code=422, detail="不明なバージョンです")
 
-    def has_engine(self, version: str) -> bool:
-        """指定バージョンのエンジンが登録されているか否かを返す。"""
-        return version in self._engines
-
 
 def make_tts_engines_from_cores(core_manager: CoreManager) -> TTSEngineManager:
     """コア一覧からTTSエンジン一覧を生成する"""


### PR DESCRIPTION
## 内容
https://github.com/VOICEVOX/voicevox_engine/pull/1421#discussion_r1657980666 に従い、使用されていない `TTSEngineManager.has_engine()` を削除するリファクタリングを提案します。  

## 関連 Issue
ref https://github.com/VOICEVOX/voicevox_engine/pull/1421#discussion_r1657980666