### PR TITLE
整理: コアバージョン一覧を `core_version_list` 変数で管理

### DIFF
--- a/voicevox_engine/app/application.py
+++ b/voicevox_engine/app/application.py
@@ -68,6 +68,8 @@ def generate_app(
     resource_manager = ResourceManager(is_development())
     resource_manager.register_dir(character_info_dir)
 
+    core_version_list = core_manager.versions()
+
     def _get_core_characters(version: str | None) -> list[CoreCharacter]:
         version = version or core_manager.latest_version()
         core = core_manager.get_core(version)
@@ -93,7 +95,7 @@ def generate_app(
         )
     app.include_router(generate_user_dict_router(user_dict, verify_mutability_allowed))
     app.include_router(
-        generate_engine_info_router(core_manager, tts_engines, engine_manifest)
+        generate_engine_info_router(core_version_list, tts_engines, engine_manifest)
     )
     app.include_router(
         generate_setting_router(

--- a/voicevox_engine/app/routers/engine_info.py
+++ b/voicevox_engine/app/routers/engine_info.py
@@ -10,7 +10,7 @@ from voicevox_engine import __version__
 from voicevox_engine.core.core_adapter import DeviceSupport
 from voicevox_engine.core.core_initializer import CoreManager
 from voicevox_engine.engine_manifest import EngineManifest
-from voicevox_engine.tts_pipeline.tts_engine import TTSEngineManager
+from voicevox_engine.tts_pipeline.tts_engine import LATEST_VERSION, TTSEngineManager
 
 
 class SupportedDevicesInfo(BaseModel):
@@ -33,7 +33,7 @@ class SupportedDevicesInfo(BaseModel):
 
 
 def generate_engine_info_router(
-    core_manager: CoreManager,
+    core_version_list: list[str],
     tts_engine_manager: TTSEngineManager,
     engine_manifest_data: EngineManifest,
 ) -> APIRouter:
@@ -48,7 +48,7 @@ def generate_engine_info_router(
     @router.get("/core_versions")
     async def core_versions() -> list[str]:
         """利用可能なコアのバージョン一覧を取得します。"""
-        return core_manager.versions()
+        return core_version_list
 
     @router.get("/supported_devices")
     def supported_devices(

--- a/voicevox_engine/app/routers/engine_info.py
+++ b/voicevox_engine/app/routers/engine_info.py
@@ -8,7 +8,6 @@ from pydantic.json_schema import SkipJsonSchema
 
 from voicevox_engine import __version__
 from voicevox_engine.core.core_adapter import DeviceSupport
-from voicevox_engine.core.core_initializer import CoreManager
 from voicevox_engine.engine_manifest import EngineManifest
 from voicevox_engine.tts_pipeline.tts_engine import LATEST_VERSION, TTSEngineManager
 

--- a/voicevox_engine/app/routers/engine_info.py
+++ b/voicevox_engine/app/routers/engine_info.py
@@ -55,7 +55,7 @@ def generate_engine_info_router(
         core_version: str | SkipJsonSchema[None] = None,
     ) -> SupportedDevicesInfo:
         """対応デバイスの一覧を取得します。"""
-        version = core_version or core_manager.latest_version()
+        version = core_version or LATEST_VERSION
         supported_devices = tts_engine_manager.get_engine(version).supported_devices
         if supported_devices is None:
             raise HTTPException(status_code=422, detail="非対応の機能です。")


### PR DESCRIPTION
## 内容
https://github.com/VOICEVOX/voicevox_engine/issues/1391#issuecomment-2185316711 に従い、`core_version_list` でコアバージョン一覧を管理するリファクタリングを提案します。  

これにより全 router が `CoreManager` 非依存になります🎉  

## 関連 Issue
ref https://github.com/VOICEVOX/voicevox_engine/issues/1391#issuecomment-2185316711  
resolve #1391 (final step 🎉)  
