### PR TITLE
設定UIで、辞書のインポートが失敗したときも成功したトーストが出てしまうのを修正

### DIFF
--- a/resources/setting_ui_template.html
+++ b/resources/setting_ui_template.html
@@ -187,7 +187,7 @@
           setup() {
             // 設定値周り
             const corsPolicyMode = ref(
-              "<JINJA_PRE>cors_policy_mode<JINJA_POST>",
+              "<JINJA_PRE>cors_policy_mode<JINJA_POST>"
             );
             const allowOrigin = ref("<JINJA_PRE>allow_origin<JINJA_POST>");
 
@@ -258,8 +258,6 @@
               console.log(`showToastWithMessage: ${message}, ${type}`);
               bootstrapToast.value.show();
               toastMessage.value = message;
-
-              // 成功時は緑、失敗時は赤
               toastElem.value.classList.remove("bg-success", "bg-danger");
               toastElem.value.classList.add(`bg-${type}`);
             };
@@ -318,7 +316,7 @@
             elem.onload = resolve;
             elem.onerror = () => {
               console.warn(
-                `CDNの読み込みに失敗しました。 ${candidateUrlList[current]}`,
+                `CDNの読み込みに失敗しました。 ${candidateUrlList[current]}`
               );
               document.head.removeChild(elem);
               current++;
@@ -343,7 +341,7 @@
             "https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css",
             "https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.0.2/css/bootstrap.min.css",
           ],
-          "sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC",
+          "sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC"
         );
         libraryLoadingPromises.push(bootstrapCssPromise);
 
@@ -354,7 +352,7 @@
             "https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js",
             "https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.0.2/js/bootstrap.bundle.min.js",
           ],
-          "sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM",
+          "sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM"
         );
         libraryLoadingPromises.push(bootstrapScriptPromise);
 
@@ -366,7 +364,7 @@
             "https://cdn.jsdelivr.net/npm/vue@3.3.10/dist/vue.global.js",
             "https://cdnjs.cloudflare.com/ajax/libs/vue/3.3.10/vue.global.js",
           ],
-          "sha384-ttfhgYK68lNlS8ak6Z//mvUbpRbRCh43MYGuqEtK8mj/yzlKqY8GA8o3BPMi23cE",
+          "sha384-ttfhgYK68lNlS8ak6Z//mvUbpRbRCh43MYGuqEtK8mj/yzlKqY8GA8o3BPMi23cE"
         );
         libraryLoadingPromises.push(vuePromise);
 

--- a/resources/setting_ui_template.html
+++ b/resources/setting_ui_template.html
@@ -167,6 +167,7 @@
       <div class="position-fixed bottom-0 end-0 p-3" style="z-index: 5">
         <div
           class="toast align-items-center autohide text-white"
+          :class="'bg-' + toastType"
           role="alert"
           aria-live="assertive"
           aria-atomic="true"
@@ -187,7 +188,7 @@
           setup() {
             // 設定値周り
             const corsPolicyMode = ref(
-              "<JINJA_PRE>cors_policy_mode<JINJA_POST>"
+              "<JINJA_PRE>cors_policy_mode<JINJA_POST>",
             );
             const allowOrigin = ref("<JINJA_PRE>allow_origin<JINJA_POST>");
 
@@ -246,6 +247,7 @@
             const toastElem = ref(undefined);
             const bootstrapToast = ref(undefined);
             const toastMessage = ref("");
+            const toastType = ref("success");
             onMounted(() => {
               if (toastElem.value == undefined) {
                 throw new Error("toastElemが見つかりません。");
@@ -253,18 +255,12 @@
               bootstrapToast.value = new bootstrap.Toast(toastElem.value);
             });
 
-            // メッセージを表示する。typeはsuccess・info・warning・danger。
+            // メッセージを表示する。typeはsuccess・info・warning・dangerなど。
             const showToastWithMessage = (message, type) => {
               console.log(`showToastWithMessage: ${message}, ${type}`);
               bootstrapToast.value.show();
               toastMessage.value = message;
-              toastElem.value.classList.remove(
-                "bg-success",
-                "bg-info",
-                "bg-warning",
-                "bg-danger"
-              );
-              toastElem.value.classList.add(`bg-${type}`);
+              toastType.value = type;
             };
 
             // 表示用の情報
@@ -283,6 +279,7 @@
               importUserDict,
               toastElem,
               toastMessage,
+              toastType,
               showToastWithMessage,
               brandName,
             };
@@ -321,7 +318,7 @@
             elem.onload = resolve;
             elem.onerror = () => {
               console.warn(
-                `CDNの読み込みに失敗しました。 ${candidateUrlList[current]}`
+                `CDNの読み込みに失敗しました。 ${candidateUrlList[current]}`,
               );
               document.head.removeChild(elem);
               current++;
@@ -346,7 +343,7 @@
             "https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css",
             "https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.0.2/css/bootstrap.min.css",
           ],
-          "sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC"
+          "sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC",
         );
         libraryLoadingPromises.push(bootstrapCssPromise);
 
@@ -357,7 +354,7 @@
             "https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js",
             "https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.0.2/js/bootstrap.bundle.min.js",
           ],
-          "sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM"
+          "sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM",
         );
         libraryLoadingPromises.push(bootstrapScriptPromise);
 
@@ -369,7 +366,7 @@
             "https://cdn.jsdelivr.net/npm/vue@3.3.10/dist/vue.global.js",
             "https://cdnjs.cloudflare.com/ajax/libs/vue/3.3.10/vue.global.js",
           ],
-          "sha384-ttfhgYK68lNlS8ak6Z//mvUbpRbRCh43MYGuqEtK8mj/yzlKqY8GA8o3BPMi23cE"
+          "sha384-ttfhgYK68lNlS8ak6Z//mvUbpRbRCh43MYGuqEtK8mj/yzlKqY8GA8o3BPMi23cE",
         );
         libraryLoadingPromises.push(vuePromise);
 

--- a/resources/setting_ui_template.html
+++ b/resources/setting_ui_template.html
@@ -262,7 +262,7 @@
                 "bg-success",
                 "bg-info",
                 "bg-warning",
-                "bg-danger",
+                "bg-danger"
               );
               toastElem.value.classList.add(`bg-${type}`);
             };

--- a/resources/setting_ui_template.html
+++ b/resources/setting_ui_template.html
@@ -103,7 +103,7 @@
             download="VOICEVOXユーザー辞書.json"
             class="btn btn-primary mb-3"
             href="/user_dict"
-            @click="showToastWithMessage('辞書をエクスポートしました。');"
+            @click="showToastWithMessage('辞書をエクスポートしました。', 'success');"
             target="_blank"
             rel="noopener noreferrer"
           >
@@ -166,7 +166,7 @@
       <!-- トースト -->
       <div class="position-fixed bottom-0 end-0 p-3" style="z-index: 5">
         <div
-          class="toast align-items-center autohide text-white bg-success"
+          class="toast align-items-center autohide text-white"
           role="alert"
           aria-live="assertive"
           aria-atomic="true"
@@ -187,7 +187,7 @@
           setup() {
             // 設定値周り
             const corsPolicyMode = ref(
-              "<JINJA_PRE>cors_policy_mode<JINJA_POST>"
+              "<JINJA_PRE>cors_policy_mode<JINJA_POST>",
             );
             const allowOrigin = ref("<JINJA_PRE>allow_origin<JINJA_POST>");
 
@@ -203,9 +203,9 @@
                 body: formData,
               }).then((res) => {
                 if (res.ok) {
-                  showToastWithMessage("設定を保存しました。");
+                  showToastWithMessage("設定を保存しました。", "success");
                 } else {
-                  showToastWithMessage("設定の保存に失敗しました。");
+                  showToastWithMessage("設定の保存に失敗しました。", "danger");
                 }
               });
             });
@@ -223,14 +223,20 @@
                 const params = new URLSearchParams({
                   override: true, // 重複するエントリを上書きする
                 });
-                await fetch(`/import_user_dict?${params}`, {
+                const response = await fetch(`/import_user_dict?${params}`, {
                   method: "POST",
                   mode: "same-origin",
                   headers: { "Content-Type": "application/json" },
                   body: reader.result,
                 });
-
-                showToastWithMessage("辞書をインポートしました。");
+                if (response.ok) {
+                  showToastWithMessage("辞書をインポートしました。", "success");
+                } else {
+                  showToastWithMessage(
+                    "辞書のインポートに失敗しました。",
+                    "danger",
+                  );
+                }
               });
 
               reader.readAsText(userDictFileForImport.value);
@@ -246,10 +252,16 @@
               }
               bootstrapToast.value = new bootstrap.Toast(toastElem.value);
             });
-            const showToastWithMessage = (message) => {
-              console.log(`showToastWithMessage: ${message}`);
+
+            // メッセージを表示する。typeはsuccess・info・warning・dangerなど。
+            const showToastWithMessage = (message, type) => {
+              console.log(`showToastWithMessage: ${message}, ${type}`);
               bootstrapToast.value.show();
               toastMessage.value = message;
+
+              // 成功時は緑、失敗時は赤
+              toastElem.value.classList.remove("bg-success", "bg-danger");
+              toastElem.value.classList.add(`bg-${type}`);
             };
 
             // 表示用の情報
@@ -306,7 +318,7 @@
             elem.onload = resolve;
             elem.onerror = () => {
               console.warn(
-                `CDNの読み込みに失敗しました。 ${candidateUrlList[current]}`
+                `CDNの読み込みに失敗しました。 ${candidateUrlList[current]}`,
               );
               document.head.removeChild(elem);
               current++;
@@ -331,7 +343,7 @@
             "https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css",
             "https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.0.2/css/bootstrap.min.css",
           ],
-          "sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC"
+          "sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC",
         );
         libraryLoadingPromises.push(bootstrapCssPromise);
 
@@ -342,7 +354,7 @@
             "https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js",
             "https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.0.2/js/bootstrap.bundle.min.js",
           ],
-          "sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM"
+          "sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM",
         );
         libraryLoadingPromises.push(bootstrapScriptPromise);
 
@@ -354,7 +366,7 @@
             "https://cdn.jsdelivr.net/npm/vue@3.3.10/dist/vue.global.js",
             "https://cdnjs.cloudflare.com/ajax/libs/vue/3.3.10/vue.global.js",
           ],
-          "sha384-ttfhgYK68lNlS8ak6Z//mvUbpRbRCh43MYGuqEtK8mj/yzlKqY8GA8o3BPMi23cE"
+          "sha384-ttfhgYK68lNlS8ak6Z//mvUbpRbRCh43MYGuqEtK8mj/yzlKqY8GA8o3BPMi23cE",
         );
         libraryLoadingPromises.push(vuePromise);
 

--- a/resources/setting_ui_template.html
+++ b/resources/setting_ui_template.html
@@ -253,12 +253,17 @@
               bootstrapToast.value = new bootstrap.Toast(toastElem.value);
             });
 
-            // メッセージを表示する。typeはsuccess・info・warning・dangerなど。
+            // メッセージを表示する。typeはsuccess・info・warning・danger。
             const showToastWithMessage = (message, type) => {
               console.log(`showToastWithMessage: ${message}, ${type}`);
               bootstrapToast.value.show();
               toastMessage.value = message;
-              toastElem.value.classList.remove("bg-success", "bg-danger");
+              toastElem.value.classList.remove(
+                "bg-success",
+                "bg-info",
+                "bg-warning",
+                "bg-danger",
+              );
               toastElem.value.classList.add(`bg-${type}`);
             };
 

--- a/test/e2e/single_api/setting/__snapshots__/test_setting_api.ambr
+++ b/test/e2e/single_api/setting/__snapshots__/test_setting_api.ambr
@@ -106,7 +106,7 @@
               download="VOICEVOXユーザー辞書.json"
               class="btn btn-primary mb-3"
               href="/user_dict"
-              @click="showToastWithMessage('辞書をエクスポートしました。');"
+              @click="showToastWithMessage('辞書をエクスポートしました。', 'success');"
               target="_blank"
               rel="noopener noreferrer"
             >
@@ -169,7 +169,8 @@
         <!-- トースト -->
         <div class="position-fixed bottom-0 end-0 p-3" style="z-index: 5">
           <div
-            class="toast align-items-center autohide text-white bg-success"
+            class="toast align-items-center autohide text-white"
+            :class="'bg-' + toastType"
             role="alert"
             aria-live="assertive"
             aria-atomic="true"
@@ -190,7 +191,7 @@
             setup() {
               // 設定値周り
               const corsPolicyMode = ref(
-                "localapps"
+                "localapps",
               );
               const allowOrigin = ref("");
   
@@ -206,9 +207,9 @@
                   body: formData,
                 }).then((res) => {
                   if (res.ok) {
-                    showToastWithMessage("設定を保存しました。");
+                    showToastWithMessage("設定を保存しました。", "success");
                   } else {
-                    showToastWithMessage("設定の保存に失敗しました。");
+                    showToastWithMessage("設定の保存に失敗しました。", "danger");
                   }
                 });
               });
@@ -226,14 +227,20 @@
                   const params = new URLSearchParams({
                     override: true, // 重複するエントリを上書きする
                   });
-                  await fetch(`/import_user_dict?${params}`, {
+                  const response = await fetch(`/import_user_dict?${params}`, {
                     method: "POST",
                     mode: "same-origin",
                     headers: { "Content-Type": "application/json" },
                     body: reader.result,
                   });
-  
-                  showToastWithMessage("辞書をインポートしました。");
+                  if (response.ok) {
+                    showToastWithMessage("辞書をインポートしました。", "success");
+                  } else {
+                    showToastWithMessage(
+                      "辞書のインポートに失敗しました。",
+                      "danger",
+                    );
+                  }
                 });
   
                 reader.readAsText(userDictFileForImport.value);
@@ -243,16 +250,20 @@
               const toastElem = ref(undefined);
               const bootstrapToast = ref(undefined);
               const toastMessage = ref("");
+              const toastType = ref("success");
               onMounted(() => {
                 if (toastElem.value == undefined) {
                   throw new Error("toastElemが見つかりません。");
                 }
                 bootstrapToast.value = new bootstrap.Toast(toastElem.value);
               });
-              const showToastWithMessage = (message) => {
-                console.log(`showToastWithMessage: ${message}`);
+  
+              // メッセージを表示する。typeはsuccess・info・warning・dangerなど。
+              const showToastWithMessage = (message, type) => {
+                console.log(`showToastWithMessage: ${message}, ${type}`);
                 bootstrapToast.value.show();
                 toastMessage.value = message;
+                toastType.value = type;
               };
   
               // 表示用の情報
@@ -271,6 +282,7 @@
                 importUserDict,
                 toastElem,
                 toastMessage,
+                toastType,
                 showToastWithMessage,
                 brandName,
               };
@@ -309,7 +321,7 @@
               elem.onload = resolve;
               elem.onerror = () => {
                 console.warn(
-                  `CDNの読み込みに失敗しました。 ${candidateUrlList[current]}`
+                  `CDNの読み込みに失敗しました。 ${candidateUrlList[current]}`,
                 );
                 document.head.removeChild(elem);
                 current++;
@@ -334,7 +346,7 @@
               "https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css",
               "https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.0.2/css/bootstrap.min.css",
             ],
-            "sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC"
+            "sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC",
           );
           libraryLoadingPromises.push(bootstrapCssPromise);
   
@@ -345,7 +357,7 @@
               "https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js",
               "https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.0.2/js/bootstrap.bundle.min.js",
             ],
-            "sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM"
+            "sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM",
           );
           libraryLoadingPromises.push(bootstrapScriptPromise);
   
@@ -357,7 +369,7 @@
               "https://cdn.jsdelivr.net/npm/vue@3.3.10/dist/vue.global.js",
               "https://cdnjs.cloudflare.com/ajax/libs/vue/3.3.10/vue.global.js",
             ],
-            "sha384-ttfhgYK68lNlS8ak6Z//mvUbpRbRCh43MYGuqEtK8mj/yzlKqY8GA8o3BPMi23cE"
+            "sha384-ttfhgYK68lNlS8ak6Z//mvUbpRbRCh43MYGuqEtK8mj/yzlKqY8GA8o3BPMi23cE",
           );
           libraryLoadingPromises.push(vuePromise);
   


### PR DESCRIPTION
## 内容

設定UIで、辞書のインポートが失敗した場合も、成功したトーストが出てしまっていたのを修正します。

ついでに失敗時は色がdangerな感じのトーストを表示するようにしてみました。

<img width="641" alt="image" src="https://github.com/user-attachments/assets/4a6d0f10-c83f-463a-879b-41c000408deb">

## その他

ついでにデフォルトのTypeScriptのルールが変わってケツカンマが必ずつくようになってますが、まあ良いかなと思っています！
