### PR TITLE
macosでvvpppができてしまう問題を解決

### DIFF
--- a/.github/workflows/build-engine-package.yml
+++ b/.github/workflows/build-engine-package.yml
@@ -606,7 +606,7 @@ jobs:
           done
 
           # Rename to artifact.vvpp if there are only artifact.001.vvppp
-          if [ "$(find ${{ steps.vars.outputs.package_name }}.*.vvppp -maxdepth 1 | wc -l)" == 1 ]; then
+          if [ "$(find ${{ steps.vars.outputs.package_name }}.*.vvppp -maxdepth 1 | wc -l)" -eq 1 ]; then
             mv ${{ steps.vars.outputs.package_name }}.001.vvppp ${{ steps.vars.outputs.package_name }}.vvpp
           fi
 


### PR DESCRIPTION
## 内容

- https://github.com/VOICEVOX/voicevox_engine/issues/1174

の解決プルリクエストです。

## 関連 Issue

close #1174

## その他

`wc -l`の結果が、macの時だけ数字の前にタブ？が含まれているのが挙動が変になってる理由です。

`-eq`は数字比較用、`==`は文字列比較用らしく、`-eq`にすれば数字として扱ってくれるので空白を無視してくれる感じでした。
`tr`で空白を除去するのがいいのか、数字として扱って空白を無視するのがいいのか、どっちの方がいいのか難しいところですが、まあ数字の比較をする時は`-eq`を使うのがいいらしく、それで解決するっぽいのでこっちに倒しました。。
