### PR TITLE
fix: --retry-all-errorsの未対応をなくす

### DIFF
--- a/.github/workflows/build-engine-package.yml
+++ b/.github/workflows/build-engine-package.yml
@@ -215,7 +215,7 @@ jobs:
           # 一度代入して actionlint のエラー回避 (詳細: NOTE 1)
           OS=${{ matrix.os }}
           if [[ $OS == windows-* ]]; then
-            curl -L --retry 3 --retry-delay 5 --retry-all-errors "${{ matrix.cudnn_url }}" > download/cudnn.zip
+            curl -L --retry 3 --retry-delay 5 "${{ matrix.cudnn_url }}" > download/cudnn.zip
 
             unzip download/cudnn.zip cudnn-*/bin/*.dll -d download/cudnn_tmp
 
@@ -225,7 +225,7 @@ jobs:
 
             rm download/cudnn.zip
           else
-            curl -L --retry 3 --retry-delay 5 --retry-all-errors "${{ matrix.cudnn_url }}" > download/cudnn.tar.xz
+            curl -L --retry 3 --retry-delay 5 "${{ matrix.cudnn_url }}" > download/cudnn.tar.xz
 
             tar -Jxf download/cudnn.tar.xz -C download/
 
@@ -263,7 +263,7 @@ jobs:
       - name: <Setup> Download zlib dynamic Library
         if: steps.zlib-cache-restore.outputs.cache-hit != 'true' && matrix.zlib_url != ''
         run: |
-          curl -L --retry 3 --retry-delay 5 --retry-all-errors "${{ matrix.zlib_url }}" -o download/zlib.zip
+          curl -L --retry 3 --retry-delay 5 "${{ matrix.zlib_url }}" -o download/zlib.zip
           mkdir -p download/zlib
 
           # extract only dlls
@@ -329,7 +329,7 @@ jobs:
       - name: <Setup> Set up DirectML dynamic Library
         if: steps.directml-cache-restore.outputs.cache-hit != 'true' && endswith(matrix.target, '-directml')
         run: |
-          curl -L --retry 3 --retry-delay 5 --retry-all-errors "${{ matrix.directml_url }}" -o download/directml.zip
+          curl -L --retry 3 --retry-delay 5 "${{ matrix.directml_url }}" -o download/directml.zip
           mkdir -p download/directml
 
           # extract only dlls
@@ -359,7 +359,7 @@ jobs:
       - name: <Setup> Download ONNX Runtime (Windows)
         if: steps.onnxruntime-cache-restore.outputs.cache-hit != 'true' && startsWith(matrix.os, 'windows-')
         run: |
-          curl -L --retry 3 --retry-delay 5 --retry-all-errors "${{ matrix.onnxruntime_url }}" > download/onnxruntime.zip
+          curl -L --retry 3 --retry-delay 5 "${{ matrix.onnxruntime_url }}" > download/onnxruntime.zip
 
           # extract only dlls
           # 一度代入して actionlint のエラー回避 (詳細: NOTE 1)
@@ -379,7 +379,7 @@ jobs:
       - name: <Setup> Download ONNX Runtime (Mac/Linux)
         if: steps.onnxruntime-cache-restore.outputs.cache-hit != 'true' && startsWith(matrix.os, 'windows-') != true
         run: |
-          curl -L --retry 3 --retry-delay 5 --retry-all-errors "${{ matrix.onnxruntime_url }}" > download/onnxruntime.tgz
+          curl -L --retry 3 --retry-delay 5 "${{ matrix.onnxruntime_url }}" > download/onnxruntime.tgz
           mkdir -p download/onnxruntime
           tar xf "download/onnxruntime.tgz" -C "download/onnxruntime" --strip-components 1
           rm download/onnxruntime.tgz
@@ -424,7 +424,7 @@ jobs:
         env:
           VOICEVOX_CORE_ASSET_NAME: ${{ matrix.voicevox_core_asset_prefix }}-${{ env.VOICEVOX_CORE_VERSION }}
         run: |
-          curl -L --retry 3 --retry-delay 5 --retry-all-errors \
+          curl -L --retry 3 --retry-delay 5 \
             "https://github.com/VOICEVOX/voicevox_core/releases/download/${{ env.VOICEVOX_CORE_VERSION }}/${{ env.VOICEVOX_CORE_ASSET_NAME }}.zip" > download/${{ env.VOICEVOX_CORE_ASSET_NAME }}.zip
           # 一度代入して actionlint のエラー回避 (詳細: NOTE 1)
           OS=${{ matrix.os }}

--- a/.github/workflows/test-engine-package.yml
+++ b/.github/workflows/test-engine-package.yml
@@ -72,8 +72,8 @@ jobs:
       - name: <Setup> Download ENGINE package
         run: |
           mkdir -p download
-          curl -L --retry 3 --retry-delay 5 --retry-all-errors -o "download/list.txt" "${{ steps.vars.outputs.release_url }}/${{ steps.vars.outputs.package_name }}.7z.txt"
-          <download/list.txt xargs -I '%' curl -L --retry 3 --retry-delay 5 --retry-all-errors -o "download/%" "${{ steps.vars.outputs.release_url }}/%"
+          curl -L --retry 3 --retry-delay 5 -o "download/list.txt" "${{ steps.vars.outputs.release_url }}/${{ steps.vars.outputs.package_name }}.7z.txt"
+          <download/list.txt xargs -I '%' curl -L --retry 3 --retry-delay 5 -o "download/%" "${{ steps.vars.outputs.release_url }}/%"
           7z x "download/$(head -n1 download/list.txt)"
           mv "${{ matrix.target }}" dist/
 

--- a/tools/codesign.bash
+++ b/tools/codesign.bash
@@ -27,7 +27,7 @@ target_file_glob="$1"
 # eSignerCKAのセットアップ
 INSTALL_DIR='..\eSignerCKA'
 if [ ! -d "$INSTALL_DIR" ]; then
-    curl -LO --retry 3 --retry-delay 5 --retry-all-errors "https://github.com/SSLcom/eSignerCKA/releases/download/v1.0.6/SSL.COM-eSigner-CKA_1.0.6.zip"
+    curl -LO --retry 3 --retry-delay 5 "https://github.com/SSLcom/eSignerCKA/releases/download/v1.0.6/SSL.COM-eSigner-CKA_1.0.6.zip"
     unzip -o SSL.COM-eSigner-CKA_1.0.6.zip
     mv ./*eSigner*CKA_*.exe eSigner_CKA_Installer.exe
     powershell "


### PR DESCRIPTION
## 内容

curlの`--retry-all-errors`引数はubuntu-20.04でだけ使えなかったっぽいことがわかったので無くしました。

ちなみにこの引数はサーバー側が400エラーになったり500エラーになった場合でもリトライする仕組みです。
それ以外のエラーはちゃんとリトライされるはず。

## その他
