### PR TITLE
追加: SkipJsonSchemaが要らないモデルの値からSkipJsonSchemaを省いていく

### DIFF
--- a/test/e2e/__snapshots__/test_openapi/test_OpenAPIの形が変わっていないことを確認.json
+++ b/test/e2e/__snapshots__/test_openapi/test_OpenAPIの形が変わっていないことを確認.json
@@ -24,13 +24,15 @@
             "type": "array"
           },
           "pause_mora": {
-            "allOf": [
+            "anyOf": [
               {
                 "$ref": "#/components/schemas/Mora"
+              },
+              {
+                "type": "null"
               }
             ],
-            "description": "後ろに無音を付けるかどうか",
-            "title": "Pause Mora"
+            "description": "後ろに付ける無音モーラ"
           }
         },
         "required": [
@@ -57,9 +59,16 @@
             "type": "number"
           },
           "kana": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "description": "[読み取り専用]AquesTalk 風記法によるテキスト。音声合成用のクエリとしては無視される",
-            "title": "Kana",
-            "type": "string"
+            "title": "Kana"
           },
           "outputSamplingRate": {
             "description": "音声データの出力サンプリングレート",
@@ -316,9 +325,16 @@
             "description": "エンジンが持つ機能"
           },
           "supported_vvlib_manifest_version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "description": "エンジンが対応するvvlibのバージョン",
-            "title": "Supported Vvlib Manifest Version",
-            "type": "string"
+            "title": "Supported Vvlib Manifest Version"
           },
           "terms_of_service": {
             "description": "エンジンの利用規約",
@@ -524,9 +540,16 @@
         "description": "依存ライブラリのライセンス情報",
         "properties": {
           "license": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "description": "依存ライブラリのライセンス名",
-            "title": "License",
-            "type": "string"
+            "title": "License"
           },
           "name": {
             "description": "依存ライブラリ名",
@@ -539,9 +562,16 @@
             "type": "string"
           },
           "version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "description": "依存ライブラリのバージョン",
-            "title": "Version",
-            "type": "string"
+            "title": "Version"
           }
         },
         "required": [
@@ -555,14 +585,28 @@
         "description": "モーラ（子音＋母音）ごとの情報",
         "properties": {
           "consonant": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "description": "子音の音素",
-            "title": "Consonant",
-            "type": "string"
+            "title": "Consonant"
           },
           "consonant_length": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "description": "子音の音長",
-            "title": "Consonant Length",
-            "type": "number"
+            "title": "Consonant Length"
           },
           "pitch": {
             "description": "音高",
@@ -617,9 +661,16 @@
             "type": "integer"
           },
           "key": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "description": "音階",
-            "title": "Key",
-            "type": "integer"
+            "title": "Key"
           },
           "lyric": {
             "description": "音符の歌詞",
@@ -682,9 +733,16 @@
             "type": "string"
           },
           "pauseLength": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "description": "句読点などの無音時間",
-            "title": "Pauselength",
-            "type": "number"
+            "title": "Pauselength"
           },
           "pauseLengthScale": {
             "default": 1,
@@ -900,9 +958,16 @@
             "type": "integer"
           },
           "portrait": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "description": "このスタイルの立ち絵画像をbase64エンコードしたもの、あるいはURL",
-            "title": "Portrait",
-            "type": "string"
+            "title": "Portrait"
           },
           "voice_samples": {
             "description": "サンプル音声をbase64エンコードしたもの、あるいはURL",
@@ -962,9 +1027,16 @@
             "type": "boolean"
           },
           "adjust_pause_length": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "description": "句読点などの無音時間の調整",
-            "title": "Adjust Pause Length",
-            "type": "boolean"
+            "title": "Adjust Pause Length"
           },
           "adjust_phoneme_length": {
             "description": "音素ごとの長さの調整",
@@ -992,19 +1064,40 @@
             "type": "boolean"
           },
           "manage_library": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "description": "音声ライブラリのインストール・アンインストール",
-            "title": "Manage Library",
-            "type": "boolean"
+            "title": "Manage Library"
           },
           "return_resource_url": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "description": "キャラクター情報のリソースをURLで返送",
-            "title": "Return Resource Url",
-            "type": "boolean"
+            "title": "Return Resource Url"
           },
           "sing": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "description": "歌唱音声合成",
-            "title": "Sing",
-            "type": "boolean"
+            "title": "Sing"
           },
           "synthesis_morphing": {
             "description": "2種類のスタイルでモーフィングした音声を合成",
@@ -1029,12 +1122,19 @@
         "description": "エンジンのアップデート情報",
         "properties": {
           "contributors": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "description": "貢献者名",
-            "items": {
-              "type": "string"
-            },
-            "title": "Contributors",
-            "type": "array"
+            "title": "Contributors"
           },
           "descriptions": {
             "description": "アップデートの詳細についての説明",
@@ -1087,9 +1187,16 @@
             "type": "string"
           },
           "mora_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "description": "モーラ数",
-            "title": "Mora Count",
-            "type": "integer"
+            "title": "Mora Count"
           },
           "part_of_speech": {
             "description": "品詞",

--- a/voicevox_engine/engine_manifest.py
+++ b/voicevox_engine/engine_manifest.py
@@ -12,7 +12,6 @@ from pathlib import Path
 from typing import TypeAlias
 
 from pydantic import BaseModel, Field, TypeAdapter
-from pydantic.json_schema import SkipJsonSchema
 
 
 @dataclass(frozen=True)
@@ -73,9 +72,7 @@ class UpdateInfo(BaseModel):
 
     version: str = Field(description="エンジンのバージョン名")
     descriptions: list[str] = Field(description="アップデートの詳細についての説明")
-    contributors: list[str] | SkipJsonSchema[None] = Field(
-        default=None, description="貢献者名"
-    )
+    contributors: list[str] | None = Field(default=None, description="貢献者名")
 
 
 class LicenseInfo(BaseModel):
@@ -84,10 +81,8 @@ class LicenseInfo(BaseModel):
     """
 
     name: str = Field(description="依存ライブラリ名")
-    version: str | SkipJsonSchema[None] = Field(
-        default=None, description="依存ライブラリのバージョン"
-    )
-    license: str | SkipJsonSchema[None] = Field(
+    version: str | None = Field(default=None, description="依存ライブラリのバージョン")
+    license: str | None = Field(
         default=None, description="依存ライブラリのライセンス名"
     )
     text: str = Field(description="依存ライブラリのライセンス本文")
@@ -104,18 +99,18 @@ class SupportedFeatures(BaseModel):
     adjust_pitch_scale: bool = Field(description="全体の音高の調整")
     adjust_intonation_scale: bool = Field(description="全体の抑揚の調整")
     adjust_volume_scale: bool = Field(description="全体の音量の調整")
-    adjust_pause_length: bool | SkipJsonSchema[None] = Field(
+    adjust_pause_length: bool | None = Field(
         default=None, description="句読点などの無音時間の調整"
     )
     interrogative_upspeak: bool = Field(description="疑問文の自動調整")
     synthesis_morphing: bool = Field(
         description="2種類のスタイルでモーフィングした音声を合成"
     )
-    sing: bool | SkipJsonSchema[None] = Field(default=None, description="歌唱音声合成")
-    manage_library: bool | SkipJsonSchema[None] = Field(
+    sing: bool | None = Field(default=None, description="歌唱音声合成")
+    manage_library: bool | None = Field(
         default=None, description="音声ライブラリのインストール・アンインストール"
     )
-    return_resource_url: bool | SkipJsonSchema[None] = Field(
+    return_resource_url: bool | None = Field(
         default=None, description="キャラクター情報のリソースをURLで返送"
     )
 
@@ -142,7 +137,7 @@ class EngineManifest(BaseModel):
     dependency_licenses: list[LicenseInfo] = Field(
         description="依存関係のライセンス情報"
     )
-    supported_vvlib_manifest_version: str | SkipJsonSchema[None] = Field(
+    supported_vvlib_manifest_version: str | None = Field(
         default=None, description="エンジンが対応するvvlibのバージョン"
     )
     supported_features: SupportedFeatures = Field(description="エンジンが持つ機能")

--- a/voicevox_engine/metas/Metas.py
+++ b/voicevox_engine/metas/Metas.py
@@ -3,7 +3,6 @@
 from typing import Literal, NewType
 
 from pydantic import BaseModel, Field
-from pydantic.json_schema import SkipJsonSchema
 
 # NOTE: 循環importを防ぐためにとりあえずここに書いている
 # FIXME: 他のmodelに依存せず、全modelから参照できる場所に配置する
@@ -59,7 +58,7 @@ class StyleInfo(BaseModel):
     icon: str = Field(
         description="このスタイルのアイコンをbase64エンコードしたもの、あるいはURL"
     )
-    portrait: str | SkipJsonSchema[None] = Field(
+    portrait: str | None = Field(
         default=None,
         description="このスタイルの立ち絵画像をbase64エンコードしたもの、あるいはURL",
     )

--- a/voicevox_engine/model.py
+++ b/voicevox_engine/model.py
@@ -8,7 +8,6 @@ API と ENGINE 内部実装が共有するモデル
 """
 
 from pydantic import BaseModel, Field
-from pydantic.json_schema import SkipJsonSchema
 
 from voicevox_engine.tts_pipeline.model import AccentPhrase
 
@@ -34,7 +33,7 @@ class AudioQuery(BaseModel):
     )
     outputSamplingRate: int = Field(description="音声データの出力サンプリングレート")
     outputStereo: bool = Field(description="音声データをステレオ出力するか否か")
-    kana: str | SkipJsonSchema[None] = Field(
+    kana: str | None = Field(
         default=None,
         description="[読み取り専用]AquesTalk 風記法によるテキスト。音声合成用のクエリとしては無視される",
     )

--- a/voicevox_engine/preset/model.py
+++ b/voicevox_engine/preset/model.py
@@ -5,7 +5,6 @@
 """
 
 from pydantic import BaseModel, Field
-from pydantic.json_schema import SkipJsonSchema
 
 from voicevox_engine.metas.Metas import StyleId
 
@@ -25,9 +24,7 @@ class Preset(BaseModel):
     volumeScale: float = Field(description="全体の音量")
     prePhonemeLength: float = Field(description="音声の前の無音時間")
     postPhonemeLength: float = Field(description="音声の後の無音時間")
-    pauseLength: float | SkipJsonSchema[None] = Field(
-        default=None, description="句読点などの無音時間"
-    )
+    pauseLength: float | None = Field(default=None, description="句読点などの無音時間")
     pauseLengthScale: float = Field(
         default=1, description="句読点などの無音時間（倍率）"
     )

--- a/voicevox_engine/tts_pipeline/model.py
+++ b/voicevox_engine/tts_pipeline/model.py
@@ -7,7 +7,6 @@
 from enum import Enum
 
 from pydantic import BaseModel, ConfigDict, Field
-from pydantic.json_schema import SkipJsonSchema
 
 
 class Mora(BaseModel):
@@ -18,12 +17,8 @@ class Mora(BaseModel):
     model_config = ConfigDict(validate_assignment=True)
 
     text: str = Field(description="文字")
-    consonant: str | SkipJsonSchema[None] = Field(
-        default=None, description="子音の音素"
-    )
-    consonant_length: float | SkipJsonSchema[None] = Field(
-        default=None, description="子音の音長"
-    )
+    consonant: str | None = Field(default=None, description="子音の音素")
+    consonant_length: float | None = Field(default=None, description="子音の音長")
     vowel: str = Field(description="母音の音素")
     vowel_length: float = Field(description="母音の音長")
     pitch: float = Field(
@@ -45,9 +40,7 @@ class AccentPhrase(BaseModel):
 
     moras: list[Mora] = Field(description="モーラのリスト")
     accent: int = Field(description="アクセント箇所")
-    pause_mora: Mora | SkipJsonSchema[None] = Field(
-        default=None, description="後ろに無音を付けるかどうか"
-    )
+    pause_mora: Mora | None = Field(default=None, description="後ろに付ける無音モーラ")
     is_interrogative: bool = Field(default=False, description="疑問系かどうか")
 
     def __hash__(self) -> int:
@@ -63,7 +56,7 @@ class Note(BaseModel):
     音符ごとの情報
     """
 
-    key: int | SkipJsonSchema[None] = Field(default=None, description="音階")
+    key: int | None = Field(default=None, description="音階")
     frame_length: int = Field(description="音符のフレーム長")
     lyric: str = Field(description="音符の歌詞")
 

--- a/voicevox_engine/user_dict/model.py
+++ b/voicevox_engine/user_dict/model.py
@@ -9,7 +9,6 @@ from re import findall, fullmatch
 from typing import Self
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
-from pydantic.json_schema import SkipJsonSchema
 
 
 class WordTypes(str, Enum):
@@ -48,7 +47,7 @@ class UserDictWord(BaseModel):
     yomi: str = Field(description="読み")
     pronunciation: str = Field(description="発音")
     accent_type: int = Field(description="アクセント型")
-    mora_count: int | SkipJsonSchema[None] = Field(default=None, description="モーラ数")
+    mora_count: int | None = Field(default=None, description="モーラ数")
     accent_associative_rule: str = Field(description="アクセント結合規則")
 
     @field_validator("surface")


### PR DESCRIPTION
## 内容

`SkipJsonSchema`が要らないモデルの値から`SkipJsonSchema`を省いていきます。
これによってはサードパーティ側のバグになりえる型が出なくなるはず。

例えば`int | SkipJsonSchema[None] = default(None)`の場合、
「キーがない、もしくはキーがあって値がint」
という意味なのですが、実際に入る値は
「キーがない、もしくはキーがあって値がint、もしくはキーがあって値がNone」
だったので、`キーがあって値がNone`が来うることがわからないようになってました。

これを`int | None = default(None)`にすることで、実際の値と型をあわせました。

## 関連 Issue

close #1458 

## その他

ちなみに`SkipJsonSchema`を付けていたのはpydantic v1→v2アプデのときにモデルの型を一応変えないようにしたため。
詳細は

- https://github.com/VOICEVOX/voicevox_engine/issues/1458