### PR TITLE
localhostと扱うURLの種類を広くする

### DIFF
--- a/voicevox_engine/app/middlewares.py
+++ b/voicevox_engine/app/middlewares.py
@@ -28,7 +28,7 @@ def configure_middlewares(
     app.add_middleware(ServerErrorMiddleware, handler=global_execution_handler)
 
     # CORS用のヘッダを生成するミドルウェア
-    localhost_regex = "^https?://(localhost|127\\.0\\.0\\.1|\\[::1\\])(:[0-9]+)?$"
+    localhost_regex = r"^[a-zA-Z+\-\.]+://(([^/]+\.)localhost|127\.0\.0\.1|\[::1\])(:[0-9]+)?$"
     compiled_localhost_regex = re.compile(localhost_regex)
     allowed_origins = ["*"]
     if cors_policy_mode == "localapps":

--- a/voicevox_engine/app/middlewares.py
+++ b/voicevox_engine/app/middlewares.py
@@ -28,7 +28,9 @@ def configure_middlewares(
     app.add_middleware(ServerErrorMiddleware, handler=global_execution_handler)
 
     # CORS用のヘッダを生成するミドルウェア
-    localhost_regex = r"^[a-zA-Z+\-\.]+://(([^/]+\.)localhost|127\.0\.0\.1|\[::1\])(:[0-9]+)?$"
+    localhost_regex = (
+        r"^[a-zA-Z+\-\.]+://(([^/]+\.)localhost|127\.0\.0\.1|\[::1\])(:[0-9]+)?$"
+    )
     compiled_localhost_regex = re.compile(localhost_regex)
     allowed_origins = ["*"]
     if cors_policy_mode == "localapps":


### PR DESCRIPTION
## 内容

サブドメイン付きlocalhost、`app://localhost`を許容するようにします。
VVVST用。

## 関連 Issue

（なし）

## スクリーンショット・動画など

（なし）

## その他

（なし）