### PR TITLE
FIX: 未処理の例外が発生した場合スタックトレースが表示されない問題を修正

### DIFF
--- a/voicevox_engine/app/middlewares.py
+++ b/voicevox_engine/app/middlewares.py
@@ -3,6 +3,7 @@
 import re
 import sys
 from collections.abc import Awaitable, Callable
+from traceback import print_exception
 
 from fastapi import FastAPI, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
@@ -20,6 +21,7 @@ def configure_middlewares(
     # 未処理の例外が発生するとCORSMiddlewareが適用されない問題に対するワークアラウンド
     # ref: https://github.com/VOICEVOX/voicevox_engine/issues/91
     async def global_execution_handler(request: Request, exc: Exception) -> Response:
+        print_exception(exc)
         return JSONResponse(
             status_code=500,
             content="Internal Server Error",


### PR DESCRIPTION
## 内容

未処理の例外が発生した場合`global_execution_handler`内で例外をそのまま捨てていました。
結果、例外はコンソールに一切表示されていませんでした。

この問題を修正します。

https://github.com/VOICEVOX/voicevox_engine/issues/1478#issuecomment-2470485499

## 関連 Issue

- fix: #1478

## その他

例外の内容をレスポンスに含めるのは意図しない情報が外部に漏洩する可能性があるので`global_execution_handler`のレスポンスに含めてはいけないと思います。

`PresetManager`でファイルの書き込み時に`FileNotFoundError`を捕捉するようになっているがこれは発生しない気がする…