### PR TITLE
FIX: プリセットマネージャーのエラーハンドリングを改善

### DIFF
--- a/test/unit/preset/test_preset.py
+++ b/test/unit/preset/test_preset.py
@@ -192,7 +192,7 @@ def test_add_preset_write_failure(tmp_path: Path) -> None:
     preset_manager.load_presets()
     preset_manager._refresh_cache = lambda: None  # type:ignore[method-assign]
     preset_manager.preset_path = ""  # type: ignore[assignment]
-    true_msg = "プリセットの設定ファイルが見つかりません"
+    true_msg = "プリセットの書き込みに失敗しました"
     with pytest.raises(PresetInternalError, match=true_msg):
         preset_manager.add_preset(preset)
     assert len(preset_manager.presets) == 2
@@ -302,7 +302,7 @@ def test_update_preset_write_failure(tmp_path: Path) -> None:
     preset_manager.load_presets()
     preset_manager._refresh_cache = lambda: None  # type:ignore[method-assign]
     preset_manager.preset_path = ""  # type: ignore[assignment]
-    true_msg = "プリセットの設定ファイルが見つかりません"
+    true_msg = "プリセットの書き込みに失敗しました"
     with pytest.raises(PresetInternalError, match=true_msg):
         preset_manager.update_preset(preset)
     assert len(preset_manager.presets) == 2
@@ -345,7 +345,7 @@ def test_delete_preset_write_failure(tmp_path: Path) -> None:
     preset_manager.load_presets()
     preset_manager._refresh_cache = lambda: None  # type:ignore[method-assign]
     preset_manager.preset_path = ""  # type: ignore[assignment]
-    true_msg = "プリセットの設定ファイルが見つかりません"
+    true_msg = "プリセットの書き込みに失敗しました"
     with pytest.raises(PresetInternalError, match=true_msg):
         preset_manager.delete_preset(1)
     assert len(preset_manager.presets) == 2

--- a/voicevox_engine/preset/preset_manager.py
+++ b/voicevox_engine/preset/preset_manager.py
@@ -50,20 +50,18 @@ class PresetManager:
             # データベースの読み込み
             with open(self.preset_path, mode="r", encoding="utf-8") as f:
                 obj = yaml.safe_load(f)
-        except OSError as err:
-            raise PresetInternalError("プリセットの読み込みに失敗しました") from err
-        except yaml.YAMLError as err:
-            raise PresetInternalError("プリセットのパースに失敗しました") from err
+        except OSError:
+            raise PresetInternalError("プリセットの読み込みに失敗しました")
+        except yaml.YAMLError:
+            raise PresetInternalError("プリセットのパースに失敗しました")
         if obj is None:
             raise PresetInternalError("プリセットの設定ファイルが空の内容です")
 
         try:
             preset_list_adapter = TypeAdapter(list[Preset])
             _presets = preset_list_adapter.validate_python(obj)
-        except ValidationError as err:
-            raise PresetInternalError(
-                "プリセットの設定ファイルにミスがあります"
-            ) from err
+        except ValidationError:
+            raise PresetInternalError("プリセットの設定ファイルにミスがあります")
 
         # 全idの一意性をバリデーション
         if len([preset.id for preset in _presets]) != len(
@@ -93,7 +91,7 @@ class PresetManager:
         except Exception as err:
             self.presets.pop()
             if isinstance(err, OSError):
-                raise PresetInternalError("プリセットの書き込みに失敗しました") from err
+                raise PresetInternalError("プリセットの書き込みに失敗しました")
             else:
                 raise err
 
@@ -129,7 +127,7 @@ class PresetManager:
         except Exception as err:
             self.presets[prev_preset[0]] = prev_preset[1]
             if isinstance(err, OSError):
-                raise PresetInternalError("プリセットの書き込みに失敗しました") from err
+                raise PresetInternalError("プリセットの書き込みに失敗しました")
             else:
                 raise err
 
@@ -155,9 +153,9 @@ class PresetManager:
         # 変更の反映。失敗時はリバート。
         try:
             self._write_on_file()
-        except OSError as err:
+        except OSError:
             self.presets.insert(buf_index, buf)
-            raise PresetInternalError("プリセットの書き込みに失敗しました") from err
+            raise PresetInternalError("プリセットの書き込みに失敗しました")
 
         return id
 


### PR DESCRIPTION
## 内容

PresetManagerで`FileNotFoundError`を捕捉するように書かれていますが通常はまず起こらない上にそれ以外の`OSError`を捕捉しないので修正します。

それに伴いエラーメッセージも変更します。

## 関連 Issue

- ref: #1487

## その他

個人的な意見ですが`Internal Server Error`はエラーの詳細をクライアントに伝えるべきではないような気がします。
例外の内容コンソールに表示した方がいいような気がします。

https://github.com/VOICEVOX/voicevox_engine/blob/581c303affa18a548b3e86c9c4198956997e25c0/voicevox_engine/app/routers/preset.py#L31-L36
```diff
-        except PresetInternalError as err:
-            raise HTTPException(status_code=500, detail=str(err))
+        except PresetInternalError:
+            print_exc()
+            raise HTTPException(status_code=500, detail="Internal Server Error")
```