### PR TITLE
DockerビルドCI: デフォルトのタグをUbuntu 22.04ベースのイメージに切り替える

### DIFF
--- a/.github/workflows/build-engine-container.yml
+++ b/.github/workflows/build-engine-container.yml
@@ -48,34 +48,34 @@ jobs:
         # onnxruntime_version: ONNX Runtimeのバージョン
         # platforms: Dockerのプラットフォームバリアント。カンマ区切り。 参考: https://docs.docker.com/build/building/multi-platform/
         include:
-          # Ubuntu 20.04
-          - prefixes: ",cpu,cpu-ubuntu20.04"
-            buildcache_prefix: "cpu-ubuntu20.04"
-            target: runtime-env
-            base_image: ubuntu:20.04
-            base_runtime_image: ubuntu:20.04
-            onnxruntime_version: 1.13.1
-            platforms: linux/amd64,linux/arm64/v8
-          - prefixes: "nvidia,nvidia-ubuntu20.04"
-            buildcache_prefix: "nvidia-ubuntu20.04"
-            target: runtime-nvidia-env
-            base_image: ubuntu:20.04
-            base_runtime_image: nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu20.04
-            onnxruntime_version: 1.13.1
-            platforms: linux/amd64
           # Ubuntu 22.04
-          - prefixes: "cpu-ubuntu22.04"
+          - prefixes: ",cpu,cpu-ubuntu22.04"
             buildcache_prefix: "cpu-ubuntu22.04"
             target: runtime-env
             base_image: ubuntu:22.04
             base_runtime_image: ubuntu:22.04
             onnxruntime_version: 1.13.1
             platforms: linux/amd64,linux/arm64/v8
-          - prefixes: "nvidia-ubuntu22.04"
+          - prefixes: "nvidia,nvidia-ubuntu22.04"
             buildcache_prefix: "nvidia-ubuntu22.04"
             target: runtime-nvidia-env
             base_image: ubuntu:22.04
             base_runtime_image: nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu22.04
+            onnxruntime_version: 1.13.1
+            platforms: linux/amd64
+          # Ubuntu 20.04
+          - prefixes: "cpu-ubuntu20.04"
+            buildcache_prefix: "cpu-ubuntu20.04"
+            target: runtime-env
+            base_image: ubuntu:20.04
+            base_runtime_image: ubuntu:20.04
+            onnxruntime_version: 1.13.1
+            platforms: linux/amd64,linux/arm64/v8
+          - prefixes: "nvidia-ubuntu20.04"
+            buildcache_prefix: "nvidia-ubuntu20.04"
+            target: runtime-nvidia-env
+            base_image: ubuntu:20.04
+            base_runtime_image: nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu20.04
             onnxruntime_version: 1.13.1
             platforms: linux/amd64
 

--- a/.github/workflows/build-engine-container.yml
+++ b/.github/workflows/build-engine-container.yml
@@ -48,21 +48,6 @@ jobs:
         # onnxruntime_version: ONNX Runtimeのバージョン
         # platforms: Dockerのプラットフォームバリアント。カンマ区切り。 参考: https://docs.docker.com/build/building/multi-platform/
         include:
-          # Ubuntu 22.04
-          - prefixes: ",cpu,cpu-ubuntu22.04"
-            buildcache_prefix: "cpu-ubuntu22.04"
-            target: runtime-env
-            base_image: ubuntu:22.04
-            base_runtime_image: ubuntu:22.04
-            onnxruntime_version: 1.13.1
-            platforms: linux/amd64,linux/arm64/v8
-          - prefixes: "nvidia,nvidia-ubuntu22.04"
-            buildcache_prefix: "nvidia-ubuntu22.04"
-            target: runtime-nvidia-env
-            base_image: ubuntu:22.04
-            base_runtime_image: nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu22.04
-            onnxruntime_version: 1.13.1
-            platforms: linux/amd64
           # Ubuntu 20.04
           - prefixes: "cpu-ubuntu20.04"
             buildcache_prefix: "cpu-ubuntu20.04"
@@ -76,6 +61,21 @@ jobs:
             target: runtime-nvidia-env
             base_image: ubuntu:20.04
             base_runtime_image: nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu20.04
+            onnxruntime_version: 1.13.1
+            platforms: linux/amd64
+          # Ubuntu 22.04
+          - prefixes: ",cpu,cpu-ubuntu22.04"
+            buildcache_prefix: "cpu-ubuntu22.04"
+            target: runtime-env
+            base_image: ubuntu:22.04
+            base_runtime_image: ubuntu:22.04
+            onnxruntime_version: 1.13.1
+            platforms: linux/amd64,linux/arm64/v8
+          - prefixes: "nvidia,nvidia-ubuntu22.04"
+            buildcache_prefix: "nvidia-ubuntu22.04"
+            target: runtime-nvidia-env
+            base_image: ubuntu:22.04
+            base_runtime_image: nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu22.04
             onnxruntime_version: 1.13.1
             platforms: linux/amd64
 

--- a/README.md
+++ b/README.md
@@ -43,15 +43,15 @@ VOICEVOX エンジンもしくはエディタを起動した状態で http://127
 #### CPU
 
 ```bash
-docker pull voicevox/voicevox_engine:cpu-ubuntu20.04-latest
-docker run --rm -p '127.0.0.1:50021:50021' voicevox/voicevox_engine:cpu-ubuntu20.04-latest
+docker pull voicevox/voicevox_engine:cpu-ubuntu22.04-latest
+docker run --rm -p '127.0.0.1:50021:50021' voicevox/voicevox_engine:cpu-ubuntu22.04-latest
 ```
 
 #### GPU
 
 ```bash
-docker pull voicevox/voicevox_engine:nvidia-ubuntu20.04-latest
-docker run --rm --gpus all -p '127.0.0.1:50021:50021' voicevox/voicevox_engine:nvidia-ubuntu20.04-latest
+docker pull voicevox/voicevox_engine:nvidia-ubuntu22.04-latest
+docker run --rm --gpus all -p '127.0.0.1:50021:50021' voicevox/voicevox_engine:nvidia-ubuntu22.04-latest
 ```
 
 ##### トラブルシューティング

--- a/README.md
+++ b/README.md
@@ -43,15 +43,15 @@ VOICEVOX エンジンもしくはエディタを起動した状態で http://127
 #### CPU
 
 ```bash
-docker pull voicevox/voicevox_engine:cpu-ubuntu22.04-latest
-docker run --rm -p '127.0.0.1:50021:50021' voicevox/voicevox_engine:cpu-ubuntu22.04-latest
+docker pull voicevox/voicevox_engine:cpu-latest
+docker run --rm -p '127.0.0.1:50021:50021' voicevox/voicevox_engine:cpu-latest
 ```
 
 #### GPU
 
 ```bash
-docker pull voicevox/voicevox_engine:nvidia-ubuntu22.04-latest
-docker run --rm --gpus all -p '127.0.0.1:50021:50021' voicevox/voicevox_engine:nvidia-ubuntu22.04-latest
+docker pull voicevox/voicevox_engine:nvidia-latest
+docker run --rm --gpus all -p '127.0.0.1:50021:50021' voicevox/voicevox_engine:nvidia-latest
 ```
 
 ##### トラブルシューティング


### PR DESCRIPTION
## 内容

DockerビルドCIで、Dockerイメージのデフォルトのタグ（`latest`、`cpu-latest`、`nvidia-latest`）をUbuntu 22.04ベースのイメージに切り替えます。

- #1500

の実装です。

Ubuntu 20.04は、サポート期限が切れる前に削除する想定で、このプルリクエストでは、これまでのUbuntu 22.04のように並列ビルドする形で残しています。

## 変更点

- [x] `.github/workflows/build-engine-container.yml`のデフォルトのタグをUbuntu 22.04ベースのイメージに変更
- [x] READMEのDockerイメージの案内をUbuntu 22.04ベースのイメージに変更

## 変更をお願いしたい点

- Docker HubのDockerイメージの案内をUbuntu 22.04ベースのイメージに変更
    - https://hub.docker.com/r/voicevox/voicevox_engine

## 関連 Issue

- close #1500 

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->
