### PR TITLE
fix: typo in warning log

### DIFF
--- a/voicevox_engine/app/middlewares.py
+++ b/voicevox_engine/app/middlewares.py
@@ -42,7 +42,7 @@ def configure_middlewares(
             if "*" in allow_origin:
                 print(
                     'WARNING: Deprecated use of argument "*" in allow_origin. '
-                    'Use option "--cors_policy_mod all" instead. See "--help" for more.',
+                    'Use option "--cors_policy_mode all" instead. See "--help" for more.',
                     file=sys.stderr,
                 )
 


### PR DESCRIPTION
## 内容

Thank you for this library.
This PR fixes a typo in the warning logs.

