### PR TITLE
feat: Linux arm64向けパッケージを追加

### DIFF
--- a/.github/workflows/build-engine-package.yml
+++ b/.github/workflows/build-engine-package.yml
@@ -87,12 +87,18 @@ jobs:
             voicevox_core_asset_prefix: voicevox_core-osx-arm64-cpu
             onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.13.1/onnxruntime-osx-arm64-1.13.1.tgz
             target: macos-arm64
-          # Linux CPU
+          # Linux CPU (x64 arch)
           - os: ubuntu-20.04
             architecture: "x64"
             voicevox_core_asset_prefix: voicevox_core-linux-x64-cpu
             onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.13.1/onnxruntime-linux-x64-1.13.1.tgz
-            target: linux-cpu
+            target: linux-cpu-x64
+          # Linux CPU (arm64 arch)
+          - os: ubuntu-22.04-arm
+            architecture: "arm64"
+            voicevox_core_asset_prefix: voicevox_core-linux-arm64-cpu
+            onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.13.1/onnxruntime-linux-aarch64-1.13.1.tgz
+            target: linux-cpu-arm64
           # Linux NVIDIA GPU
           - os: ubuntu-20.04
             architecture: "x64"

--- a/.github/workflows/test-engine-package.yml
+++ b/.github/workflows/test-engine-package.yml
@@ -83,5 +83,13 @@ jobs:
         if: startsWith(matrix.target, 'linux') || startsWith(matrix.target, 'macos')
         run: chmod +x dist/run
 
+      # ref: https://github.com/VOICEVOX/voicevox_engine/issues/839
+      # ref: https://github.com/VOICEVOX/voicevox_engine/pull/806
+      - name: <Setup> Install libsndfile1 for Linux arm64 architecture
+        if: startsWith(matrix.target, 'linux') && endsWith(matrix.target, 'arm64')
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libsndfile1
+
       - name: <Test> Test ENGINE package
         run: python tools/check_release_build.py --dist_dir dist/

--- a/.github/workflows/test-engine-package.yml
+++ b/.github/workflows/test-engine-package.yml
@@ -38,7 +38,9 @@ jobs:
       matrix:
         include:
           - os: ubuntu-20.04
-            target: linux-cpu
+            target: linux-cpu-x64
+          - os: ubuntu-22.04-arm
+            target: linux-cpu-arm64
           - os: ubuntu-20.04
             target: linux-nvidia
           - os: macos-13

--- a/.github/workflows/test-engine-package.yml
+++ b/.github/workflows/test-engine-package.yml
@@ -83,8 +83,8 @@ jobs:
         if: startsWith(matrix.target, 'linux') || startsWith(matrix.target, 'macos')
         run: chmod +x dist/run
 
-      # ref: https://github.com/VOICEVOX/voicevox_engine/issues/839
       # ref: https://github.com/VOICEVOX/voicevox_engine/pull/806
+      # ref: https://github.com/VOICEVOX/voicevox_engine/issues/1516
       - name: <Setup> Install libsndfile1 for Linux arm64 architecture
         if: startsWith(matrix.target, 'linux') && endsWith(matrix.target, 'arm64')
         run: |


### PR DESCRIPTION
## 内容

Linux arm64向けPythonパッケージを追加します。
これにより、64bitアーキテクチャで動作するRaspberry Piや、安価なクラウドインスタンス環境などで利用できるようになります。
Dockerイメージのビルドはすでにあったため、変更を加えていません。

## 関連 Issue

close #322 
ref. #839 

## その他

Linux x64向けのパッケージ名が変わるため、エンジンを利用するVOICEVOXや第三者は対応が必要になると思われます。

GitHub Actionsのlinterである[actionlint](https://github.com/rhysd/actionlint)がまだpublic previewであるGitHub ActionsランナーのOS`ubuntu-22.04-arm`に対応していないため、[テストを通過できていません](https://github.com/VOICEVOX/voicevox_engine/actions/runs/12844562386/job/35817701165?pr=1515)。
数日中にはテストが通過できる見込みです。
ref. https://github.com/rhysd/actionlint/pull/503#issuecomment-2599503837
