### PR TITLE
追加: 起動前にengine_manifest.jsonをチェックする

### DIFF
--- a/.github/workflows/test-engine-container.yml
+++ b/.github/workflows/test-engine-container.yml
@@ -86,4 +86,4 @@ jobs:
           exit 1
 
       - name: <Test> Test ENGINE application docker container
-        run: python tools/check_release_build.py --skip_check_manifest --skip_run_process --dist_dir dist/
+        run: python tools/check_release_build.py --skip_run_process --skip_check_manifest --dist_dir dist/

--- a/.github/workflows/test-engine-container.yml
+++ b/.github/workflows/test-engine-container.yml
@@ -68,11 +68,11 @@ jobs:
       - name: <Setup> Warm up ENGINE server by waiting
         run: |
           set +e # curlのエラーを無視する
-          
+
           url="http://127.0.0.1:50021/version"
           max_attempts=10
           sleep_interval=5
-          
+
           for i in $(seq 1 "$max_attempts"); do
             status=$(curl -o /dev/null -s -w '%{http_code}\n' "$url")
             if [ "$status" -eq 200 ]; then
@@ -86,4 +86,4 @@ jobs:
           exit 1
 
       - name: <Test> Test ENGINE application docker container
-        run: python tools/check_release_build.py --skip_run_process --dist_dir dist/
+        run: python tools/check_release_build.py --skip_check_manifest --skip_run_process --dist_dir dist/

--- a/tools/check_release_build.py
+++ b/tools/check_release_build.py
@@ -24,6 +24,11 @@ def test_release_build(dist_dir: Path, skip_run_process: bool) -> None:
     # 起動
     process = None
     if not skip_run_process:
+        manifest_file = dist_dir / "engine_manifest.json"
+        assert manifest_file.is_file()
+        manifest = json.loads(manifest_file.read_text(encoding="utf-8"))
+        assert "manifest_version" in manifest
+
         process = Popen([run_file.absolute()], cwd=dist_dir)
 
     # 起動待機

--- a/tools/check_release_build.py
+++ b/tools/check_release_build.py
@@ -16,19 +16,23 @@ import soundfile
 base_url = "http://127.0.0.1:50021/"
 
 
-def test_release_build(dist_dir: Path, skip_run_process: bool) -> None:
+def test_release_build(
+    dist_dir: Path, skip_run_process: bool, skip_check_manifest: bool
+) -> None:
     run_file = dist_dir / "run"
     if not run_file.exists():
         run_file = dist_dir / "run.exe"
 
-    # 起動
-    process = None
-    if not skip_run_process:
+    # マニフェストファイルの確認
+    if not skip_check_manifest:
         manifest_file = dist_dir / "engine_manifest.json"
         assert manifest_file.is_file()
         manifest = json.loads(manifest_file.read_text(encoding="utf-8"))
         assert "manifest_version" in manifest
 
+    # 起動
+    process = None
+    if not skip_run_process:
         process = Popen([run_file.absolute()], cwd=dist_dir)
 
     # 起動待機
@@ -82,5 +86,10 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--dist_dir", type=Path, default=Path("dist/"))
     parser.add_argument("--skip_run_process", action="store_true")
+    parser.add_argument("--skip_check_manifest", action="store_true")
     args = parser.parse_args()
-    test_release_build(dist_dir=args.dist_dir, skip_run_process=args.skip_run_process)
+    test_release_build(
+        dist_dir=args.dist_dir,
+        skip_run_process=args.skip_run_process,
+        skip_check_manifest=args.skip_check_manifest,
+    )


### PR DESCRIPTION
## 内容
check_release_build.py でエンジン起動前に`engine_manifest.json`の

1. 存在チェック
1. jsonとして読み込めるかチェック
1. 適当なキー(`manifest_version`とした)の存在チェック

を行うようにしました。

fork先でbuildのCIが通ることを確認しました。
https://github.com/nanae772/voicevox_engine/actions/runs/13263787224

<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue
ref #1300 
<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
