### PR TITLE
docs: READMEの--voicevox_dirの指定方法を更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,7 +484,7 @@ python run.py --help
 
 ```bash
 # 製品版 VOICEVOX でサーバーを起動
-VOICEVOX_DIR="C:/path/to/voicevox" # 製品版 VOICEVOX ディレクトリのパス
+VOICEVOX_DIR="C:/path/to/VOICEVOX/vv-engine" # 製品版 VOICEVOX ディレクトリ内の ENGINE のパス
 python run.py --voicevox_dir=$VOICEVOX_DIR
 ```
 
@@ -533,13 +533,13 @@ Mac での libtorch 版コアのサポートはしていません。
 製品版 VOICEVOX もしくはコンパイル済みエンジンのディレクトリを`--voicevox_dir`引数で指定すると、そのバージョンのコアが使用されます。
 
 ```bash
-python run.py --voicevox_dir="/path/to/voicevox"
+python run.py --voicevox_dir="/path/to/VOICEVOX/vv-engine"
 ```
 
 Mac では、`DYLD_LIBRARY_PATH`の指定が必要です。
 
 ```bash
-DYLD_LIBRARY_PATH="/path/to/voicevox" python run.py --voicevox_dir="/path/to/voicevox"
+DYLD_LIBRARY_PATH="/path/to/voicevox" python run.py --voicevox_dir="/path/to/VOICEVOX/vv-engine"
 ```
 
 ##### 音声ライブラリを直接指定する


### PR DESCRIPTION
## 内容
vv-engineまで指定しないと動かなかったので、ドキュメントもそのように更新しました。

CONTRIBUTING.mdのほうでは

```sh
VOICEVOX_DIR="C:/path/to/VOICEVOX/vv-engine" # 製品版 VOICEVOX ディレクトリ内の ENGINE のパス
```

とあったので、現在はこちらのほうが正確なのではないかと思い、そのようにしました。

https://github.com/VOICEVOX/voicevox_engine/blob/master/CONTRIBUTING.md#%E9%9F%B3%E5%A3%B0%E3%83%A9%E3%82%A4%E3%83%96%E3%83%A9%E3%83%AA%E3%81%AB%E8%A3%BD%E5%93%81%E7%89%88-voicevox-%E3%82%92%E5%88%A9%E7%94%A8%E3%81%97%E3%81%A6%E5%AE%9F%E8%A1%8C

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
