### PR TITLE
chore(build): OpenBLASのライセンスはNumpyのライセンスに含まれているため削除する

### DIFF
--- a/tools/generate_licenses.py
+++ b/tools/generate_licenses.py
@@ -207,14 +207,6 @@ def generate_licenses() -> list[License]:
             license_text=f"https://raw.githubusercontent.com/python/cpython/v{python_version}/LICENSE",
             license_text_type="remote_address",
         ),
-        # OpenBLAS
-        License(
-            package_name="OpenBLAS",
-            package_version=None,
-            license_name="BSD 3-clause license",
-            license_text="https://raw.githubusercontent.com/xianyi/OpenBLAS/develop/LICENSE",
-            license_text_type="remote_address",
-        ),
         License(
             package_name="libsndfile-binaries",
             package_version="1.2.0",


### PR DESCRIPTION
## 内容

Numpyのライセンス文にはNumpyが依存するOpenBLAS等のライブラリのライセンス文が含まれています。
そのため個別にOpenBLASのライセンスを追加する必要はありません。

`generate_licenses.py`を変更してOpenBLASのライセンスを追加しないように変更します。

## その他

ところでこのスクリプトは`pip-licenses`にパスが通っていないと実行できないという問題があります。
個人的に気になって軽く調べたところ[`sysconfig.get_path("scripts")`](https://docs.python.org/ja/3/library/sysconfig.html#sysconfig.get_path)で実行中のPythonの実行ファイルがあるディレクトリが取得できることが分かりました。

これを使えば`pip-license`のフルパスを取得するか`pip-license`実行時のみに`PATH`環境変数を追加するようにすることで実行前に`PATH`を追加する必要がなくなります。

とりあえず直そうと思えば直すことができるという情報です。