### PR TITLE
feat!: OpenAPIで生成される関数を元の関数名ベースにする

### DIFF
--- a/test/e2e/__snapshots__/test_openapi/test_OpenAPIの形が変わっていないことを確認.json
+++ b/test/e2e/__snapshots__/test_openapi/test_OpenAPIの形が変わっていないことを確認.json
@@ -1293,7 +1293,7 @@
     "/": {
       "get": {
         "description": "ポータルページを返します。",
-        "operationId": "get_portal_page__get",
+        "operationId": "get_portal_page",
         "responses": {
           "200": {
             "content": {
@@ -1315,7 +1315,7 @@
     "/accent_phrases": {
       "post": {
         "description": "テキストからアクセント句を得ます。\nis_kanaが`true`のとき、テキストは次のAquesTalk 風記法で解釈されます。デフォルトは`false`です。\n* 全てのカナはカタカナで記述される\n* アクセント句は`/`または`、`で区切る。`、`で区切った場合に限り無音区間が挿入される。\n* カナの手前に`_`を入れるとそのカナは無声化される\n* アクセント位置を`'`で指定する。全てのアクセント句にはアクセント位置を1つ指定する必要がある。\n* アクセント句末に`？`(全角)を入れることにより疑問文の発音ができる。",
-        "operationId": "accent_phrases_accent_phrases_post",
+        "operationId": "accent_phrases",
         "parameters": [
           {
             "in": "query",
@@ -1400,7 +1400,7 @@
     "/add_preset": {
       "post": {
         "description": "新しいプリセットを追加します",
-        "operationId": "add_preset_add_preset_post",
+        "operationId": "add_preset",
         "requestBody": {
           "content": {
             "application/json": {
@@ -1444,7 +1444,7 @@
     "/audio_query": {
       "post": {
         "description": "音声合成用のクエリの初期値を得ます。ここで得られたクエリはそのまま音声合成に利用できます。各値の意味は`Schemas`を参照してください。",
-        "operationId": "audio_query_audio_query_post",
+        "operationId": "audio_query",
         "parameters": [
           {
             "in": "query",
@@ -1505,7 +1505,7 @@
     "/audio_query_from_preset": {
       "post": {
         "description": "音声合成用のクエリの初期値を得ます。ここで得られたクエリはそのまま音声合成に利用できます。各値の意味は`Schemas`を参照してください。",
-        "operationId": "audio_query_from_preset_audio_query_from_preset_post",
+        "operationId": "audio_query_from_preset",
         "parameters": [
           {
             "in": "query",
@@ -1565,7 +1565,7 @@
     },
     "/cancellable_synthesis": {
       "post": {
-        "operationId": "cancellable_synthesis_cancellable_synthesis_post",
+        "operationId": "cancellable_synthesis",
         "parameters": [
           {
             "in": "query",
@@ -1628,7 +1628,7 @@
     "/connect_waves": {
       "post": {
         "description": "base64エンコードされたwavデータを一纏めにし、wavファイルで返します。",
-        "operationId": "connect_waves_connect_waves_post",
+        "operationId": "connect_waves",
         "requestBody": {
           "content": {
             "application/json": {
@@ -1675,7 +1675,7 @@
     "/core_versions": {
       "get": {
         "description": "利用可能なコアのバージョン一覧を取得します。",
-        "operationId": "core_versions_core_versions_get",
+        "operationId": "core_versions",
         "responses": {
           "200": {
             "content": {
@@ -1701,7 +1701,7 @@
     "/delete_preset": {
       "post": {
         "description": "既存のプリセットを削除します",
-        "operationId": "delete_preset_delete_preset_post",
+        "operationId": "delete_preset",
         "parameters": [
           {
             "description": "削除するプリセットのプリセットID",
@@ -1739,7 +1739,7 @@
     "/downloadable_libraries": {
       "get": {
         "description": "ダウンロード可能な音声ライブラリの情報を返します。",
-        "operationId": "downloadable_libraries_downloadable_libraries_get",
+        "operationId": "downloadable_libraries",
         "responses": {
           "200": {
             "content": {
@@ -1765,7 +1765,7 @@
     "/engine_manifest": {
       "get": {
         "description": "エンジンマニフェストを取得します。",
-        "operationId": "engine_manifest_engine_manifest_get",
+        "operationId": "engine_manifest",
         "responses": {
           "200": {
             "content": {
@@ -1787,7 +1787,7 @@
     "/frame_synthesis": {
       "post": {
         "description": "歌唱音声合成を行います。",
-        "operationId": "frame_synthesis_frame_synthesis_post",
+        "operationId": "frame_synthesis",
         "parameters": [
           {
             "in": "query",
@@ -1850,7 +1850,7 @@
     "/import_user_dict": {
       "post": {
         "description": "他のユーザー辞書をインポートします。",
-        "operationId": "import_user_dict_words_import_user_dict_post",
+        "operationId": "import_user_dict_words",
         "parameters": [
           {
             "description": "重複したエントリがあった場合、上書きするかどうか",
@@ -1903,7 +1903,7 @@
     "/initialize_speaker": {
       "post": {
         "description": "指定されたスタイルを初期化します。\n実行しなくても他のAPIは使用できますが、初回実行時に時間がかかることがあります。",
-        "operationId": "initialize_speaker_initialize_speaker_post",
+        "operationId": "initialize_speaker",
         "parameters": [
           {
             "in": "query",
@@ -1960,7 +1960,7 @@
     "/install_library/{library_uuid}": {
       "post": {
         "description": "音声ライブラリをインストールします。\n音声ライブラリのZIPファイルをリクエストボディとして送信してください。",
-        "operationId": "install_library_install_library__library_uuid__post",
+        "operationId": "install_library",
         "parameters": [
           {
             "description": "音声ライブラリのID",
@@ -1998,7 +1998,7 @@
     "/installed_libraries": {
       "get": {
         "description": "インストールした音声ライブラリの情報を返します。",
-        "operationId": "installed_libraries_installed_libraries_get",
+        "operationId": "installed_libraries",
         "responses": {
           "200": {
             "content": {
@@ -2024,7 +2024,7 @@
     "/is_initialized_speaker": {
       "get": {
         "description": "指定されたスタイルが初期化されているかどうかを返します。",
-        "operationId": "is_initialized_speaker_is_initialized_speaker_get",
+        "operationId": "is_initialized_speaker",
         "parameters": [
           {
             "in": "query",
@@ -2076,7 +2076,7 @@
     },
     "/mora_data": {
       "post": {
-        "operationId": "mora_data_mora_data_post",
+        "operationId": "mora_data",
         "parameters": [
           {
             "in": "query",
@@ -2145,7 +2145,7 @@
     },
     "/mora_length": {
       "post": {
-        "operationId": "mora_length_mora_length_post",
+        "operationId": "mora_length",
         "parameters": [
           {
             "in": "query",
@@ -2214,7 +2214,7 @@
     },
     "/mora_pitch": {
       "post": {
-        "operationId": "mora_pitch_mora_pitch_post",
+        "operationId": "mora_pitch",
         "parameters": [
           {
             "in": "query",
@@ -2284,7 +2284,7 @@
     "/morphable_targets": {
       "post": {
         "description": "指定されたベーススタイルに対してエンジン内の各キャラクターがモーフィング機能を利用可能か返します。\nモーフィングの許可/禁止は`/speakers`の`speaker.supported_features.synthesis_morphing`に記載されています。\nプロパティが存在しない場合は、モーフィングが許可されているとみなします。\n返り値のスタイルIDはstring型なので注意。",
-        "operationId": "morphable_targets_morphable_targets_post",
+        "operationId": "morphable_targets",
         "parameters": [
           {
             "in": "query",
@@ -2347,7 +2347,7 @@
     },
     "/multi_synthesis": {
       "post": {
-        "operationId": "multi_synthesis_multi_synthesis_post",
+        "operationId": "multi_synthesis",
         "parameters": [
           {
             "in": "query",
@@ -2414,7 +2414,7 @@
     "/presets": {
       "get": {
         "description": "エンジンが保持しているプリセットの設定を返します",
-        "operationId": "get_presets_presets_get",
+        "operationId": "get_presets",
         "responses": {
           "200": {
             "content": {
@@ -2440,7 +2440,7 @@
     "/setting": {
       "get": {
         "description": "設定ページを返します。",
-        "operationId": "setting_get_setting_get",
+        "operationId": "setting_get",
         "responses": {
           "200": {
             "description": "Successful Response"
@@ -2453,7 +2453,7 @@
       },
       "post": {
         "description": "設定を更新します。",
-        "operationId": "setting_post_setting_post",
+        "operationId": "setting_post",
         "requestBody": {
           "content": {
             "application/x-www-form-urlencoded": {
@@ -2488,7 +2488,7 @@
     "/sing_frame_audio_query": {
       "post": {
         "description": "歌唱音声合成用のクエリの初期値を得ます。ここで得られたクエリはそのまま歌唱音声合成に利用できます。各値の意味は`Schemas`を参照してください。",
-        "operationId": "sing_frame_audio_query_sing_frame_audio_query_post",
+        "operationId": "sing_frame_audio_query",
         "parameters": [
           {
             "in": "query",
@@ -2549,7 +2549,7 @@
     },
     "/sing_frame_f0": {
       "post": {
-        "operationId": "sing_frame_f0_sing_frame_f0_post",
+        "operationId": "sing_frame_f0",
         "parameters": [
           {
             "in": "query",
@@ -2614,7 +2614,7 @@
     },
     "/sing_frame_volume": {
       "post": {
-        "operationId": "sing_frame_volume_sing_frame_volume_post",
+        "operationId": "sing_frame_volume",
         "parameters": [
           {
             "in": "query",
@@ -2680,7 +2680,7 @@
     "/singer_info": {
       "get": {
         "description": "UUID で指定された歌えるキャラクターの情報を返します。\n画像や音声はresource_formatで指定した形式で返されます。",
-        "operationId": "singer_info_singer_info_get",
+        "operationId": "singer_info",
         "parameters": [
           {
             "in": "query",
@@ -2746,7 +2746,7 @@
     "/singers": {
       "get": {
         "description": "歌えるキャラクターの情報の一覧を返します。",
-        "operationId": "singers_singers_get",
+        "operationId": "singers",
         "parameters": [
           {
             "in": "query",
@@ -2793,7 +2793,7 @@
     "/speaker_info": {
       "get": {
         "description": "UUID で指定された喋れるキャラクターの情報を返します。\n画像や音声はresource_formatで指定した形式で返されます。",
-        "operationId": "speaker_info_speaker_info_get",
+        "operationId": "speaker_info",
         "parameters": [
           {
             "in": "query",
@@ -2859,7 +2859,7 @@
     "/speakers": {
       "get": {
         "description": "喋れるキャラクターの情報の一覧を返します。",
-        "operationId": "speakers_speakers_get",
+        "operationId": "speakers",
         "parameters": [
           {
             "in": "query",
@@ -2906,7 +2906,7 @@
     "/supported_devices": {
       "get": {
         "description": "対応デバイスの一覧を取得します。",
-        "operationId": "supported_devices_supported_devices_get",
+        "operationId": "supported_devices",
         "parameters": [
           {
             "in": "query",
@@ -2948,7 +2948,7 @@
     },
     "/synthesis": {
       "post": {
-        "operationId": "synthesis_synthesis_post",
+        "operationId": "synthesis",
         "parameters": [
           {
             "in": "query",
@@ -3023,7 +3023,7 @@
     "/synthesis_morphing": {
       "post": {
         "description": "指定された2種類のスタイルで音声を合成、指定した割合でモーフィングした音声を得ます。\nモーフィングの割合は`morph_rate`で指定でき、0.0でベースのスタイル、1.0でターゲットのスタイルに近づきます。",
-        "operationId": "_synthesis_morphing_synthesis_morphing_post",
+        "operationId": "_synthesis_morphing",
         "parameters": [
           {
             "in": "query",
@@ -3106,7 +3106,7 @@
     "/uninstall_library/{library_uuid}": {
       "post": {
         "description": "音声ライブラリをアンインストールします。",
-        "operationId": "uninstall_library_uninstall_library__library_uuid__post",
+        "operationId": "uninstall_library",
         "parameters": [
           {
             "description": "音声ライブラリのID",
@@ -3144,7 +3144,7 @@
     "/update_preset": {
       "post": {
         "description": "既存のプリセットを更新します",
-        "operationId": "update_preset_update_preset_post",
+        "operationId": "update_preset",
         "requestBody": {
           "content": {
             "application/json": {
@@ -3188,7 +3188,7 @@
     "/user_dict": {
       "get": {
         "description": "ユーザー辞書に登録されている単語の一覧を返します。\n単語の表層形(surface)は正規化済みの物を返します。",
-        "operationId": "get_user_dict_words_user_dict_get",
+        "operationId": "get_user_dict_words",
         "responses": {
           "200": {
             "content": {
@@ -3214,7 +3214,7 @@
     "/user_dict_word": {
       "post": {
         "description": "ユーザー辞書に言葉を追加します。",
-        "operationId": "add_user_dict_word_user_dict_word_post",
+        "operationId": "add_user_dict_word",
         "parameters": [
           {
             "description": "言葉の表層形",
@@ -3305,7 +3305,7 @@
     "/user_dict_word/{word_uuid}": {
       "delete": {
         "description": "ユーザー辞書に登録されている言葉を削除します。",
-        "operationId": "delete_user_dict_word_user_dict_word__word_uuid__delete",
+        "operationId": "delete_user_dict_word",
         "parameters": [
           {
             "description": "削除する言葉のUUID",
@@ -3341,7 +3341,7 @@
       },
       "put": {
         "description": "ユーザー辞書に登録されている言葉を更新します。",
-        "operationId": "rewrite_user_dict_word_user_dict_word__word_uuid__put",
+        "operationId": "rewrite_user_dict_word",
         "parameters": [
           {
             "description": "更新する言葉のUUID",
@@ -3435,7 +3435,7 @@
     "/validate_kana": {
       "post": {
         "description": "テキストがAquesTalk 風記法に従っているかどうかを判定します。\n従っていない場合はエラーが返ります。",
-        "operationId": "validate_kana_validate_kana_post",
+        "operationId": "validate_kana",
         "parameters": [
           {
             "description": "判定する対象の文字列",
@@ -3491,7 +3491,7 @@
     "/version": {
       "get": {
         "description": "エンジンのバージョンを取得します。",
-        "operationId": "version_version_get",
+        "operationId": "version",
         "responses": {
           "200": {
             "content": {

--- a/tools/make_docs.py
+++ b/tools/make_docs.py
@@ -1,9 +1,6 @@
 import json
 from pathlib import Path
 
-from fastapi import FastAPI
-from fastapi.routing import APIRoute
-
 from voicevox_engine.app.application import generate_app
 from voicevox_engine.core.core_adapter import CoreAdapter
 from voicevox_engine.core.core_initializer import CoreManager
@@ -16,18 +13,6 @@ from voicevox_engine.setting.setting_manager import USER_SETTING_PATH, SettingHa
 from voicevox_engine.tts_pipeline.tts_engine import TTSEngineManager
 from voicevox_engine.user_dict.user_dict_manager import UserDictionary
 from voicevox_engine.utility.path_utility import engine_manifest_path, get_save_dir
-
-
-def use_route_names_as_operation_ids(app: FastAPI) -> None:
-    """
-    Simplify operation IDs so that generated API clients have simpler function
-    names.
-
-    Should be called only after all routes have been added.
-    """
-    for route in app.routes:
-        if isinstance(route, APIRoute):
-            route.operation_id = route.name  # in this case, 'read_items'
 
 
 def generate_api_docs_html(schema: str) -> str:
@@ -78,7 +63,6 @@ if __name__ == "__main__":
         engine_manifest=engine_manifest,
         library_manager=library_manager,
     )
-    use_route_names_as_operation_ids(app)
     api_schema = json.dumps(app.openapi())
 
     # API ドキュメント HTML を生成する

--- a/tools/make_docs.py
+++ b/tools/make_docs.py
@@ -14,6 +14,17 @@ from voicevox_engine.tts_pipeline.tts_engine import TTSEngineManager
 from voicevox_engine.user_dict.user_dict_manager import UserDictionary
 from voicevox_engine.utility.path_utility import engine_manifest_path, get_save_dir
 
+def use_route_names_as_operation_ids(app: FastAPI) -> None:
+    """
+    Simplify operation IDs so that generated API clients have simpler function
+    names.
+
+    Should be called only after all routes have been added.
+    """
+    for route in app.routes:
+        if isinstance(route, APIRoute):
+            route.operation_id = route.name  # in this case, 'read_items'
+
 
 def generate_api_docs_html(schema: str) -> str:
     """OpenAPI schema から API ドキュメント HTML を生成する"""
@@ -63,6 +74,7 @@ if __name__ == "__main__":
         engine_manifest=engine_manifest,
         library_manager=library_manager,
     )
+    use_route_names_as_operation_ids(app)
     api_schema = json.dumps(app.openapi())
 
     # API ドキュメント HTML を生成する

--- a/tools/make_docs.py
+++ b/tools/make_docs.py
@@ -1,6 +1,9 @@
 import json
 from pathlib import Path
 
+from fastapi import FastAPI
+from fastapi.routing import APIRoute
+
 from voicevox_engine.app.application import generate_app
 from voicevox_engine.core.core_adapter import CoreAdapter
 from voicevox_engine.core.core_initializer import CoreManager
@@ -13,6 +16,7 @@ from voicevox_engine.setting.setting_manager import USER_SETTING_PATH, SettingHa
 from voicevox_engine.tts_pipeline.tts_engine import TTSEngineManager
 from voicevox_engine.user_dict.user_dict_manager import UserDictionary
 from voicevox_engine.utility.path_utility import engine_manifest_path, get_save_dir
+
 
 def use_route_names_as_operation_ids(app: FastAPI) -> None:
     """

--- a/voicevox_engine/app/application.py
+++ b/voicevox_engine/app/application.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 
 from fastapi import FastAPI
+from fastapi.routing import APIRoute
 
 from voicevox_engine import __version__
 from voicevox_engine.app.dependencies import generate_mutability_allowed_verifier
@@ -33,6 +34,17 @@ from voicevox_engine.user_dict.user_dict_manager import UserDictionary
 from voicevox_engine.utility.path_utility import engine_root
 from voicevox_engine.utility.runtime_utility import is_development
 
+
+def use_route_names_as_operation_ids(app: FastAPI) -> None:
+    """
+    Simplify operation IDs so that generated API clients have simpler function
+    names.
+
+    Should be called only after all routes have been added.
+    """
+    for route in app.routes:
+        if isinstance(route, APIRoute):
+            route.operation_id = route.name  # in this case, 'read_items'
 
 def generate_app(
     tts_engines: TTSEngineManager,
@@ -105,5 +117,6 @@ def generate_app(
     app = configure_openapi_schema(
         app, engine_manifest.supported_features.manage_library
     )
+    use_route_names_as_operation_ids(app)
 
     return app

--- a/voicevox_engine/app/application.py
+++ b/voicevox_engine/app/application.py
@@ -46,6 +46,7 @@ def use_route_names_as_operation_ids(app: FastAPI) -> None:
         if isinstance(route, APIRoute):
             route.operation_id = route.name  # in this case, 'read_items'
 
+
 def generate_app(
     tts_engines: TTSEngineManager,
     core_manager: CoreManager,

--- a/voicevox_engine/app/application.py
+++ b/voicevox_engine/app/application.py
@@ -3,13 +3,15 @@
 from pathlib import Path
 
 from fastapi import FastAPI
-from fastapi.routing import APIRoute
 
 from voicevox_engine import __version__
 from voicevox_engine.app.dependencies import generate_mutability_allowed_verifier
 from voicevox_engine.app.global_exceptions import configure_global_exception_handlers
 from voicevox_engine.app.middlewares import configure_middlewares
-from voicevox_engine.app.openapi_schema import configure_openapi_schema
+from voicevox_engine.app.openapi_schema import (
+    configure_openapi_schema,
+    simplify_operation_ids,
+)
 from voicevox_engine.app.routers.character import generate_character_router
 from voicevox_engine.app.routers.engine_info import generate_engine_info_router
 from voicevox_engine.app.routers.library import generate_library_router
@@ -33,18 +35,6 @@ from voicevox_engine.tts_pipeline.tts_engine import TTSEngineManager
 from voicevox_engine.user_dict.user_dict_manager import UserDictionary
 from voicevox_engine.utility.path_utility import engine_root
 from voicevox_engine.utility.runtime_utility import is_development
-
-
-def use_route_names_as_operation_ids(app: FastAPI) -> None:
-    """
-    Simplify operation IDs so that generated API clients have simpler function
-    names.
-
-    Should be called only after all routes have been added.
-    """
-    for route in app.routes:
-        if isinstance(route, APIRoute):
-            route.operation_id = route.name  # in this case, 'read_items'
 
 
 def generate_app(
@@ -115,9 +105,9 @@ def generate_app(
     )
     app.include_router(generate_portal_page_router(engine_manifest.name))
 
+    app = simplify_operation_ids(app)
     app = configure_openapi_schema(
         app, engine_manifest.supported_features.manage_library
     )
-    use_route_names_as_operation_ids(app)
 
     return app

--- a/voicevox_engine/app/openapi_schema.py
+++ b/voicevox_engine/app/openapi_schema.py
@@ -4,9 +4,19 @@ from typing import Any
 
 from fastapi import FastAPI
 from fastapi.openapi.utils import get_openapi
+from fastapi.routing import APIRoute
 from pydantic import BaseModel
 
 from voicevox_engine.library.model import BaseLibraryInfo, VvlibManifest
+
+
+def simplify_operation_ids(app: FastAPI) -> FastAPI:
+    """operation ID を簡略化してAPIクライアントで生成される関数名をシンプルにする。"""
+    for route in app.routes:
+        if isinstance(route, APIRoute):
+            route.operation_id = route.name
+
+    return app
 
 
 def configure_openapi_schema(app: FastAPI, manage_library: bool | None) -> FastAPI:


### PR DESCRIPTION
## 内容
- OpenAPIで生成される関数を元の関数名ベースになるように、公式ドキュメントから、関数を移植し、使うように

## 関連 Issue
close #1521 

