### PR TITLE
chore(build): `pip-licenses`にパスが通っていなくても`generate_licenses.py`が実行できるようにする。

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -246,10 +246,6 @@ RUN <<EOF
 
     cd /opt/voicevox_engine
 
-    # Define temporary env vars
-    # /home/user/.local/bin is required to use the commands installed by pip
-    export PATH="/home/user/.local/bin:${PATH:-}"
-
     gosu user /opt/python/bin/pip3 install -r /tmp/requirements.txt
     # requirements-dev.txt でバージョン指定されている pip-licenses をインストールする
     gosu user /opt/python/bin/pip3 install "$(grep pip-licenses /tmp/requirements-dev.txt | cut -f 1 -d ';')"


### PR DESCRIPTION
## 内容

`generate_licenses.py`はpip-licensesにパスが通っていないと実行できません。
`sysconfig.get_path("scripts")`と`shutil.which()`で実行ファイルの場所を取得するすることで修正します。

## 関連 Issue

https://github.com/VOICEVOX/voicevox_engine/pull/1539#pullrequestreview-2652376472

## その他

もう一つ気が付いたのですがカレントディレクトリがプロジェクトになっていることが前提になっていますね…

他に`pip install`されたバイナリを実行しているPythonのコードはありませんね。
シェルスクリプトにはありますがこれはどうしようもない気がする…