### PR TITLE
build: Windowsの`engine_manifest.json`に`.exe`を追加する

### DIFF
--- a/.github/workflows/build-engine-package.yml
+++ b/.github/workflows/build-engine-package.yml
@@ -459,7 +459,10 @@ jobs:
         run: |
           set -eux
 
-          jq '.version = "${{ needs.config.outputs.version_or_latest }}"' engine_manifest.json > engine_manifest.json.tmp
+          jq '.version = "${{ needs.config.outputs.version_or_latest }}"
+          | if ${{ startsWith(matrix.os, 'windows-') }} then .command += ".exe" else . end' \
+          engine_manifest.json > engine_manifest.json.tmp
+
           mv -f engine_manifest.json.tmp engine_manifest.json
 
           # Replace version & specify dynamic libraries

--- a/.github/workflows/build-engine-package.yml
+++ b/.github/workflows/build-engine-package.yml
@@ -459,9 +459,10 @@ jobs:
         run: |
           set -eux
 
-          jq '.version = "${{ needs.config.outputs.version_or_latest }}"
-          | if ${{ startsWith(matrix.os, 'windows-') }} then .command += ".exe" else . end' \
-          engine_manifest.json > engine_manifest.json.tmp
+          jq '
+            .version = "${{ needs.config.outputs.version_or_latest }}" |
+            if ${{ startsWith(matrix.os, 'windows-') }} then .command += ".exe" else . end
+          ' engine_manifest.json > engine_manifest.json.tmp
 
           mv -f engine_manifest.json.tmp engine_manifest.json
 

--- a/tools/check_release_build.py
+++ b/tools/check_release_build.py
@@ -4,6 +4,7 @@
 
 import argparse
 import json
+import shlex
 import time
 from io import BytesIO
 from pathlib import Path
@@ -29,6 +30,8 @@ def test_release_build(
         assert manifest_file.is_file()
         manifest = json.loads(manifest_file.read_text(encoding="utf-8"))
         assert "manifest_version" in manifest
+        command = shlex.split(manifest["command"])[0]
+        assert (dist_dir / command).exists()
 
     # 起動
     process = None

--- a/tools/check_release_build.py
+++ b/tools/check_release_build.py
@@ -30,8 +30,8 @@ def test_release_build(
         assert manifest_file.is_file()
         manifest = json.loads(manifest_file.read_text(encoding="utf-8"))
         assert "manifest_version" in manifest
-        command = shlex.split(manifest["command"])[0]
-        assert (dist_dir / command).exists()
+        command_filename = shlex.split(manifest["command"])[0]
+        assert (dist_dir / command_filename).exists()
 
     # 起動
     process = None


### PR DESCRIPTION
## 内容

`engine_manifest.json`の`command`には現在全てのOSで`"run"`が指定されています。
Windowsの実行ファイルは`run.exe`なのでそれに合わせるべきです。

現在のところ問題は発生していませんがトラブルの原因になりかねないので修正します。

また、`check_release_build.py`に`manifest["command"]`で指定している実行ファイルが存在するかチェックするようにしました。

## 関連 Issue

- fix: #1470

## その他

#1470 が非アクティブになったのでやりました。