### PR TITLE
test: /multi_synthesis のスナップショットテストを追加

### DIFF
--- a/test/e2e/single_api/tts_pipeline/__snapshots__/test_multi_synthesis.ambr
+++ b/test/e2e/single_api/tts_pipeline/__snapshots__/test_multi_synthesis.ambr
@@ -1,0 +1,7 @@
+# serializer version: 1
+# name: test_post_multi_synthesis_200
+  'MD5:f7d42ce5787856549abc3d2d7561c06f'
+# ---
+# name: test_post_multi_synthesis_200.1
+  'MD5:f7931b06272316e78e375025dbfd03e3'
+# ---

--- a/test/e2e/single_api/tts_pipeline/test_multi_synthesis.py
+++ b/test/e2e/single_api/tts_pipeline/test_multi_synthesis.py
@@ -70,6 +70,7 @@ def test_post_multi_synthesis_200(
     response = client.post("/multi_synthesis", params={"speaker": 0}, json=queries)
     assert response.status_code == 200
     assert response.headers["content-type"] == "application/zip"
+
     # zipに含まれる全てのwavの波形がスナップショットと一致することを確認
     zip_bytes = io.BytesIO(response.read())
     with zipfile.ZipFile(zip_bytes, "r") as zip_file:

--- a/test/e2e/single_api/tts_pipeline/test_multi_synthesis.py
+++ b/test/e2e/single_api/tts_pipeline/test_multi_synthesis.py
@@ -71,7 +71,7 @@ def test_post_multi_synthesis_200(
     assert response.status_code == 200
     assert response.headers["content-type"] == "application/zip"
 
-    # zipに含まれる全てのwavの波形がスナップショットと一致することを確認
+    # zip 内の全ての wav の波形がスナップショットと一致する
     zip_bytes = io.BytesIO(response.read())
     with zipfile.ZipFile(zip_bytes, "r") as zip_file:
         wav_files = (zip_file.read(name) for name in zip_file.namelist())

--- a/test/e2e/single_api/tts_pipeline/test_multi_synthesis.py
+++ b/test/e2e/single_api/tts_pipeline/test_multi_synthesis.py
@@ -2,12 +2,18 @@
 /multi_synthesis API のテスト
 """
 
+import io
+import zipfile
 from test.e2e.single_api.utils import gen_mora
+from test.utility import hash_wave_floats_from_wav_bytes
 
 from fastapi.testclient import TestClient
+from syrupy.assertion import SnapshotAssertion
 
 
-def test_post_multi_synthesis_200(client: TestClient) -> None:
+def test_post_multi_synthesis_200(
+    client: TestClient, snapshot: SnapshotAssertion
+) -> None:
     queries = [
         {
             "accent_phrases": [
@@ -63,14 +69,10 @@ def test_post_multi_synthesis_200(client: TestClient) -> None:
     ]
     response = client.post("/multi_synthesis", params={"speaker": 0}, json=queries)
     assert response.status_code == 200
-
-    # FileResponse 内の zip ファイルに圧縮された .wav から抽出された音声波形が一致する
-    # FIXME: スナップショットテストを足す
-    # NOTE: ZIP ファイル内の .wav に Linux-Windows 数値精度問題があるため解凍が必要
     assert response.headers["content-type"] == "application/zip"
-    # from test.utility import summarize_wav_bytes
-    # from syrupy.assertion import SnapshotAssertion
-    # # zip 解凍
-    # wav_summarys = map(lambda wav_byte: summarize_wav_bytes(wav_byte), wav_bytes)
-    # wavs_summary = concatenate_func(wav_summarys)
-    # assert snapshot == wavs_summary
+    # zipに含まれる全てのwavの波形がスナップショットと一致することを確認
+    zip_bytes = io.BytesIO(response.read())
+    with zipfile.ZipFile(zip_bytes, "r") as zip_file:
+        wav_files = (zip_file.read(name) for name in zip_file.namelist())
+        for wav in wav_files:
+            assert snapshot == hash_wave_floats_from_wav_bytes(wav)


### PR DESCRIPTION
## 内容
表題の通り、/multi_synthesisのスナップショットテストを追加しました。
OS間の数値精度問題に関しては`hash_wave_floats_from_wav_bytes`で解消されている認識で、
zipを解凍した後は/synthesisが行っているスナップショットテストと等しいはずです。

## 関連 Issue
ref #1065
<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
本当は/synthesis_morphing のほうもやろうとしたのですが、こちらはおそらくOS間の数値精度問題の影響か
CIでWindows, Macのテストがコケてしまったので一旦そちらは後回しにします。