### PR TITLE
refactor: 重複を無くすため、ONNXRUNTIME_VERSIONをenvにする

### DIFF
--- a/.github/workflows/build-engine-container.yml
+++ b/.github/workflows/build-engine-container.yml
@@ -16,6 +16,7 @@ env:
   IMAGE_NAME: ${{ vars.DOCKERHUB_USERNAME }}/voicevox_engine
   VOICEVOX_RESOURCE_VERSION: "0.23.0"
   VOICEVOX_CORE_VERSION: "0.15.7"
+  ONNXRUNTIME_VERSION: "1.13.1"
 
 defaults:
   run:
@@ -45,7 +46,6 @@ jobs:
         # target: Dockerfileのビルドステージ名
         # base_image: Dockerfileのビルド用ステージのベースイメージ
         # base_runtime_image: Dockerfileの実行用ステージのベースイメージ
-        # onnxruntime_version: ONNX Runtimeのバージョン
         # platforms: Dockerのプラットフォームバリアント。カンマ区切り。 参考: https://docs.docker.com/build/building/multi-platform/
         include:
           # Ubuntu 20.04
@@ -54,7 +54,6 @@ jobs:
             target: runtime-env
             base_image: ubuntu:20.04
             base_runtime_image: ubuntu:20.04
-            onnxruntime_version: 1.13.1
             # platforms: linux/amd64,linux/arm64/v8
             platforms: linux/amd64
           - prefixes: "nvidia-ubuntu20.04"
@@ -62,7 +61,6 @@ jobs:
             target: runtime-nvidia-env
             base_image: ubuntu:20.04
             base_runtime_image: nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu20.04
-            onnxruntime_version: 1.13.1
             platforms: linux/amd64
           # Ubuntu 22.04
           - prefixes: ",cpu,cpu-ubuntu22.04"
@@ -70,7 +68,6 @@ jobs:
             target: runtime-env
             base_image: ubuntu:22.04
             base_runtime_image: ubuntu:22.04
-            onnxruntime_version: 1.13.1
             # platforms: linux/amd64,linux/arm64/v8
             platforms: linux/amd64
           - prefixes: "nvidia,nvidia-ubuntu22.04"
@@ -78,7 +75,6 @@ jobs:
             target: runtime-nvidia-env
             base_image: ubuntu:22.04
             base_runtime_image: nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu22.04
-            onnxruntime_version: 1.13.1
             platforms: linux/amd64
 
     steps:
@@ -173,7 +169,7 @@ jobs:
             VOICEVOX_CORE_VERSION=${{ env.VOICEVOX_CORE_VERSION }}
             VOICEVOX_RESOURCE_VERSION=${{ env.VOICEVOX_RESOURCE_VERSION }}
             USE_GPU=${{ matrix.target == 'runtime-nvidia-env' }}
-            ONNXRUNTIME_VERSION=${{ matrix.onnxruntime_version }}
+            ONNXRUNTIME_VERSION=${{ env.ONNXRUNTIME_VERSION }}
           target: ${{ matrix.target }}
           push: true
           tags: ${{ steps.generate-docker-image-names.outputs.tags }}


### PR DESCRIPTION
## 内容
`build-engine-container.yml`で、matrix.includeの中で`onnxruntime_version: 1.13.1`という値が繰り返し現れます。
特に環境ごとにonnxruntime_versionを変える必要が無いならenvにして1か所で管理するほうが良いのではないかと思い
PRを作成しました。

### Pros
- 保守性の向上
  - onnxruntimeのバージョン変更が１か所で済む
  - 新しいmatrix.includeを追加した際にonnxruntime_versionを指定しなくてよくなる
- コード量の削減

### Cons
- 一部の環境でonnxruntime_versionを変えたい場合があるとき、少し不便？
  - その場合、`ONNXRUNTIME_VERSION=${{ matrix.onnxruntime_version || env.ONNXRUNTIME_VERSION }}`と書けば、includeで定義されてたらそれを優先的に使うみたいな対応で解決できそう
  - `build-engine-container.yml`のログを見た限り、一部だけ異なるバージョンを使っていたことは無さそうだった

<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
このような形になっている経緯をログをさかのぼって調べてみたところ、
#639 でonnxruntime_urlがonnxruntime_versionに置き換わっていました。

onnxruntime_urlは環境ごとに異なるURLからonnxruntimeをダウンロードする必要があり、
そのため各環境でincludeによって指定していたものと思われます。

ただ #639 の変更によって、Dockerfile内で環境ごとに適したonnxruntime_urlを生成するようになっており、
現在はバージョンのみを指定する形になっています。
そしてそれは各環境で同じ値を使っているため、includeでそれぞれ指定するより
envを使って一か所で指定したほうが保守性が高くなりそうだと考えました。