### PR TITLE
refactor: [project-e2k] e2kを使用しない場合でも`njd_features`を経由するように変更

### DIFF
--- a/test/unit/tts_pipeline/test_katakana_english.py
+++ b/test/unit/tts_pipeline/test_katakana_english.py
@@ -1,62 +1,95 @@
-from voicevox_engine.tts_pipeline.katakana_english import extract_fullcontext_with_e2k
-from voicevox_engine.tts_pipeline.text_analyzer import Label
+from voicevox_engine.tts_pipeline.katakana_english import (
+    convert_english_in_njd_features_to_katakana,
+)
 
 
 def test_extract_fullcontext_with_e2k_normal() -> None:
     """`extract_fullcontext_with_e2k`は英単語をアルファベットそのままで読まない"""
-    phonemes = [
-        Label.from_feature(feature).phoneme
-        for feature in extract_fullcontext_with_e2k("Voivo")
+    features = [
+        {
+            "string": "Ｖｏｉｖｏ",
+            "pos": "フィラー",
+            "pos_group1": "*",
+            "pos_group2": "*",
+            "pos_group3": "*",
+            "ctype": "*",
+            "cform": "*",
+            "orig": "Ｖｏｉｖｏ",
+            "read": "ブイオーアイブイオー",
+            "pron": "ブイオーアイブイオー",
+            "acc": 0,
+            "mora_size": 10,
+            "chain_rule": "*",
+            "chain_flag": -1,
+        }
+    ]
+    prons = [
+        feature["pron"]
+        for feature in convert_english_in_njd_features_to_katakana(features)
     ]
 
-    expected_phonemes = [
-        "sil",
-        "b",
-        "o",
-        "i",
-        "b",
-        "o",
-        "sil",
-    ]
+    expected_prons = ["ボイボ"]
 
     # FIXME: e2kの結果が決定論的でない場合、テストが落ちる可能性がある
-    assert expected_phonemes == phonemes
+    assert expected_prons == prons
 
 
 def test_extract_fullcontext_with_e2k_uppercase() -> None:
     """`extract_fullcontext_with_e2k`は大文字のみの英単語をアルファベットそのままで読む"""
-    phonemes = [
-        Label.from_feature(feature).phoneme
-        for feature in extract_fullcontext_with_e2k("VOIVO")
+    features = [
+        {
+            "string": "ＶＯＩＶＯ",
+            "pos": "フィラー",
+            "pos_group1": "*",
+            "pos_group2": "*",
+            "pos_group3": "*",
+            "ctype": "*",
+            "cform": "*",
+            "orig": "ＶＯＩＶＯ",
+            "read": "ブイオーアイブイオー",
+            "pron": "ブイオーアイブイオー",
+            "acc": 0,
+            "mora_size": 10,
+            "chain_rule": "*",
+            "chain_flag": -1,
+        }
+    ]
+    prons = [
+        feature["pron"]
+        for feature in convert_english_in_njd_features_to_katakana(features)
     ]
 
-    expected_phonemes = [
-        "sil",
-        "b",
-        "u",
-        "i",
-        "o",
-        "o",
-        "a",
-        "i",
-        "b",
-        "u",
-        "i",
-        "o",
-        "o",
-        "sil",
-    ]
+    expected_prons = ["ブイオーアイブイオー"]
 
-    assert expected_phonemes == phonemes
+    assert expected_prons == prons
 
 
 def test_extract_fullcontext_with_e2k_short() -> None:
     """`extract_fullcontext_with_e2k`は2文字以下の英単語をアルファベットそのままで読む"""
-    phonemes = [
-        Label.from_feature(feature).phoneme
-        for feature in extract_fullcontext_with_e2k("Vo")
+    # NOTE: 実際の pyopenjtalk.run_frontend の出力とは異なる
+    features = [
+        {
+            "string": "Ｖｏ",
+            "pos": "フィラー",
+            "pos_group1": "*",
+            "pos_group2": "*",
+            "pos_group3": "*",
+            "ctype": "*",
+            "cform": "*",
+            "orig": "Ｖｏ",
+            "read": "ブイオー",
+            "pron": "ブイオー",
+            "acc": 0,
+            "mora_size": 4,
+            "chain_rule": "*",
+            "chain_flag": -1,
+        }
+    ]
+    prons = [
+        feature["pron"]
+        for feature in convert_english_in_njd_features_to_katakana(features)
     ]
 
-    expected_phonemes = ["sil", "b", "u", "i", "o", "o", "sil"]
+    expected_prons = ["ブイオー"]
 
-    assert expected_phonemes == phonemes
+    assert expected_prons == prons

--- a/test/unit/tts_pipeline/test_katakana_english.py
+++ b/test/unit/tts_pipeline/test_katakana_english.py
@@ -3,8 +3,8 @@ from voicevox_engine.tts_pipeline.katakana_english import (
 )
 
 
-def test_extract_fullcontext_with_e2k_normal() -> None:
-    """`extract_fullcontext_with_e2k`は英単語をアルファベットそのままで読まない"""
+def test_convert_english_in_njd_features_to_katakana_normal() -> None:
+    """`convert_english_in_njd_features_to_katakana`は英単語をアルファベットそのままで読まない"""
     features = [
         {
             "string": "Ｖｏｉｖｏ",
@@ -34,8 +34,8 @@ def test_extract_fullcontext_with_e2k_normal() -> None:
     assert expected_prons == prons
 
 
-def test_extract_fullcontext_with_e2k_uppercase() -> None:
-    """`extract_fullcontext_with_e2k`は大文字のみの英単語をアルファベットそのままで読む"""
+def test_convert_english_in_njd_features_to_katakana_uppercase() -> None:
+    """`convert_english_in_njd_features_to_katakana`は大文字のみの英単語をアルファベットそのままで読む"""
     features = [
         {
             "string": "ＶＯＩＶＯ",
@@ -64,8 +64,8 @@ def test_extract_fullcontext_with_e2k_uppercase() -> None:
     assert expected_prons == prons
 
 
-def test_extract_fullcontext_with_e2k_short() -> None:
-    """`extract_fullcontext_with_e2k`は2文字以下の英単語をアルファベットそのままで読む"""
+def test_convert_english_in_njd_features_to_katakana_short() -> None:
+    """`convert_english_in_njd_features_to_katakana`は2文字以下の英単語をアルファベットそのままで読む"""
     # NOTE: 実際の pyopenjtalk.run_frontend の出力とは異なる
     features = [
         {

--- a/test/unit/tts_pipeline/test_text_analyzer.py
+++ b/test/unit/tts_pipeline/test_text_analyzer.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from voicevox_engine.tts_pipeline.model import AccentPhrase, Mora
 from voicevox_engine.tts_pipeline.text_analyzer import (
     AccentPhraseLabel,
@@ -355,7 +357,7 @@ def test_text_to_accent_phrases_normal() -> None:
     assert accent_phrases == true_accent_phrases
 
 
-def stub_unknown_features_koxx(_: str) -> list[str]:
+def stub_unknown_features_koxx(_: dict[str, Any]) -> list[str]:
     """`sil-k-o-xx-sil` に相当する features を常に返す `text_to_features()` のStub"""
     return [
         ".^.-sil+.=./A:.+xx+./B:.-._./C:._.+./D:.+._./E:._.!._.-./F:xx_xx#xx_.@xx_.|._./G:._.%._._./H:._./I:.-.@xx+.&.-.|.+./J:._./K:.+.-.",
@@ -381,7 +383,7 @@ def test_text_to_accent_phrases_unknown() -> None:
     ]
     # Outputs
     accent_phrases = text_to_accent_phrases(
-        "dummy", text_to_features=stub_unknown_features_koxx
+        "dummy", njd_features_to_full_context_label=stub_unknown_features_koxx
     )
     # Tests
     assert accent_phrases == true_accent_phrases

--- a/test/unit/tts_pipeline/test_text_analyzer.py
+++ b/test/unit/tts_pipeline/test_text_analyzer.py
@@ -383,7 +383,7 @@ def test_text_to_accent_phrases_unknown() -> None:
     ]
     # Outputs
     accent_phrases = text_to_accent_phrases(
-        "dummy", njd_features_to_full_context_label=stub_unknown_features_koxx
+        "dummy", njd_features_to_full_context_labels=stub_unknown_features_koxx
     )
     # Tests
     assert accent_phrases == true_accent_phrases

--- a/test/unit/tts_pipeline/test_tts_engine.py
+++ b/test/unit/tts_pipeline/test_tts_engine.py
@@ -206,7 +206,7 @@ def test_create_accent_phrases_toward_unknown() -> None:
 
     # NOTE: TTSEngine.create_accent_phrases() のコールで unknown feature を得ることが難しいため、疑似再現
     accent_phrases = text_to_accent_phrases(
-        "dummy", njd_features_to_full_context_label=stub_unknown_features_koxx
+        "dummy", njd_features_to_full_context_labels=stub_unknown_features_koxx
     )
     with pytest.raises(ValueError) as e:
         accent_phrases = engine.update_length_and_pitch(accent_phrases, StyleId(0))

--- a/test/unit/tts_pipeline/test_tts_engine.py
+++ b/test/unit/tts_pipeline/test_tts_engine.py
@@ -206,7 +206,7 @@ def test_create_accent_phrases_toward_unknown() -> None:
 
     # NOTE: TTSEngine.create_accent_phrases() のコールで unknown feature を得ることが難しいため、疑似再現
     accent_phrases = text_to_accent_phrases(
-        "dummy", text_to_features=stub_unknown_features_koxx
+        "dummy", njd_features_to_full_context_label=stub_unknown_features_koxx
     )
     with pytest.raises(ValueError) as e:
         accent_phrases = engine.update_length_and_pitch(accent_phrases, StyleId(0))

--- a/voicevox_engine/tts_pipeline/katakana_english.py
+++ b/voicevox_engine/tts_pipeline/katakana_english.py
@@ -4,7 +4,6 @@ import re
 from typing import Any
 
 import e2k
-import pyopenjtalk
 
 
 def _convert_zenkaku_alphabet_to_hankaku(surface: str) -> str:
@@ -78,9 +77,10 @@ def _create_njd_feature(orig: str, kana: str, mora_size: int) -> dict[str, Any]:
     }
 
 
-def extract_fullcontext_with_e2k(text: str) -> list[str]:
-    """e2kを用いて読みが不明な英単語をカタカナに変換し、フルコンテキストラベルを生成する"""
-    njd_features: list[dict[str, Any]] = pyopenjtalk.run_frontend(text)
+def convert_english_in_njd_features_to_katakana(
+    njd_features: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """e2kを用いて、NJD Features内の読みが不明な英単語をカタカナに変換する"""
     for i, feature in enumerate(njd_features):
         # Mecabの解析で未知語となった場合、読みは空となる
         # NJDは、読みが空の場合、読みを補完して品詞をフィラーとして扱う
@@ -125,4 +125,4 @@ def extract_fullcontext_with_e2k(text: str) -> list[str]:
             orig=feature["string"], kana=kana, mora_size=mora_size
         )
 
-    return pyopenjtalk.make_label(njd_features)  # type: ignore
+    return njd_features

--- a/voicevox_engine/tts_pipeline/text_analyzer.py
+++ b/voicevox_engine/tts_pipeline/text_analyzer.py
@@ -359,6 +359,7 @@ def _utterance_to_accent_phrases(utterance: UtteranceLabel) -> list[AccentPhrase
     ]
 
 
+# TODO: クラス化するとかしてリファクタリングする
 def text_to_accent_phrases(
     text: str,
     enable_e2k: bool = False,

--- a/voicevox_engine/tts_pipeline/text_analyzer.py
+++ b/voicevox_engine/tts_pipeline/text_analyzer.py
@@ -362,7 +362,7 @@ def _utterance_to_accent_phrases(utterance: UtteranceLabel) -> list[AccentPhrase
 def text_to_accent_phrases(
     text: str,
     enable_e2k: bool = False,
-    njd_features_to_full_context_label: Callable[
+    njd_features_to_full_context_labels: Callable[
         [dict[str, Any]], list[str]
     ] = pyopenjtalk.make_label,  # type: ignore
 ) -> list[AccentPhrase]:
@@ -374,9 +374,9 @@ def text_to_accent_phrases(
     njd_features = pyopenjtalk.run_frontend(text)
     if enable_e2k:
         njd_features = convert_english_in_njd_features_to_katakana(njd_features)
-    full_context_label = njd_features_to_full_context_label(njd_features)
+    full_context_labels = njd_features_to_full_context_labels(njd_features)
     utterance = UtteranceLabel.from_labels(
-        list(map(Label.from_feature, full_context_label))
+        list(map(Label.from_feature, full_context_labels))
     )
 
     # ドメインを変換する

--- a/voicevox_engine/tts_pipeline/text_analyzer.py
+++ b/voicevox_engine/tts_pipeline/text_analyzer.py
@@ -3,10 +3,11 @@
 import re
 from dataclasses import dataclass
 from itertools import chain
-from typing import Callable, Literal, Self
+from typing import Any, Callable, Literal, Self
 
 import pyopenjtalk
 
+from .katakana_english import convert_english_in_njd_features_to_katakana
 from .model import AccentPhrase, Mora
 from .mora_mapping import mora_phonemes_to_mora_kana
 
@@ -360,17 +361,23 @@ def _utterance_to_accent_phrases(utterance: UtteranceLabel) -> list[AccentPhrase
 
 def text_to_accent_phrases(
     text: str,
-    text_to_features: Callable[
-        [str], list[str]
-    ] = pyopenjtalk.extract_fullcontext,  # TODO: 初期値をなくす？
+    enable_e2k: bool = False,
+    njd_features_to_full_context_label: Callable[
+        [dict[str, Any]], list[str]
+    ] = pyopenjtalk.make_label,  # type: ignore
 ) -> list[AccentPhrase]:
     """日本語文からアクセント句系列を生成する"""
     if len(text.strip()) == 0:
         return []
 
     # 日本語文からUtteranceLabelを抽出する
-    features = text_to_features(text)
-    utterance = UtteranceLabel.from_labels(list(map(Label.from_feature, features)))
+    njd_features = pyopenjtalk.run_frontend(text)
+    if enable_e2k:
+        njd_features = convert_english_in_njd_features_to_katakana(njd_features)
+    full_context_label = njd_features_to_full_context_label(njd_features)
+    utterance = UtteranceLabel.from_labels(
+        list(map(Label.from_feature, full_context_label))
+    )
 
     # ドメインを変換する
     accent_phrases = _utterance_to_accent_phrases(utterance)

--- a/voicevox_engine/tts_pipeline/tts_engine.py
+++ b/voicevox_engine/tts_pipeline/tts_engine.py
@@ -7,7 +7,6 @@ from typing import Final, Literal, TypeAlias
 import numpy as np
 from fastapi import HTTPException
 from numpy.typing import NDArray
-from pyopenjtalk import extract_fullcontext
 from soxr import resample
 
 from voicevox_engine.utility.core_version_utility import get_latest_version
@@ -18,7 +17,6 @@ from ..core.core_wrapper import CoreWrapper
 from ..metas.Metas import StyleId
 from ..model import AudioQuery
 from .kana_converter import parse_kana
-from .katakana_english import extract_fullcontext_with_e2k
 from .model import (
     AccentPhrase,
     FrameAudioQuery,
@@ -568,10 +566,7 @@ class TTSEngine:
         enable_e2k: bool = False,  # TODO: 初期値をなくす？
     ) -> list[AccentPhrase]:
         """テキストからアクセント句系列を生成し、スタイルIDに基づいてその音素長・モーラ音高を更新する"""
-        if enable_e2k:
-            accent_phrases = text_to_accent_phrases(text, extract_fullcontext_with_e2k)
-        else:
-            accent_phrases = text_to_accent_phrases(text, extract_fullcontext)
+        accent_phrases = text_to_accent_phrases(text, enable_e2k=enable_e2k)
         accent_phrases = self.update_length_and_pitch(accent_phrases, style_id)
         return accent_phrases
 


### PR DESCRIPTION
## 内容

今までは[`text_to_accent_phrases`](https://github.com/VOICEVOX/voicevox_engine/blob/4fe83ab4553bba51f1d32a7db0de2d2e6bf2ce54/voicevox_engine/tts_pipeline/text_analyzer.py#L361)の引数に、テキストを入力としフルコンテキストラベルを出力する関数を指定していました。
#### e2kを使用する場合
一度テキストから`njd_features`を作成し、e2kで後処理して`njd_features`からフルコンテキストラベルを作成する関数、[`extract_fullcontext_with_e2k`](https://github.com/VOICEVOX/voicevox_engine/blob/4fe83ab4553bba51f1d32a7db0de2d2e6bf2ce54/voicevox_engine/tts_pipeline/katakana_english.py#L81)を指定
#### e2kを使用しない場合
テキストから直接フルコンテキストラベルを作成する関数、`pyopenjtalk.extract_fullcontext`を指定

----

`text_to_accent_phrases`の引数にこのような関数を指定するのをやめ、代わりにe2kを使用するかしないかのフラグを指定するように変更します。
`text_to_accent_phrases`関数内部では、フラグの状態に関わらず、`njd_features`を作成するようにします。
ただし、テスト用に、`njd_features`からフルコンテキストラベルを作成する関数を指定できるようにします。

このリファクタリングにより、記号に由来するpauを取り除くオプションを実装できるようにします。

## 関連 Issue

ref #1524 
ref https://github.com/VOICEVOX/voicevox_engine/pull/1548#issuecomment-2735322097

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
