### PR TITLE
fix: ソングではモーフィングできない判定を追加する

### DIFF
--- a/test/e2e/single_api/morphing/__snapshots__/test_morphable_targets/test_post_morphable_targets_200.json
+++ b/test/e2e/single_api/morphing/__snapshots__/test_morphable_targets/test_post_morphable_targets_200.json
@@ -13,13 +13,13 @@
       "is_morphable": false
     },
     "4": {
-      "is_morphable": true
+      "is_morphable": false
     },
     "5": {
       "is_morphable": false
     },
     "6": {
-      "is_morphable": true
+      "is_morphable": false
     },
     "7": {
       "is_morphable": false
@@ -28,7 +28,7 @@
       "is_morphable": false
     },
     "9": {
-      "is_morphable": true
+      "is_morphable": false
     }
   }
 ]

--- a/voicevox_engine/morphing/morphing.py
+++ b/voicevox_engine/morphing/morphing.py
@@ -78,21 +78,16 @@ def is_morphable(
     except KeyError:
         raise StyleIdNotFoundError(style_id_2)
 
-    uuid_1 = character_1.uuid
-    uuid_2 = character_2.uuid
     morphable_1 = character_1.supported_features.permitted_synthesis_morphing
     morphable_2 = character_2.supported_features.permitted_synthesis_morphing
 
     # 禁止されている場合はFalse
-    if morphable_1 == "NOTHING":
+    if morphable_1 == "NOTHING" or morphable_2 == "NOTHING":
         return False
-    elif morphable_2 == "NOTHING":
-        return False
+
     # 同一キャラクターのみの場合は同一キャラクター判定
-    elif morphable_1 == "SELF_ONLY":
-        return uuid_1 == uuid_2
-    elif morphable_2 == "SELF_ONLY":
-        return uuid_1 == uuid_2
+    if morphable_1 == "SELF_ONLY" or morphable_2 == "SELF_ONLY":
+        return character_1.uuid == character_2.uuid
 
     # 念のため許可されているかチェック
     return morphable_1 == "ALL" and morphable_2 == "ALL"

--- a/voicevox_engine/morphing/morphing.py
+++ b/voicevox_engine/morphing/morphing.py
@@ -78,6 +78,13 @@ def is_morphable(
     except KeyError:
         raise StyleIdNotFoundError(style_id_2)
 
+    sing_style_ids_1 = [sing_style.id for sing_style in character_1.sing_styles]
+    sing_style_ids_2 = [sing_style.id for sing_style in character_2.sing_styles]
+
+    # モーフィング機能はソングに対応していない
+    if style_id_1 in sing_style_ids_1 or style_id_2 in sing_style_ids_2:
+        return False
+
     morphable_1 = character_1.supported_features.permitted_synthesis_morphing
     morphable_2 = character_2.supported_features.permitted_synthesis_morphing
 


### PR DESCRIPTION
## 内容
#1327 の対応です。
スタイルIDのどちらかがsing_styleである場合にis_morphableがFalseを返すようにしました。
この変更により、スナップショットの更新も行われています。
falseとなった4,6,9はそれぞれframe_decode, singであるとモックで定義されているようなのでこれは正しい更新になっていると思います。
https://github.com/VOICEVOX/voicevox_engine/blob/e1b5fde07194b79c965d076ddf881b94e49b1838/voicevox_engine/dev/core/mock.py#L27-L68

ついでにif分岐を簡略化できそうだったのでそこも少し修正しました。

<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue
close #1327
<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
