### PR TITLE
build: Github Actionsのubuntu-20.04を22.04にアップデートする

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - "master"
+  workflow_dispatch:
 
 env:
   PUBLISH_DIR: "./docs/api"

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - "master"
-  workflow_dispatch:
 
 env:
   PUBLISH_DIR: "./docs/api"

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -15,10 +15,10 @@ env:
 defaults:
   run:
     shell: bash
-  
+
 jobs:
   upload-doc:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: <Setup> Check out the repository
         uses: actions/checkout@v4

--- a/.github/workflows/build-engine-package.yml
+++ b/.github/workflows/build-engine-package.yml
@@ -88,7 +88,7 @@ jobs:
             onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.13.1/onnxruntime-osx-arm64-1.13.1.tgz
             target: macos-arm64
           # Linux CPU (x64 arch)
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             architecture: "x64"
             voicevox_core_asset_prefix: voicevox_core-linux-x64-cpu
             onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.13.1/onnxruntime-linux-x64-1.13.1.tgz
@@ -100,7 +100,7 @@ jobs:
             onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.13.1/onnxruntime-linux-aarch64-1.13.1.tgz
             target: linux-cpu-arm64
           # Linux NVIDIA GPU
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             architecture: "x64"
             voicevox_core_asset_prefix: voicevox_core-linux-x64-gpu
             onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.13.1/onnxruntime-linux-x64-gpu-1.13.1.tgz

--- a/.github/workflows/test-engine-container.yml
+++ b/.github/workflows/test-engine-container.yml
@@ -27,7 +27,7 @@ defaults:
 
 jobs:
   test:
-    runs-on: [ ubuntu-20.04 ]
+    runs-on: [ubuntu-22.04]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-engine-package.yml
+++ b/.github/workflows/test-engine-package.yml
@@ -37,11 +37,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             target: linux-cpu-x64
           - os: ubuntu-22.04-arm
             target: linux-cpu-arm64
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             target: linux-nvidia
           - os: macos-13
             target: macos-x64

--- a/.github/workflows/test-security.yml
+++ b/.github/workflows/test-security.yml
@@ -12,7 +12,7 @@ defaults:
 
 jobs:
   test-security:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: <Setup> Check out the repository
         uses: actions/checkout@v4
@@ -35,6 +35,5 @@ jobs:
           username: GitHub Actions
           title: "依存パッケージ脆弱性診断の結果"
           status: ${{ job.status }}
-          color: ${{ job.status == 'success' && '0x00FF00' || '0xFF0000' }} 
+          color: ${{ job.status == 'success' && '0x00FF00' || '0xFF0000' }}
           url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-

--- a/.github/workflows/test-security.yml
+++ b/.github/workflows/test-security.yml
@@ -5,7 +5,6 @@ name: test-security
 on:
   schedule:
     - cron: "00 04 15 * *" # 毎月15日 13:00 JST
-  workflow_dispatch:
 
 defaults:
   run:

--- a/.github/workflows/test-security.yml
+++ b/.github/workflows/test-security.yml
@@ -5,6 +5,7 @@ name: test-security
 on:
   schedule:
     - cron: "00 04 15 * *" # 毎月15日 13:00 JST
+  workflow_dispatch:
 
 defaults:
   run:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-latest, windows-latest]
+        os: [ubuntu-22.04, macos-latest, windows-latest]
 
     steps:
       - name: <Setup> Check out the repository
@@ -51,7 +51,7 @@ jobs:
         run: coverage run --omit=test/* -m pytest
 
       - name: <Deploy> Submit coverage results to Coveralls
-        if: matrix.os == 'ubuntu-20.04'
+        if: matrix.os == 'ubuntu-22.04'
         run: coveralls --service=github
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -60,11 +60,11 @@ jobs:
         run: OUTPUT_LICENSE_JSON_PATH=/dev/null bash tools/create_venv_and_generate_licenses.bash
 
       - name: <Test> Test names by checking typo
-        if: matrix.os == 'ubuntu-20.04'
+        if: matrix.os == 'ubuntu-22.04'
         uses: crate-ci/typos@v1.21.0
 
   lint-builders:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: <Setup> Check out the repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## 内容
#1549 への対応です。
ActionsのRunnerにubuntu-20.04が2025/4/1からサポートされなくなるため、
ubuntu-22.04にアップデートしました。

変更が行われたワークフローに関しては全てfork先でワークフローを実行し確認しました。
特に新たな問題などは発生しませんでした。
https://github.com/nanae772/voicevox_engine/actions

test-securityについてはjinja2のバージョンをアップデートしろと言われてfailしているのですが
これは元のレポジトリでも起こっているので本変更の影響ではないという認識です。
https://github.com/nanae772/voicevox_engine/actions/runs/13961780637
https://github.com/VOICEVOX/voicevox_engine/actions/runs/13869402407

## 関連 Issue
close #1549 
<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
