### PR TITLE
refactor: run.py

### DIFF
--- a/run.py
+++ b/run.py
@@ -366,7 +366,7 @@ def main() -> None:
     )
     preset_manager = PresetManager(preset_path)
 
-    use_dict = UserDictionary()
+    user_dict = UserDictionary()
 
     engine_manifest = load_manifest(engine_manifest_path())
 
@@ -395,7 +395,7 @@ def main() -> None:
         core_manager,
         setting_loader,
         preset_manager,
-        use_dict,
+        user_dict,
         engine_manifest,
         library_manager,
         cancellable_engine,

--- a/run.py
+++ b/run.py
@@ -399,7 +399,7 @@ def main() -> None:
         character_info_dir,
         cors_policy_mode,
         allow_origin,
-        disable_mutable_api,
+        disable_mutable_api=disable_mutable_api,
     )
 
     # VOICEVOX ENGINE サーバーを起動

--- a/run.py
+++ b/run.py
@@ -378,10 +378,7 @@ def main() -> None:
         engine_manifest.uuid,
     )
 
-    if args.disable_mutable_api:
-        disable_mutable_api = True
-    else:
-        disable_mutable_api = envs.disable_mutable_api
+    disable_mutable_api = args.disable_mutable_api or envs.disable_mutable_api
 
     root_dir = select_first_not_none([args.voicevox_dir, engine_root()])
     character_info_dir = root_dir / "resources" / "character_info"

--- a/run.py
+++ b/run.py
@@ -378,13 +378,13 @@ def main() -> None:
         engine_manifest.uuid,
     )
 
-    disable_mutable_api = args.disable_mutable_api or envs.disable_mutable_api
-
     root_dir = select_first_not_none([args.voicevox_dir, engine_root()])
     character_info_dir = root_dir / "resources" / "character_info"
     # NOTE: ENGINE v0.19 以前向けに後方互換性を確保する
     if not character_info_dir.exists():
         character_info_dir = root_dir / "speaker_info"
+
+    disable_mutable_api = args.disable_mutable_api or envs.disable_mutable_api
 
     # ASGI に準拠した VOICEVOX ENGINE アプリケーションを生成する
     app = generate_app(

--- a/run.py
+++ b/run.py
@@ -399,7 +399,7 @@ def main() -> None:
         character_info_dir,
         cors_policy_mode,
         allow_origin,
-        disable_mutable_api=disable_mutable_api,
+        disable_mutable_api,
     )
 
     # VOICEVOX ENGINE サーバーを起動


### PR DESCRIPTION
## 内容
run.py を少しだけリファクタリングしました。

1. typoの修正: use_dict -> user_dict
2. disable_mutable_api の定義のif分岐を減らす
3. disable_mutable_api の位置を変更(generate_appに最後に渡されるので、定義も最後にして一貫性をもたせる）
4. disable_mutable_api だけgenerate_appにキーワード引数で渡されており、その理由が特に見当たらなかったため一貫性のため他と同様に位置引数で渡す

<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
