### PR TITLE
refactor(ci): Github WorkflowのOS判定に runner.os を使用

### DIFF
--- a/.github/workflows/build-engine-package.yml
+++ b/.github/workflows/build-engine-package.yml
@@ -426,11 +426,7 @@ jobs:
         run: |
           curl -L --retry 3 --retry-delay 5 \
             "https://github.com/VOICEVOX/voicevox_core/releases/download/${{ env.VOICEVOX_CORE_VERSION }}/${{ env.VOICEVOX_CORE_ASSET_NAME }}.zip" > download/${{ env.VOICEVOX_CORE_ASSET_NAME }}.zip
-          if [[ ${{ runner.os }} == macOS ]]; then
-            ditto -x -k --sequesterRsrc --rsrc download/${{ env.VOICEVOX_CORE_ASSET_NAME }}.zip download/
-          else
-            unzip download/${{ env.VOICEVOX_CORE_ASSET_NAME }}.zip -d download/
-          fi
+          unzip download/${{ env.VOICEVOX_CORE_ASSET_NAME }}.zip -d download/
           mkdir -p download/core
           mv download/${{ env.VOICEVOX_CORE_ASSET_NAME }}/* download/core
           rm -rf download/${{ env.VOICEVOX_CORE_ASSET_NAME }}

--- a/.github/workflows/build-engine-package.yml
+++ b/.github/workflows/build-engine-package.yml
@@ -166,10 +166,8 @@ jobs:
           CUDA_ROOT=$( echo "${{ steps.cuda-toolkit.outputs.CUDA_PATH }}" | tr '\\' '/' )
 
           mkdir -p download/cuda/bin
-          # NOTE 1: actionlint による GitHub Actions 文法の暗示的 `________________` 置換が SchellCheck の `never be equal` エラーを起こさないように、変数代入する
-          # 一度代入して actionlint のエラー回避 (詳細: NOTE 1)
-          OS=${{ matrix.os }}
-          if [[ $OS == windows-* ]]; then
+
+          if [[ ${{ runner.os }} == Windows ]]; then
             mv "${CUDA_ROOT}/bin/"*.dll download/cuda/bin/
 
             # remove CUDA to reduce disk usage
@@ -218,9 +216,7 @@ jobs:
         run: |
           set -eux
 
-          # 一度代入して actionlint のエラー回避 (詳細: NOTE 1)
-          OS=${{ matrix.os }}
-          if [[ $OS == windows-* ]]; then
+          if [[ ${{ runner.os }} == Windows ]]; then
             curl -L --retry 3 --retry-delay 5 "${{ matrix.cudnn_url }}" > download/cudnn.zip
 
             unzip download/cudnn.zip cudnn-*/bin/*.dll -d download/cudnn_tmp
@@ -368,6 +364,7 @@ jobs:
           curl -L --retry 3 --retry-delay 5 "${{ matrix.onnxruntime_url }}" > download/onnxruntime.zip
 
           # extract only dlls
+          # NOTE 1: actionlint による GitHub Actions 文法の暗示的 `________________` 置換が SchellCheck の `never be equal` エラーを起こさないように、変数代入する
           # 一度代入して actionlint のエラー回避 (詳細: NOTE 1)
           TARGET=${{ matrix.target }}
           if [[ $TARGET != *-directml ]]; then
@@ -432,9 +429,7 @@ jobs:
         run: |
           curl -L --retry 3 --retry-delay 5 \
             "https://github.com/VOICEVOX/voicevox_core/releases/download/${{ env.VOICEVOX_CORE_VERSION }}/${{ env.VOICEVOX_CORE_ASSET_NAME }}.zip" > download/${{ env.VOICEVOX_CORE_ASSET_NAME }}.zip
-          # 一度代入して actionlint のエラー回避 (詳細: NOTE 1)
-          OS=${{ matrix.os }}
-          if [[ $OS == mac-* ]]; then
+          if [[ ${{ runner.os }} == macOS ]]; then
             ditto -x -k --sequesterRsrc --rsrc download/${{ env.VOICEVOX_CORE_ASSET_NAME }}.zip download/
           else
             unzip download/${{ env.VOICEVOX_CORE_ASSET_NAME }}.zip -d download/
@@ -468,12 +463,11 @@ jobs:
 
           # Replace version & specify dynamic libraries
           $sed -i "s/__version__ = \"latest\"/__version__ = \"${{ needs.config.outputs.version_or_latest }}\"/" voicevox_engine/__init__.py
-          # 一度代入して actionlint のエラー回避 (詳細: NOTE 1)
-          OS=${{ matrix.os }}
-          if [[ $OS == windows-* ]]; then
+
+          if [[ ${{ runner.os }} == Windows  ]]; then
             LIBCORE_PATH=download/core/voicevox_core.dll
             LIBONNXRUNTIME_PATH=download/onnxruntime/lib/onnxruntime.dll
-          elif [[ $OS == macos-* ]]; then
+          elif [[ ${{ runner.os }} == macOS ]]; then
             LIBCORE_PATH=download/core/libvoicevox_core.dylib
             LIBONNXRUNTIME_PATH=download/onnxruntime/lib/libonnxruntime.dylib
           else

--- a/.github/workflows/build-engine-package.yml
+++ b/.github/workflows/build-engine-package.yml
@@ -127,12 +127,12 @@ jobs:
       #       There is a difference in specification between BSD 'sed' and 'split' and GNU 'sed' and 'split',
       #       so you need to install GNU 'sed' and 'split'.
       - name: <Setup> Install dependencies (macOS)
-        if: startsWith(matrix.os, 'macos-')
+        if: runner.os == 'macOS'
         run: brew install gnu-sed coreutils
 
       # ONNX Runtime providersとCUDA周りをリンクするために使う
       - name: <Setup> Install ONNX Runtime dependencies (Linux)
-        if: startsWith(matrix.os, 'ubuntu-') && endsWith(matrix.target, 'nvidia')
+        if: runner.os == 'Linux' && endsWith(matrix.target, 'nvidia')
         run: |
           sudo apt-get update
           sudo apt-get install -y patchelf
@@ -286,7 +286,7 @@ jobs:
           path: download/zlib
 
       - name: <Setup> Set up MSVC
-        if: startsWith(matrix.os, 'windows-')
+        if: runner.os == 'Windows'
         uses: ilammy/msvc-dev-cmd@v1
 
       - name: <Setup> Prepare Python Runtime / Python Dependencies
@@ -295,7 +295,7 @@ jobs:
           requirements-suffix: "-build"
 
       - name: <Setup> Prepare custom PyInstaller
-        if: startsWith(matrix.os, 'windows-')
+        if: runner.os == 'Windows'
         run: ./tools/modify_pyinstaller.bash
 
       - name: <Setup> Download pyopenjtalk dictionary
@@ -363,7 +363,7 @@ jobs:
           path: download/onnxruntime
 
       - name: <Setup> Download ONNX Runtime (Windows)
-        if: steps.onnxruntime-cache-restore.outputs.cache-hit != 'true' && startsWith(matrix.os, 'windows-')
+        if: steps.onnxruntime-cache-restore.outputs.cache-hit != 'true' && runner.os == 'Windows'
         run: |
           curl -L --retry 3 --retry-delay 5 "${{ matrix.onnxruntime_url }}" > download/onnxruntime.zip
 
@@ -383,7 +383,7 @@ jobs:
           rm download/onnxruntime.zip
 
       - name: <Setup> Download ONNX Runtime (Mac/Linux)
-        if: steps.onnxruntime-cache-restore.outputs.cache-hit != 'true' && startsWith(matrix.os, 'windows-') != true
+        if: steps.onnxruntime-cache-restore.outputs.cache-hit != 'true' && runner.os != 'Windows'
         run: |
           curl -L --retry 3 --retry-delay 5 "${{ matrix.onnxruntime_url }}" > download/onnxruntime.tgz
           mkdir -p download/onnxruntime
@@ -461,7 +461,7 @@ jobs:
 
           jq '
             .version = "${{ needs.config.outputs.version_or_latest }}" |
-            if ${{ startsWith(matrix.os, 'windows-') }} then .command += ".exe" else . end
+            if ${{ runner.os == 'Windows' }} then .command += ".exe" else . end
           ' engine_manifest.json > engine_manifest.json.tmp
 
           mv -f engine_manifest.json.tmp engine_manifest.json
@@ -490,7 +490,7 @@ jobs:
       # manually move DLL dependencies into `dist/run/` (cache already saved)
 
       - name: <Build> Gather DLL dependencies (Windows)
-        if: startsWith(matrix.os, 'windows-')
+        if: runner.os == 'Windows'
         run: |
           set -eux
 
@@ -533,7 +533,7 @@ jobs:
           fi
 
       - name: <Build> Gather DLL dependencies (Linux CUDA)
-        if: startsWith(matrix.os, 'ubuntu-') && endsWith(matrix.target, 'nvidia')
+        if: runner.os == 'Linux' && endsWith(matrix.target, 'nvidia')
         run: |
           set -eux
 
@@ -560,7 +560,7 @@ jobs:
           rm -rf download/cudnn
 
       - name: <Build> Code signing
-        if: github.event.inputs.code_signing == 'true' && startsWith(matrix.os, 'windows-')
+        if: github.event.inputs.code_signing == 'true' && runner.os == 'Windows'
         run: bash tools/codesign.bash "dist/run/run.exe"
         env:
           ESIGNERCKA_USERNAME: ${{ secrets.ESIGNERCKA_USERNAME }}

--- a/.github/workflows/build-engine-package.yml
+++ b/.github/workflows/build-engine-package.yml
@@ -364,10 +364,7 @@ jobs:
           curl -L --retry 3 --retry-delay 5 "${{ matrix.onnxruntime_url }}" > download/onnxruntime.zip
 
           # extract only dlls
-          # NOTE 1: actionlint による GitHub Actions 文法の暗示的 `________________` 置換が SchellCheck の `never be equal` エラーを起こさないように、変数代入する
-          # 一度代入して actionlint のエラー回避 (詳細: NOTE 1)
-          TARGET=${{ matrix.target }}
-          if [[ $TARGET != *-directml ]]; then
+          if [[ ${{ endsWith(matrix.target, '-directml') }} == false ]]; then
             unzip download/onnxruntime.zip onnxruntime-*/lib/*.dll -d download/
             mv download/onnxruntime-* download/onnxruntime
           else
@@ -516,9 +513,7 @@ jobs:
           fi
 
           # Windows DirectML
-          # 一度代入して actionlint のエラー回避 (詳細: NOTE 1)
-          TARGET=${{ matrix.target }}
-          if [[ $TARGET == *-directml ]]; then
+          if [[ ${{ endsWith(matrix.target, '-directml') }} == true ]]; then
             # DirectML
             mv download/directml/DirectML.dll dist/run/
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
         run: coverage run --omit=test/* -m pytest
 
       - name: <Deploy> Submit coverage results to Coveralls
-        if: matrix.os == 'ubuntu-22.04'
+        if: runner.os == 'Linux'
         run: coveralls --service=github
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -60,7 +60,7 @@ jobs:
         run: OUTPUT_LICENSE_JSON_PATH=/dev/null bash tools/create_venv_and_generate_licenses.bash
 
       - name: <Test> Test names by checking typo
-        if: matrix.os == 'ubuntu-22.04'
+        if: runner.os == 'Linux'
         uses: crate-ci/typos@v1.21.0
 
   lint-builders:


### PR DESCRIPTION
## 内容
GitHub Actionsのワークフローファイルのリファクタリングを行いました。

1. コードをより短く・分かりやすくするため、matrix.osではなくrunner.osを使ってランナーのOSを判定する
2. 上記変更に伴い、actionlintのエラーに対するワークアラウンド( https://github.com/VOICEVOX/voicevox_engine/pull/1122 )を削除

~~リファクタリングではありますが、**一部動作に変更が生じています**。
コードにコメントをつけておきます、詳しくはそちらを参考にしてください。~~
→リファクタリング前後で動作に変更が無いようにしました。


フォーク先で今回変更があったtest, buildが通ることを確認しています。

- test: https://github.com/nanae772/voicevox_engine/actions/runs/14057353294
- build: https://github.com/nanae772/voicevox_engine/actions/runs/14057561278

## 関連 Issue

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
