### PR TITLE
chore: lintのルールにUP(pyupgrade)を追加

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 target-version = "py311"
 
 [tool.ruff.lint]
-select = ["E", "F", "B", "I", "W"]
+select = ["E", "F", "B", "I", "W", "UP"]
 ignore = [
   "E501", # line-too-long
   "B9"    # TODO: 一時期に除外、あとで有効化する

--- a/test/benchmark/speed/character.py
+++ b/test/benchmark/speed/character.py
@@ -98,9 +98,5 @@ if __name__ == "__main__":
     req_time_all_local = benchmark_request_time_for_all_talk_characters(
         "localhost", root_dir
     )
-    print(
-        f"全ての喋れるキャラクター `GET /` fakeserve: {req_time_all_fake:.3f} sec"
-    )
-    print(
-        f"全ての喋れるキャラクター `GET /` localhost: {req_time_all_local:.3f} sec"
-    )
+    print(f"全ての喋れるキャラクター `GET /` fakeserve: {req_time_all_fake:.3f} sec")
+    print(f"全ての喋れるキャラクター `GET /` localhost: {req_time_all_local:.3f} sec")

--- a/test/benchmark/speed/character.py
+++ b/test/benchmark/speed/character.py
@@ -80,13 +80,13 @@ if __name__ == "__main__":
 
     result_speakers_fakeserve = benchmark_get_speakers("fake", root_dir)
     result_speakers_localhost = benchmark_get_speakers("localhost", root_dir)
-    print("`GET /speakers` fakeserve: {:.4f} sec".format(result_speakers_fakeserve))
-    print("`GET /speakers` localhost: {:.4f} sec".format(result_speakers_localhost))
+    print(f"`GET /speakers` fakeserve: {result_speakers_fakeserve:.4f} sec")
+    print(f"`GET /speakers` localhost: {result_speakers_localhost:.4f} sec")
 
     _result_spk_infos_fakeserve = benchmark_get_speaker_info_all("fake", root_dir)
     _result_spk_infos_localhost = benchmark_get_speaker_info_all("localhost", root_dir)
-    result_spk_infos_fakeserve = "{:.3f}".format(_result_spk_infos_fakeserve)
-    result_spk_infos_localhost = "{:.3f}".format(_result_spk_infos_localhost)
+    result_spk_infos_fakeserve = f"{_result_spk_infos_fakeserve:.3f}"
+    result_spk_infos_localhost = f"{_result_spk_infos_localhost:.3f}"
     print(
         f"全ての喋れるキャラクター `GET /speaker_info` fakeserve: {result_spk_infos_fakeserve} sec"
     )
@@ -99,12 +99,8 @@ if __name__ == "__main__":
         "localhost", root_dir
     )
     print(
-        "全ての喋れるキャラクター `GET /` fakeserve: {:.3f} sec".format(
-            req_time_all_fake
-        )
+        f"全ての喋れるキャラクター `GET /` fakeserve: {req_time_all_fake:.3f} sec"
     )
     print(
-        "全ての喋れるキャラクター `GET /` localhost: {:.3f} sec".format(
-            req_time_all_local
-        )
+        f"全ての喋れるキャラクター `GET /` localhost: {req_time_all_local:.3f} sec"
     )

--- a/test/benchmark/speed/request.py
+++ b/test/benchmark/speed/request.py
@@ -36,5 +36,5 @@ if __name__ == "__main__":
 
     result_fakeserve = benchmark_request(server="fake", root_dir=root_dir)
     result_localhost = benchmark_request(server="localhost", root_dir=root_dir)
-    print("`GET /` fakeserve: {:.4f} sec".format(result_fakeserve))
-    print("`GET /` localhost: {:.4f} sec".format(result_localhost))
+    print(f"`GET /` fakeserve: {result_fakeserve:.4f} sec")
+    print(f"`GET /` localhost: {result_localhost:.4f} sec")

--- a/test/benchmark/speed/utility.py
+++ b/test/benchmark/speed/utility.py
@@ -1,7 +1,7 @@
 """速度ベンチマーク用のユーティリティ"""
 
 import time
-from typing import Callable
+from collections.abc import Callable
 
 
 def benchmark_time(

--- a/tools/make_docs.py
+++ b/tools/make_docs.py
@@ -18,8 +18,7 @@ from voicevox_engine.utility.path_utility import engine_manifest_path, get_save_
 def generate_api_docs_html(schema: str) -> str:
     """OpenAPI schema から API ドキュメント HTML を生成する"""
 
-    return (
-        """<!DOCTYPE html>
+    return f"""<!DOCTYPE html>
 <html lang="ja">
 <head>
     <title>voicevox_engine API Document</title>
@@ -30,12 +29,10 @@ def generate_api_docs_html(schema: str) -> str:
     <div id="redoc-container"></div>
     <script src="https://cdn.jsdelivr.net/npm/redoc/bundles/redoc.standalone.js"></script>
     <script>
-        Redoc.init(%s, {"hideHostname": true}, document.getElementById("redoc-container"));
+        Redoc.init({schema}, {"hideHostname": true}, document.getElementById("redoc-container"));
     </script>
 </body>
 </html>"""
-        % schema
-    )
 
 
 if __name__ == "__main__":

--- a/voicevox_engine/app/dependencies.py
+++ b/voicevox_engine/app/dependencies.py
@@ -1,6 +1,7 @@
 """FastAPI dependencies"""
 
-from typing import Any, Callable, Coroutine, TypeAlias
+from collections.abc import Callable, Coroutine
+from typing import Any, TypeAlias
 
 from fastapi import HTTPException
 

--- a/voicevox_engine/app/routers/tts_pipeline.py
+++ b/voicevox_engine/app/routers/tts_pipeline.py
@@ -53,7 +53,7 @@ class ParseKanaBadRequest(BaseModel):
         "|name|description|\n|---|---|\n"
         + "\n".join(
             [
-                "| {} | {} |".format(err.name, err.value)
+                f"| {err.name} | {err.value} |"
                 for err in list(ParseKanaErrorCode)
             ]
         ),

--- a/voicevox_engine/app/routers/tts_pipeline.py
+++ b/voicevox_engine/app/routers/tts_pipeline.py
@@ -52,10 +52,7 @@ class ParseKanaBadRequest(BaseModel):
         description="エラー名\n\n"
         "|name|description|\n|---|---|\n"
         + "\n".join(
-            [
-                f"| {err.name} | {err.value} |"
-                for err in list(ParseKanaErrorCode)
-            ]
+            [f"| {err.name} | {err.value} |" for err in list(ParseKanaErrorCode)]
         ),
     )
     error_args: dict[str, str] = Field(description="エラーを起こした箇所")

--- a/voicevox_engine/metas/MetasStore.py
+++ b/voicevox_engine/metas/MetasStore.py
@@ -1,8 +1,9 @@
 """キャラクター情報とキャラクターメタ情報の管理"""
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, Final, Literal, TypeAlias
+from typing import Final, Literal, TypeAlias
 
 from fastapi import HTTPException
 from pydantic import BaseModel, Field

--- a/voicevox_engine/preset/preset_manager.py
+++ b/voicevox_engine/preset/preset_manager.py
@@ -63,7 +63,7 @@ class PresetManager:
                 return
 
             # データベースの読み込み
-            with open(self.preset_path, mode="r", encoding="utf-8") as f:
+            with open(self.preset_path, encoding="utf-8") as f:
                 obj = yaml.safe_load(f)
         except OSError:
             raise PresetInternalError("プリセットの読み込みに失敗しました")

--- a/voicevox_engine/tts_pipeline/text_analyzer.py
+++ b/voicevox_engine/tts_pipeline/text_analyzer.py
@@ -1,9 +1,10 @@
 """テキスト解析"""
 
 import re
+from collections.abc import Callable
 from dataclasses import dataclass
 from itertools import chain
-from typing import Any, Callable, Final, Literal, Self, TypeGuard
+from typing import Any, Final, Literal, Self, TypeGuard
 
 import pyopenjtalk
 

--- a/voicevox_engine/user_dict/model.py
+++ b/voicevox_engine/user_dict/model.py
@@ -6,11 +6,10 @@
 
 from enum import Enum
 from re import findall, fullmatch
-from typing import Self
+from typing import Annotated, Self
 
 from pydantic import AfterValidator, BaseModel, ConfigDict, Field, model_validator
 from pydantic.json_schema import SkipJsonSchema
-from typing_extensions import Annotated
 
 
 class WordTypes(str, Enum):
@@ -130,8 +129,6 @@ class UserDictWord(BaseModel):
 
         if not 0 <= self.accent_type <= self.mora_count:
             raise ValueError(
-                "誤ったアクセント型です({})。 expect: 0 <= accent_type <= {}".format(
-                    self.accent_type, self.mora_count
-                )
+                f"誤ったアクセント型です({self.accent_type})。 expect: 0 <= accent_type <= {self.mora_count}"
             )
         return self


### PR DESCRIPTION
## 内容

#1575 の対応PRです。
lintのルールにUPを追加し、それにあわせてコードベースを修正しました。

修正の対象となったのは、以下の４つのルールです。

- [UP015 [*] Unnecessary mode argument](https://docs.astral.sh/ruff/rules/redundant-open-modes/)
- [UP031 Use format specifiers instead of percent format](https://docs.astral.sh/ruff/rules/printf-string-formatting/)
- [UP032 [*] Use f-string instead of `format` call](https://docs.astral.sh/ruff/rules/f-string/)
- [UP035 [*] Import from `collections.abc` instead: `Callable`](https://docs.astral.sh/ruff/rules/deprecated-import/)

## 関連 Issue

- close #1575

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
