### PR TITLE
chore: lintのB905を通す

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ target-version = "py311"
 select = ["E", "F", "B", "I", "W"]
 ignore = [
   "E501", # line-too-long
-  "B9"    # TODO: 一時期に除外、あとで有効化する
+  "B904"  # TODO: 一時期に除外、あとで有効化する
 ]
 unfixable = [
   "F401", # unused-import

--- a/voicevox_engine/tts_pipeline/text_analyzer.py
+++ b/voicevox_engine/tts_pipeline/text_analyzer.py
@@ -194,7 +194,7 @@ class AccentPhraseLabel:
         moras: list[MoraLabel] = []  # モーラ系列
         mora_labels: list[Label] = []  # モーラごとのラベル系列を一時保存するコンテナ
 
-        for label, next_label in zip(labels, labels[1:] + [None]):
+        for label, next_label in zip(labels, labels[1:] + [None], strict=True):
             # モーラ抽出を打ち切る（ワークアラウンド、VOICEVOX/voicevox_engine#57）
             # mora_index の最大値が 49 であるため、49番目以降のモーラではラベルのモーラ番号を区切りに使えない
             if label.mora_index == 49:
@@ -256,7 +256,7 @@ class BreathGroupLabel:
             Label
         ] = []  # アクセント句ごとのラベル系列を一時保存するコンテナ
 
-        for label, next_label in zip(labels, labels[1:] + [None]):
+        for label, next_label in zip(labels, labels[1:] + [None], strict=True):
             # 区切りまでラベル系列を一時保存する
             accent_labels.append(label)
 

--- a/voicevox_engine/tts_pipeline/tts_engine.py
+++ b/voicevox_engine/tts_pipeline/tts_engine.py
@@ -647,7 +647,7 @@ class TTSEngine:
                 note_id=phoneme_note_id,
             )
             for phoneme_id, phoneme_duration, phoneme_note_id in zip(
-                phonemes_array, phoneme_lengths, phoneme_note_ids
+                phonemes_array, phoneme_lengths, phoneme_note_ids, strict=True
             )
         ]
 


### PR DESCRIPTION
## 内容
#1579 の部分解決PRです。
まずは解決が容易そうなB905(zipにstrictつける)をやりました。

tts_engine.pyのほうは全ての長さが等しいのかについて自信がありません。
phonemes_array, phoneme_note_idsの長さが等しいのはコードを読んで確かめましたが、
phoneme_lengthsが生成されるロジックがいまいち追い切れていません。

テストも通っており、 @Hiroshiba さんが「全部strict=Trueにするのが正しそう」とおっしゃっていたので、
問題無いとは思うのですが、改めて確認していただけると幸いです🙇‍♂️

## 関連 Issue
- ref #1579
<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
