### PR TITLE
fix(docs): make_docs.pyのスキーマの構文を修正

### DIFF
--- a/tools/make_docs.py
+++ b/tools/make_docs.py
@@ -29,7 +29,7 @@ def generate_api_docs_html(schema: str) -> str:
     <div id="redoc-container"></div>
     <script src="https://cdn.jsdelivr.net/npm/redoc/bundles/redoc.standalone.js"></script>
     <script>
-        Redoc.init({schema}, {"hideHostname": true}, document.getElementById("redoc-container"));
+        Redoc.init({schema}, {{"hideHostname": true}}, document.getElementById("redoc-container"));
     </script>
 </body>
 </html>"""


### PR DESCRIPTION
## 内容

タイトルの通りです。
ここはjsにとってオブジェクトを与えるのが正解だったけどf-stringになってそうでした！

## 関連 Issue

close #1585

## その他
