### PR TITLE
refactor: 不要になったincludeのonnxruntime_versionを削除

### DIFF
--- a/.github/workflows/build-engine-container.yml
+++ b/.github/workflows/build-engine-container.yml
@@ -64,7 +64,6 @@ jobs:
             target: runtime-env
             base_image: ubuntu:20.04
             base_runtime_image: ubuntu:20.04
-            onnxruntime_version: 1.13.1
             platforms: linux/arm64/v8
           # Ubuntu 20.04 / AMD64 / NVIDIA
           - os: ubuntu-latest
@@ -89,7 +88,6 @@ jobs:
             target: runtime-env
             base_image: ubuntu:22.04
             base_runtime_image: ubuntu:22.04
-            onnxruntime_version: 1.13.1
             platforms: linux/arm64/v8
           # Ubuntu 22.04 / AMD64 / NVIDIA
           - os: ubuntu-latest


### PR DESCRIPTION
## 内容

#1552 でonnxruntime_versionをenvに共通化したので、
 不要になったincludeのonnxruntime_versionを削除しました。
(#1587 を見て残っていることに気づきました）

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
