### PR TITLE
refactor: tts_engine から song_engine に分離

### DIFF
--- a/run.py
+++ b/run.py
@@ -21,6 +21,7 @@ from voicevox_engine.library.library_manager import LibraryManager
 from voicevox_engine.preset.preset_manager import PresetManager
 from voicevox_engine.setting.model import CorsPolicyMode
 from voicevox_engine.setting.setting_manager import USER_SETTING_PATH, SettingHandler
+from voicevox_engine.tts_pipeline.song_engine import make_song_engines_from_cores
 from voicevox_engine.tts_pipeline.tts_engine import make_tts_engines_from_cores
 from voicevox_engine.user_dict.user_dict_manager import UserDictionary
 from voicevox_engine.utility.path_utility import (
@@ -326,7 +327,9 @@ def main() -> None:
         load_all_models=args.load_all_models,
     )
     tts_engines = make_tts_engines_from_cores(core_manager)
+    song_engines = make_song_engines_from_cores(core_manager)
     assert len(tts_engines.versions()) != 0, "音声合成エンジンがありません。"
+    assert len(song_engines.versions()) != 0, "音声合成エンジンがありません。"
 
     cancellable_engine: CancellableEngine | None = None
     if args.enable_cancellable_synthesis:
@@ -389,6 +392,7 @@ def main() -> None:
     # ASGI に準拠した VOICEVOX ENGINE アプリケーションを生成する
     app = generate_app(
         tts_engines,
+        song_engines,
         core_manager,
         setting_loader,
         preset_manager,

--- a/test/benchmark/engine_preparation.py
+++ b/test/benchmark/engine_preparation.py
@@ -13,6 +13,7 @@ from voicevox_engine.engine_manifest import load_manifest
 from voicevox_engine.library.library_manager import LibraryManager
 from voicevox_engine.preset.preset_manager import PresetManager
 from voicevox_engine.setting.setting_manager import SettingHandler
+from voicevox_engine.tts_pipeline.song_engine import make_song_engines_from_cores
 from voicevox_engine.tts_pipeline.tts_engine import make_tts_engines_from_cores
 from voicevox_engine.user_dict.user_dict_manager import UserDictionary
 from voicevox_engine.utility.path_utility import engine_manifest_path, get_save_dir
@@ -23,6 +24,7 @@ def _generate_engine_fake_server(root_dir: Path) -> TestClient:
         voicevox_dir=root_dir, use_gpu=False, enable_mock=False
     )
     tts_engines = make_tts_engines_from_cores(core_manager)
+    song_engines = make_song_engines_from_cores(core_manager)
     setting_loader = SettingHandler(Path("./not_exist.yaml"))
     preset_manager = PresetManager(get_save_dir() / "presets.yaml")
     user_dict = UserDictionary()
@@ -36,6 +38,7 @@ def _generate_engine_fake_server(root_dir: Path) -> TestClient:
     )
     app = generate_app(
         tts_engines=tts_engines,
+        song_engines=song_engines,
         core_manager=core_manager,
         setting_loader=setting_loader,
         preset_manager=preset_manager,

--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -14,6 +14,7 @@ from voicevox_engine.engine_manifest import load_manifest
 from voicevox_engine.library.library_manager import LibraryManager
 from voicevox_engine.preset.preset_manager import PresetManager
 from voicevox_engine.setting.setting_manager import SettingHandler
+from voicevox_engine.tts_pipeline.song_engine import make_song_engines_from_cores
 from voicevox_engine.tts_pipeline.tts_engine import make_tts_engines_from_cores
 from voicevox_engine.user_dict.user_dict_manager import (
     DEFAULT_DICT_PATH,
@@ -33,6 +34,7 @@ def _copy_under_dir(file_path: Path, dir_path: Path) -> Path:
 def app_params(tmp_path: Path) -> dict[str, Any]:
     core_manager = initialize_cores(use_gpu=False, enable_mock=True)
     tts_engines = make_tts_engines_from_cores(core_manager)
+    song_engines = make_song_engines_from_cores(core_manager)
     setting_loader = SettingHandler(tmp_path / "not_exist.yaml")
 
     # テスト用に隔離されたプリセットを生成する
@@ -57,6 +59,7 @@ def app_params(tmp_path: Path) -> dict[str, Any]:
 
     return {
         "tts_engines": tts_engines,
+        "song_engines": song_engines,
         "core_manager": core_manager,
         "setting_loader": setting_loader,
         "preset_manager": preset_manager,

--- a/test/unit/tts_pipeline/test_tts_engine.py
+++ b/test/unit/tts_pipeline/test_tts_engine.py
@@ -17,6 +17,9 @@ from voicevox_engine.tts_pipeline.model import (
     Note,
     Score,
 )
+from voicevox_engine.tts_pipeline.song_engine import (
+    SongEngine,
+)
 from voicevox_engine.tts_pipeline.tts_engine import (
     TTSEngine,
     _apply_interrogative_upspeak,
@@ -277,13 +280,13 @@ def test_mocked_create_sing_volume_from_phoneme_and_f0_output(
     NOTE: 入力生成の簡略化に別関数を呼び出すため、別関数が正しく動作しない場合テストが落ちる
     """
     # Inputs
-    tts_engine = TTSEngine(MockCoreWrapper())
+    tts_engine = SongEngine(MockCoreWrapper())
     doremi_srore = _gen_doremi_score()
-    phonemes, f0s, _ = tts_engine.create_sing_phoneme_and_f0_and_volume(
+    phonemes, f0s, _ = tts_engine.create_phoneme_and_f0_and_volume(
         doremi_srore, StyleId(1)
     )
     # Outputs
-    result = tts_engine.create_sing_volume_from_phoneme_and_f0(
+    result = tts_engine.create_volume_from_phoneme_and_f0(
         doremi_srore, phonemes, f0s, StyleId(1)
     )
     # Tests
@@ -298,10 +301,10 @@ def test_mocked_synthesize_wave_from_score_output(
     `TTSEngine.frame_synthesize_wave()` の出力スナップショットが一定である
     """
     # Inputs
-    tts_engine = TTSEngine(MockCoreWrapper())
+    tts_engine = SongEngine(MockCoreWrapper())
     doremi_srore = _gen_doremi_score()
     # Outputs
-    result = tts_engine.create_sing_phoneme_and_f0_and_volume(doremi_srore, StyleId(1))
+    result = tts_engine.create_phoneme_and_f0_and_volume(doremi_srore, StyleId(1))
     # Tests
     assert snapshot_json(name="query") == round_floats(
         pydantic_to_native_type(result), round_value=2

--- a/test/unit/tts_pipeline/test_tts_engines.py
+++ b/test/unit/tts_pipeline/test_tts_engines.py
@@ -45,7 +45,7 @@ def test_tts_engines_get_engine_existing() -> None:
     # Expects
     true_acquired_tts_engine = tts_engine2
     # Outputs
-    acquired_tts_engine = tts_engines.get_engine("0.0.2")
+    acquired_tts_engine = tts_engines.get_tts_engine("0.0.2")
 
     # Test
     assert true_acquired_tts_engine == acquired_tts_engine
@@ -64,7 +64,7 @@ def test_tts_engines_get_engine_latest() -> None:
     # Expects
     true_acquired_tts_engine = tts_engine3
     # Outputs
-    acquired_tts_engine = tts_engines.get_engine(LATEST_VERSION)
+    acquired_tts_engine = tts_engines.get_tts_engine(LATEST_VERSION)
 
     # Test
     assert true_acquired_tts_engine == acquired_tts_engine
@@ -80,4 +80,4 @@ def test_tts_engines_get_engine_missing() -> None:
     tts_engines.register_engine(tts_engine2, "0.0.2")
     # Test
     with pytest.raises(TTSEngineNotFound):
-        tts_engines.get_engine("0.0.3")
+        tts_engines.get_tts_engine("0.0.3")

--- a/test/unit/tts_pipeline/test_wave_synthesizer.py
+++ b/test/unit/tts_pipeline/test_wave_synthesizer.py
@@ -3,18 +3,20 @@
 import numpy as np
 
 from voicevox_engine.model import AudioQuery
+from voicevox_engine.tts_pipeline.audio_postprocessing import (
+    _apply_output_sampling_rate,
+    _apply_output_stereo,
+    _apply_volume_scale,
+    raw_wave_to_output_wave,
+)
 from voicevox_engine.tts_pipeline.model import AccentPhrase
 from voicevox_engine.tts_pipeline.tts_engine import (
     _apply_intonation_scale,
-    _apply_output_sampling_rate,
-    _apply_output_stereo,
     _apply_pitch_scale,
     _apply_prepost_silence,
     _apply_speed_scale,
-    _apply_volume_scale,
     _count_frame_per_unit,
     _query_to_decoder_feature,
-    raw_wave_to_output_wave,
 )
 
 from .tts_utils import gen_mora, sec

--- a/test/unit/user_dict/test_user_dict.py
+++ b/test/unit/user_dict/test_user_dict.py
@@ -3,8 +3,8 @@ from copy import deepcopy
 from pathlib import Path
 
 import pytest
-from pyopenjtalk import g2p, unset_user_dict
 
+from pyopenjtalk import g2p, unset_user_dict
 from voicevox_engine.user_dict.model import UserDictWord, WordTypes
 from voicevox_engine.user_dict.user_dict_manager import UserDictionary
 from voicevox_engine.user_dict.user_dict_word import (

--- a/test/unit/user_dict/test_user_dict.py
+++ b/test/unit/user_dict/test_user_dict.py
@@ -3,8 +3,8 @@ from copy import deepcopy
 from pathlib import Path
 
 import pytest
-
 from pyopenjtalk import g2p, unset_user_dict
+
 from voicevox_engine.user_dict.model import UserDictWord, WordTypes
 from voicevox_engine.user_dict.user_dict_manager import UserDictionary
 from voicevox_engine.user_dict.user_dict_word import (

--- a/tools/make_docs.py
+++ b/tools/make_docs.py
@@ -10,6 +10,7 @@ from voicevox_engine.engine_manifest import load_manifest
 from voicevox_engine.library.library_manager import LibraryManager
 from voicevox_engine.preset.preset_manager import PresetManager
 from voicevox_engine.setting.setting_manager import USER_SETTING_PATH, SettingHandler
+from voicevox_engine.tts_pipeline.song_engine import SongEngineManager
 from voicevox_engine.tts_pipeline.tts_engine import TTSEngineManager
 from voicevox_engine.user_dict.user_dict_manager import UserDictionary
 from voicevox_engine.utility.path_utility import engine_manifest_path, get_save_dir
@@ -39,6 +40,7 @@ if __name__ == "__main__":
     core_manager = CoreManager()
     core_manager.register_core(CoreAdapter(MockCoreWrapper()), "mock")
     tts_engines = TTSEngineManager()
+    song_engines = SongEngineManager()
     tts_engines.register_engine(MockTTSEngine(), "mock")
     preset_path = get_save_dir() / "presets.yaml"
     engine_manifest = load_manifest(engine_manifest_path())
@@ -53,6 +55,7 @@ if __name__ == "__main__":
     # FastAPI の機能を用いて OpenAPI schema を生成する
     app = generate_app(
         tts_engines=tts_engines,
+        song_engines=song_engines,
         core_manager=core_manager,
         setting_loader=SettingHandler(USER_SETTING_PATH),
         preset_manager=PresetManager(preset_path),

--- a/voicevox_engine/app/application.py
+++ b/voicevox_engine/app/application.py
@@ -88,10 +88,7 @@ def generate_app(
 
     app.include_router(
         generate_tts_pipeline_router(
-            tts_engines,
-            song_engines,
-            preset_manager,
-            cancellable_engine
+            tts_engines, song_engines, preset_manager, cancellable_engine
         )
     )
     app.include_router(generate_morphing_router(tts_engines, metas_store))

--- a/voicevox_engine/app/application.py
+++ b/voicevox_engine/app/application.py
@@ -31,6 +31,7 @@ from voicevox_engine.preset.preset_manager import PresetManager
 from voicevox_engine.resource_manager import ResourceManager
 from voicevox_engine.setting.model import CorsPolicyMode
 from voicevox_engine.setting.setting_manager import SettingHandler
+from voicevox_engine.tts_pipeline.song_engine import SongEngineManager
 from voicevox_engine.tts_pipeline.tts_engine import TTSEngineManager
 from voicevox_engine.user_dict.user_dict_manager import UserDictionary
 from voicevox_engine.utility.path_utility import engine_root
@@ -39,6 +40,7 @@ from voicevox_engine.utility.runtime_utility import is_development
 
 def generate_app(
     tts_engines: TTSEngineManager,
+    song_engines: SongEngineManager,
     core_manager: CoreManager,
     setting_loader: SettingHandler,
     preset_manager: PresetManager,
@@ -85,7 +87,12 @@ def generate_app(
     )
 
     app.include_router(
-        generate_tts_pipeline_router(tts_engines, preset_manager, cancellable_engine)
+        generate_tts_pipeline_router(
+            tts_engines,
+            song_engines,
+            preset_manager,
+            cancellable_engine
+        )
     )
     app.include_router(generate_morphing_router(tts_engines, metas_store))
     app.include_router(

--- a/voicevox_engine/app/routers/morphing.py
+++ b/voicevox_engine/app/routers/morphing.py
@@ -87,7 +87,7 @@ def generate_morphing_router(
         モーフィングの割合は`morph_rate`で指定でき、0.0でベースのスタイル、1.0でターゲットのスタイルに近づきます。
         """
         version = core_version or LATEST_VERSION
-        engine = tts_engines.get_engine(version)
+        engine = tts_engines.get_tts_engine(version)
 
         # モーフィングが許可されないキャラクターペアを拒否する
         characters = metas_store.characters(core_version)

--- a/voicevox_engine/cancellable_engine.py
+++ b/voicevox_engine/cancellable_engine.py
@@ -214,7 +214,7 @@ def start_synthesis_subprocess(
 
             # 音声を合成しファイルへ保存する
             try:
-                _engine = tts_engines.get_engine(version)
+                _engine = tts_engines.get_tts_engine(version)
             except Exception:
                 # コネクションを介して「バージョンが見つからないエラー」を送信する
                 connection.send("")  # `""` をエラーして扱う

--- a/voicevox_engine/dev/song_engine/mock.py
+++ b/voicevox_engine/dev/song_engine/mock.py
@@ -1,0 +1,13 @@
+"""SongEngine のモック"""
+
+from ...tts_pipeline.song_engine import (
+    SongEngine,
+)
+from ..core.mock import MockCoreWrapper
+
+
+class MockSongEngine(SongEngine):
+    """製品版コア無しに歌声音声合成可能なモック版SongEngine"""
+
+    def __init__(self) -> None:
+        super().__init__(MockCoreWrapper())

--- a/voicevox_engine/dev/tts_engine/mock.py
+++ b/voicevox_engine/dev/tts_engine/mock.py
@@ -9,9 +9,9 @@ from pyopenjtalk import tts
 
 from ...metas.Metas import StyleId
 from ...model import AudioQuery
+from ...tts_pipeline.audio_postprocessing import raw_wave_to_output_wave
 from ...tts_pipeline.tts_engine import (
     TTSEngine,
-    raw_wave_to_output_wave,
     to_flatten_moras,
 )
 from ..core.mock import MockCoreWrapper

--- a/voicevox_engine/dev/tts_engine/mock.py
+++ b/voicevox_engine/dev/tts_engine/mock.py
@@ -5,6 +5,7 @@ from typing import Final
 
 import numpy as np
 from numpy.typing import NDArray
+
 from pyopenjtalk import tts
 
 from ...metas.Metas import StyleId

--- a/voicevox_engine/dev/tts_engine/mock.py
+++ b/voicevox_engine/dev/tts_engine/mock.py
@@ -5,7 +5,6 @@ from typing import Final
 
 import numpy as np
 from numpy.typing import NDArray
-
 from pyopenjtalk import tts
 
 from ...metas.Metas import StyleId

--- a/voicevox_engine/tts_pipeline/audio_postprocessing.py
+++ b/voicevox_engine/tts_pipeline/audio_postprocessing.py
@@ -3,7 +3,6 @@ from numpy.typing import NDArray
 from soxr import resample
 
 from ..model import AudioQuery
-
 from .model import (
     FrameAudioQuery,
 )

--- a/voicevox_engine/tts_pipeline/audio_postprocessing.py
+++ b/voicevox_engine/tts_pipeline/audio_postprocessing.py
@@ -1,0 +1,46 @@
+import numpy as np
+from numpy.typing import NDArray
+from soxr import resample
+
+from ..model import AudioQuery
+
+from .model import (
+    FrameAudioQuery,
+)
+
+
+def raw_wave_to_output_wave(
+    query: AudioQuery | FrameAudioQuery, wave: NDArray[np.float32], sr_wave: int
+) -> NDArray[np.float32]:
+    """生音声波形に音声合成用のクエリを適用して出力音声波形を生成する"""
+    wave = _apply_volume_scale(wave, query)
+    wave = _apply_output_sampling_rate(wave, sr_wave, query)
+    wave = _apply_output_stereo(wave, query)
+    return wave
+
+
+def _apply_volume_scale(
+    wave: NDArray[np.float32], query: AudioQuery | FrameAudioQuery
+) -> NDArray[np.float32]:
+    """音声波形へ音声合成用のクエリがもつ音量スケール（`volumeScale`）を適用する"""
+    return wave * query.volumeScale
+
+
+def _apply_output_sampling_rate(
+    wave: NDArray[np.float32], sr_wave: float, query: AudioQuery | FrameAudioQuery
+) -> NDArray[np.float32]:
+    """音声波形へ音声合成用のクエリがもつ出力サンプリングレート（`outputSamplingRate`）を適用する"""
+    # サンプリングレート一致のときはスルー
+    if sr_wave == query.outputSamplingRate:
+        return wave
+    wave = resample(wave, sr_wave, query.outputSamplingRate)
+    return wave
+
+
+def _apply_output_stereo(
+    wave: NDArray[np.float32], query: AudioQuery | FrameAudioQuery
+) -> NDArray[np.float32]:
+    """音声波形へ音声合成用のクエリがもつステレオ出力設定（`outputStereo`）を適用する"""
+    if query.outputStereo:
+        wave = np.array([wave, wave]).T
+    return wave

--- a/voicevox_engine/tts_pipeline/song_engine.py
+++ b/voicevox_engine/tts_pipeline/song_engine.py
@@ -1,0 +1,456 @@
+"""歌声音声合成エンジン"""
+
+from typing import Any, Final, Literal, TypeAlias
+
+import numpy as np
+from numpy.typing import NDArray
+
+from voicevox_engine.utility.core_version_utility import get_latest_version
+
+from ..core.core_adapter import CoreAdapter, DeviceSupport
+from ..core.core_initializer import MOCK_VER, CoreManager
+from ..core.core_wrapper import CoreWrapper
+from ..metas.Metas import StyleId
+from .audio_postprocessing import raw_wave_to_output_wave
+from .model import (
+    FrameAudioQuery,
+    FramePhoneme,
+    Note,
+    NoteId,
+    Score,
+)
+from .mora_mapping import mora_kana_to_mora_phonemes
+from .phoneme import Phoneme
+
+
+class SongInvalidInputError(Exception):
+    """Sing の不正な入力エラー"""
+
+    pass
+
+
+def _frame_query_to_sf_decoder_feature(
+    query: FrameAudioQuery,
+) -> tuple[NDArray[np.int64], NDArray[np.float32], NDArray[np.float32]]:
+    """歌声合成用のクエリからフレームごとの音素・音高・音量を得る"""
+
+    # 各データを分解・numpy配列に変換する
+    phonemes = []
+    phoneme_lengths = []
+
+    for phoneme in query.phonemes:
+        if phoneme.phoneme not in Phoneme._PHONEME_LIST:
+            msg = f"phoneme {phoneme.phoneme} is not valid"
+            raise SongInvalidInputError(msg)
+
+        phonemes.append(Phoneme(phoneme.phoneme).id)
+        phoneme_lengths.append(phoneme.frame_length)
+
+    phonemes_array = np.array(phonemes, dtype=np.int64)
+    phoneme_lengths_array = np.array(phoneme_lengths, dtype=np.int64)
+
+    frame_phonemes = np.repeat(phonemes_array, phoneme_lengths_array)
+    f0s = np.array(query.f0, dtype=np.float32)
+    volumes = np.array(query.volume, dtype=np.float32)
+
+    return frame_phonemes, f0s, volumes
+
+
+def _notes_to_keys_and_phonemes(
+    notes: list[Note],
+) -> tuple[
+    NDArray[np.int64],
+    NDArray[np.int64],
+    NDArray[np.int64],
+    NDArray[np.int64],
+    NDArray[np.int64],
+    list[NoteId | None],
+]:
+    """
+    ノート単位の長さ・モーラ情報や、音素列・音素ごとのキー列を作成する
+    Parameters
+    ----------
+    notes : list[Note]
+        ノート列
+    Returns
+    -------
+    note_lengths : NDArray[np.int64]
+        ノートの長さ列
+    note_consonants : NDArray[np.int64]
+        ノートの子音ID列
+    note_vowels : NDArray[np.int64]
+        ノートの母音ID列
+    phonemes : NDArray[np.int64]
+        音素列
+    phoneme_keys : NDArray[np.int64]
+        音素ごとのキー列
+    phoneme_note_ids : list[NoteId]
+        音素ごとのノートID列
+    """
+
+    note_lengths: list[int] = []
+    note_consonants: list[int] = []
+    note_vowels: list[int] = []
+    phonemes: list[int] = []
+    phoneme_keys: list[int] = []
+    phoneme_note_ids: list[NoteId | None] = []
+
+    for note in notes:
+        if note.lyric == "":
+            if note.key is not None:
+                msg = "lyricが空文字列の場合、keyはnullである必要があります。"
+                raise SongInvalidInputError(msg)
+            note_lengths.append(note.frame_length)
+            note_consonants.append(-1)
+            note_vowels.append(0)  # pau
+            phonemes.append(0)  # pau
+            phoneme_keys.append(-1)
+            phoneme_note_ids.append(note.id)
+        else:
+            if note.key is None:
+                msg = "keyがnullの場合、lyricは空文字列である必要があります。"
+                raise SongInvalidInputError(msg)
+
+            # TODO: 1ノートに複数のモーラがある場合の処理
+            mora_phonemes = mora_kana_to_mora_phonemes.get(
+                note.lyric  # type: ignore
+            ) or mora_kana_to_mora_phonemes.get(
+                _hira_to_kana(note.lyric)  # type: ignore
+            )
+            if mora_phonemes is None:
+                msg = f"lyricが不正です: {note.lyric}"
+                raise SongInvalidInputError(msg)
+
+            consonant, vowel = mora_phonemes
+            if consonant is None:
+                consonant_id = -1
+            else:
+                consonant_id = Phoneme(consonant).id
+            vowel_id = Phoneme(vowel).id
+
+            note_lengths.append(note.frame_length)
+            note_consonants.append(consonant_id)
+            note_vowels.append(vowel_id)
+            if consonant_id != -1:
+                phonemes.append(consonant_id)
+                phoneme_keys.append(note.key)
+                phoneme_note_ids.append(note.id)
+            phonemes.append(vowel_id)
+            phoneme_keys.append(note.key)
+            phoneme_note_ids.append(note.id)
+
+    # 各データをnumpy配列に変換する
+    note_lengths_array = np.array(note_lengths, dtype=np.int64)
+    note_consonants_array = np.array(note_consonants, dtype=np.int64)
+    note_vowels_array = np.array(note_vowels, dtype=np.int64)
+    phonemes_array = np.array(phonemes, dtype=np.int64)
+    phoneme_keys_array = np.array(phoneme_keys, dtype=np.int64)
+
+    return (
+        note_lengths_array,
+        note_consonants_array,
+        note_vowels_array,
+        phonemes_array,
+        phoneme_keys_array,
+        phoneme_note_ids,
+    )
+
+
+def _hira_to_kana(text: str) -> str:
+    """ひらがなをカタカナに変換する"""
+    return "".join(chr(ord(c) + 96) if "ぁ" <= c <= "ゔ" else c for c in text)
+
+
+def _calc_phoneme_lengths(
+    consonant_lengths: NDArray[np.int64],
+    note_durations: NDArray[np.int64],
+) -> NDArray[np.int64]:
+    """
+    子音長と音符長から音素長を計算する
+    ただし、母音はノートの頭にくるようにするため、
+    予測された子音長は前のノートの長さを超えないように調整される
+    """
+    phoneme_durations = []
+    for i in range(len(consonant_lengths)):
+        if i < len(consonant_lengths) - 1:
+            # 最初のノートは子音長が0の、pauである必要がある
+            if i == 0 and consonant_lengths[i] != 0:
+                msg = f"consonant_lengths[0] must be 0, but {consonant_lengths[0]}"
+                raise SongInvalidInputError(msg)
+
+            next_consonant_length = consonant_lengths[i + 1]
+            note_duration = note_durations[i]
+
+            # もし、次のノートの子音長が負になる場合、現在のノートの半分にする
+            # NOTE: 将来的にコアは非負になるのでこの処理は不要になる
+            if next_consonant_length < 0:
+                next_consonant_length = consonant_lengths[i + 1] = note_duration // 2
+            vowel_length = note_duration - next_consonant_length
+
+            # もし、現在のノートの母音長が負になる場合、
+            # 次のノートの子音長を現在のノートの半分にする
+            if vowel_length < 0:
+                next_consonant_length = consonant_lengths[i + 1] = note_duration // 2
+                vowel_length = note_duration - next_consonant_length
+
+            phoneme_durations.append(vowel_length)
+            if next_consonant_length > 0:
+                phoneme_durations.append(next_consonant_length)
+        else:
+            vowel_length = note_durations[i]
+            phoneme_durations.append(vowel_length)
+
+    phoneme_durations_array = np.array(phoneme_durations, dtype=np.int64)
+    return phoneme_durations_array
+
+
+class SongEngine:
+    """音声合成器（core）の管理/実行/プロキシと音声合成フロー"""
+
+    def __init__(self, core: CoreWrapper):
+        super().__init__()
+        self._core = CoreAdapter(core)
+
+    @property
+    def default_sampling_rate(self) -> int:
+        """合成される音声波形のデフォルトサンプリングレートを取得する。"""
+        return self._core.default_sampling_rate
+
+    @property
+    def supported_devices(self) -> DeviceSupport | None:
+        """合成時に各デバイスが利用可能か否かの一覧を取得する。"""
+        return self._core.supported_devices
+
+    def create_phoneme_and_f0_and_volume(
+        self,
+        score: Score,
+        style_id: StyleId,
+    ) -> tuple[list[FramePhoneme], list[float], list[float]]:
+        """歌声合成用の楽譜・スタイルIDに基づいてフレームごとの音素・音高・音量を生成する"""
+        notes = score.notes
+
+        (
+            note_lengths_array,
+            note_consonants_array,
+            note_vowels_array,
+            phonemes_array,
+            phoneme_keys_array,
+            phoneme_note_ids,
+        ) = _notes_to_keys_and_phonemes(notes)
+
+        # コアを用いて子音長を生成する
+        consonant_lengths = self._core.safe_predict_sing_consonant_length_forward(
+            note_consonants_array, note_vowels_array, note_lengths_array, style_id
+        )
+
+        # 予測した子音長を元に、すべての音素長を計算する
+        phoneme_lengths = _calc_phoneme_lengths(consonant_lengths, note_lengths_array)
+
+        # 時間スケールを変更する（音素 → フレーム）
+        frame_phonemes = np.repeat(phonemes_array, phoneme_lengths)
+        frame_keys = np.repeat(phoneme_keys_array, phoneme_lengths)
+
+        # コアを用いて音高を生成する
+        f0s = self._core.safe_predict_sing_f0_forward(
+            frame_phonemes, frame_keys, style_id
+        )
+
+        # コアを用いて音量を生成する
+        # FIXME: 変数名のsいらない？
+        volumes = self._core.safe_predict_sing_volume_forward(
+            frame_phonemes, frame_keys, f0s, style_id
+        )
+
+        phoneme_data_list = [
+            FramePhoneme(
+                phoneme=Phoneme._PHONEME_LIST[phoneme_id],
+                frame_length=phoneme_duration,
+                note_id=phoneme_note_id,
+            )
+            for phoneme_id, phoneme_duration, phoneme_note_id in zip(
+                phonemes_array, phoneme_lengths, phoneme_note_ids, strict=True
+            )
+        ]
+
+        # mypyの型チェックを通すために明示的に型を付ける
+        f0_list: list[float] = f0s.tolist()  # type: ignore
+        volume_list: list[float] = volumes.tolist()  # type: ignore
+
+        return phoneme_data_list, f0_list, volume_list
+
+    def create_f0_from_phoneme(
+        self,
+        score: Score,
+        phonemes: list[FramePhoneme],
+        style_id: StyleId,
+    ) -> list[float]:
+        """歌声合成用の音素・スタイルIDに基づいて基本周波数を生成する"""
+        notes = score.notes
+
+        (
+            _,
+            _,
+            _,
+            phonemes_array_from_notes,
+            phoneme_keys_array,
+            _,
+        ) = _notes_to_keys_and_phonemes(notes)
+
+        phonemes_array = np.array(
+            [Phoneme(p.phoneme).id for p in phonemes], dtype=np.int64
+        )
+        phoneme_lengths = np.array([p.frame_length for p in phonemes], dtype=np.int64)
+
+        # notesから生成した音素系列と、FrameAudioQueryが持つ音素系列が一致しているか確認
+        # この確認によって、phoneme_keys_arrayが使用可能かを間接的に確認する
+        try:
+            all_equals = np.all(phonemes_array == phonemes_array_from_notes)
+        except ValueError:
+            # 長さが異なる場合はValueErrorが発生するので、Falseとする
+            # mypyを通すためにnp.bool_でラップする
+            all_equals = np.bool_(False)
+
+        if not all_equals:
+            msg = "Scoreから抽出した音素列とFrameAudioQueryから抽出した音素列が一致しません。"
+            raise SongInvalidInputError(msg)
+
+        # 時間スケールを変更する（音素 → フレーム）
+        frame_phonemes = np.repeat(phonemes_array, phoneme_lengths)
+        frame_keys = np.repeat(phoneme_keys_array, phoneme_lengths)
+
+        # コアを用いて音高を生成する
+        f0s = self._core.safe_predict_sing_f0_forward(
+            frame_phonemes, frame_keys, style_id
+        )
+
+        # mypyの型チェックを通すために明示的に型を付ける
+        f0_list: list[float] = f0s.tolist()  # type: ignore
+
+        return f0_list
+
+    def create_volume_from_phoneme_and_f0(
+        self,
+        score: Score,
+        phonemes: list[FramePhoneme],
+        f0s: list[float],
+        style_id: StyleId,
+    ) -> list[float]:
+        """歌声合成用の音素・音高・スタイルIDに基づいて音量を生成する"""
+        notes = score.notes
+
+        (
+            _,
+            _,
+            _,
+            phonemes_array_from_notes,
+            phoneme_keys_array,
+            _,
+        ) = _notes_to_keys_and_phonemes(notes)
+
+        phonemes_array = np.array(
+            [Phoneme(p.phoneme).id for p in phonemes], dtype=np.int64
+        )
+        phoneme_lengths = np.array([p.frame_length for p in phonemes], dtype=np.int64)
+        f0_array = np.array(f0s, dtype=np.float32)
+
+        # notesから生成した音素系列と、FrameAudioQueryが持つ音素系列が一致しているか確認
+        # この確認によって、phoneme_keys_arrayが使用可能かを間接的に確認する
+        try:
+            all_equals = np.all(phonemes_array == phonemes_array_from_notes)
+        except ValueError:
+            # 長さが異なる場合はValueErrorが発生するので、Falseとする
+            # mypyを通すためにnp.bool_でラップする
+            all_equals = np.bool_(False)
+
+        if not all_equals:
+            msg = "Scoreから抽出した音素列とFrameAudioQueryから抽出した音素列が一致しません。"
+            raise SongInvalidInputError(msg)
+
+        # 時間スケールを変更する（音素 → フレーム）
+        frame_phonemes = np.repeat(phonemes_array, phoneme_lengths)
+        frame_keys = np.repeat(phoneme_keys_array, phoneme_lengths)
+
+        # コアを用いて音量を生成する
+        volumes = self._core.safe_predict_sing_volume_forward(
+            frame_phonemes, frame_keys, f0_array, style_id
+        )
+
+        # mypyの型チェックを通すために明示的に型を付ける
+        volume_list: list[float] = volumes.tolist()  # type: ignore
+
+        return volume_list
+
+    def frame_synthesize_wave(
+        self,
+        query: FrameAudioQuery,
+        style_id: StyleId,
+    ) -> NDArray[np.float32]:
+        """歌声合成用のクエリ・スタイルIDに基づいて音声波形を生成する"""
+
+        phoneme, f0, volume = _frame_query_to_sf_decoder_feature(query)
+        raw_wave, sr_raw_wave = self._core.safe_sf_decode_forward(
+            phoneme, f0, volume, style_id
+        )
+        wave = raw_wave_to_output_wave(query, raw_wave, sr_raw_wave)
+        return wave
+
+
+class SongEngineNotFound(Exception):
+    """SongEngine が見つからないエラー"""
+
+    def __init__(self, *args: list[Any], version: str, **kwargs: dict[str, Any]):
+        """SongEngine のバージョン番号を用いてインスタンス化する。"""
+        super().__init__(*args, **kwargs)
+        self.version = version
+
+
+class MockSongEngineNotFound(Exception):
+    """モック SongEngine が見つからないエラー"""
+
+
+LatestVersion: TypeAlias = Literal["LATEST_VERSION"]
+LATEST_VERSION: Final[LatestVersion] = "LATEST_VERSION"
+
+
+class SongEngineManager:
+    """Song エンジンの集まりを一括管理するマネージャー"""
+
+    def __init__(self) -> None:
+        self._engines: dict[str, SongEngine] = {}
+
+    def versions(self) -> list[str]:
+        """登録されたエンジンのバージョン一覧を取得する。"""
+        return list(self._engines.keys())
+
+    def _latest_version(self) -> str:
+        return get_latest_version(self.versions())
+
+    def register_engine(self, engine: SongEngine, version: str) -> None:
+        """エンジンを登録する。"""
+        self._engines[version] = engine
+
+    def get_song_engine(self, version: str | LatestVersion) -> SongEngine:
+        """指定バージョンのエンジンを取得する。"""
+        if version == LATEST_VERSION:
+            return self._engines[self._latest_version()]
+        elif version in self._engines:
+            return self._engines[version]
+        elif version == MOCK_VER:
+            raise MockSongEngineNotFound()
+        else:
+            raise SongEngineNotFound(version=version)
+
+
+def make_song_engines_from_cores(core_manager: CoreManager) -> SongEngineManager:
+    """コア一覧からSongエンジン一覧を生成する"""
+    # FIXME: `MOCK_VER` を循環 import 無しに `initialize_cores()` 関連モジュールから import する
+    MOCK_VER = "0.0.0"
+    song_engines = SongEngineManager()
+    for ver, core in core_manager.items():
+        if ver == MOCK_VER:
+            from ..dev.song_engine.mock import MockSongEngine
+
+            song_engines.register_engine(MockSongEngine(), ver)
+        else:
+            song_engines.register_engine(SongEngine(core.core), ver)
+    return song_engines

--- a/voicevox_engine/tts_pipeline/tts_engine.py
+++ b/voicevox_engine/tts_pipeline/tts_engine.py
@@ -1,4 +1,4 @@
-"""音声合成エンジン"""
+"""テキスト音声合成エンジン"""
 
 import copy
 import math
@@ -6,7 +6,6 @@ from typing import Any, Final, Literal, TypeAlias
 
 import numpy as np
 from numpy.typing import NDArray
-from soxr import resample
 
 from voicevox_engine.utility.core_version_utility import get_latest_version
 
@@ -15,17 +14,13 @@ from ..core.core_initializer import MOCK_VER, CoreManager
 from ..core.core_wrapper import CoreWrapper
 from ..metas.Metas import StyleId
 from ..model import AudioQuery
+from .audio_postprocessing import raw_wave_to_output_wave
 from .kana_converter import parse_kana
 from .model import (
     AccentPhrase,
-    FrameAudioQuery,
-    FramePhoneme,
     Mora,
-    Note,
-    NoteId,
-    Score,
 )
-from .mora_mapping import mora_kana_to_mora_phonemes, mora_phonemes_to_mora_kana
+from .mora_mapping import mora_phonemes_to_mora_kana
 from .phoneme import Phoneme
 from .text_analyzer import text_to_accent_phrases
 
@@ -35,8 +30,8 @@ UPSPEAK_PITCH_ADD = 0.3
 UPSPEAK_PITCH_MAX = 6.5
 
 
-class TalkSingInvalidInputError(Exception):
-    """Talk と Sing の不正な入力エラー"""
+class TalkInvalidInputError(Exception):
+    """Talk の不正な入力エラー"""
 
     pass
 
@@ -201,33 +196,6 @@ def _apply_intonation_scale(moras: list[Mora], query: AudioQuery) -> list[Mora]:
     return moras
 
 
-def _apply_volume_scale(
-    wave: NDArray[np.float32], query: AudioQuery | FrameAudioQuery
-) -> NDArray[np.float32]:
-    """音声波形へ音声合成用のクエリがもつ音量スケール（`volumeScale`）を適用する"""
-    return wave * query.volumeScale
-
-
-def _apply_output_sampling_rate(
-    wave: NDArray[np.float32], sr_wave: float, query: AudioQuery | FrameAudioQuery
-) -> NDArray[np.float32]:
-    """音声波形へ音声合成用のクエリがもつ出力サンプリングレート（`outputSamplingRate`）を適用する"""
-    # サンプリングレート一致のときはスルー
-    if sr_wave == query.outputSamplingRate:
-        return wave
-    wave = resample(wave, sr_wave, query.outputSamplingRate)
-    return wave
-
-
-def _apply_output_stereo(
-    wave: NDArray[np.float32], query: AudioQuery | FrameAudioQuery
-) -> NDArray[np.float32]:
-    """音声波形へ音声合成用のクエリがもつステレオ出力設定（`outputStereo`）を適用する"""
-    if query.outputStereo:
-        wave = np.array([wave, wave]).T
-    return wave
-
-
 def _query_to_decoder_feature(
     query: AudioQuery,
 ) -> tuple[NDArray[np.float32], NDArray[np.float32]]:
@@ -252,191 +220,6 @@ def _query_to_decoder_feature(
     f0 = np.repeat(f0, frame_per_mora)
 
     return phoneme, f0
-
-
-def raw_wave_to_output_wave(
-    query: AudioQuery | FrameAudioQuery, wave: NDArray[np.float32], sr_wave: int
-) -> NDArray[np.float32]:
-    """生音声波形に音声合成用のクエリを適用して出力音声波形を生成する"""
-    wave = _apply_volume_scale(wave, query)
-    wave = _apply_output_sampling_rate(wave, sr_wave, query)
-    wave = _apply_output_stereo(wave, query)
-    return wave
-
-
-def _hira_to_kana(text: str) -> str:
-    """ひらがなをカタカナに変換する"""
-    return "".join(chr(ord(c) + 96) if "ぁ" <= c <= "ゔ" else c for c in text)
-
-
-def _calc_phoneme_lengths(
-    consonant_lengths: NDArray[np.int64],
-    note_durations: NDArray[np.int64],
-) -> NDArray[np.int64]:
-    """
-    子音長と音符長から音素長を計算する
-    ただし、母音はノートの頭にくるようにするため、
-    予測された子音長は前のノートの長さを超えないように調整される
-    """
-    phoneme_durations = []
-    for i in range(len(consonant_lengths)):
-        if i < len(consonant_lengths) - 1:
-            # 最初のノートは子音長が0の、pauである必要がある
-            if i == 0 and consonant_lengths[i] != 0:
-                msg = f"consonant_lengths[0] must be 0, but {consonant_lengths[0]}"
-                raise TalkSingInvalidInputError(msg)
-
-            next_consonant_length = consonant_lengths[i + 1]
-            note_duration = note_durations[i]
-
-            # もし、次のノートの子音長が負になる場合、現在のノートの半分にする
-            # NOTE: 将来的にコアは非負になるのでこの処理は不要になる
-            if next_consonant_length < 0:
-                next_consonant_length = consonant_lengths[i + 1] = note_duration // 2
-            vowel_length = note_duration - next_consonant_length
-
-            # もし、現在のノートの母音長が負になる場合、
-            # 次のノートの子音長を現在のノートの半分にする
-            if vowel_length < 0:
-                next_consonant_length = consonant_lengths[i + 1] = note_duration // 2
-                vowel_length = note_duration - next_consonant_length
-
-            phoneme_durations.append(vowel_length)
-            if next_consonant_length > 0:
-                phoneme_durations.append(next_consonant_length)
-        else:
-            vowel_length = note_durations[i]
-            phoneme_durations.append(vowel_length)
-
-    phoneme_durations_array = np.array(phoneme_durations, dtype=np.int64)
-    return phoneme_durations_array
-
-
-def _notes_to_keys_and_phonemes(
-    notes: list[Note],
-) -> tuple[
-    NDArray[np.int64],
-    NDArray[np.int64],
-    NDArray[np.int64],
-    NDArray[np.int64],
-    NDArray[np.int64],
-    list[NoteId | None],
-]:
-    """
-    ノート単位の長さ・モーラ情報や、音素列・音素ごとのキー列を作成する
-    Parameters
-    ----------
-    notes : list[Note]
-        ノート列
-    Returns
-    -------
-    note_lengths : NDArray[np.int64]
-        ノートの長さ列
-    note_consonants : NDArray[np.int64]
-        ノートの子音ID列
-    note_vowels : NDArray[np.int64]
-        ノートの母音ID列
-    phonemes : NDArray[np.int64]
-        音素列
-    phoneme_keys : NDArray[np.int64]
-        音素ごとのキー列
-    phoneme_note_ids : list[NoteId]
-        音素ごとのノートID列
-    """
-
-    note_lengths: list[int] = []
-    note_consonants: list[int] = []
-    note_vowels: list[int] = []
-    phonemes: list[int] = []
-    phoneme_keys: list[int] = []
-    phoneme_note_ids: list[NoteId | None] = []
-
-    for note in notes:
-        if note.lyric == "":
-            if note.key is not None:
-                msg = "lyricが空文字列の場合、keyはnullである必要があります。"
-                raise TalkSingInvalidInputError(msg)
-            note_lengths.append(note.frame_length)
-            note_consonants.append(-1)
-            note_vowels.append(0)  # pau
-            phonemes.append(0)  # pau
-            phoneme_keys.append(-1)
-            phoneme_note_ids.append(note.id)
-        else:
-            if note.key is None:
-                msg = "keyがnullの場合、lyricは空文字列である必要があります。"
-                raise TalkSingInvalidInputError(msg)
-
-            # TODO: 1ノートに複数のモーラがある場合の処理
-            mora_phonemes = mora_kana_to_mora_phonemes.get(
-                note.lyric  # type: ignore
-            ) or mora_kana_to_mora_phonemes.get(
-                _hira_to_kana(note.lyric)  # type: ignore
-            )
-            if mora_phonemes is None:
-                msg = f"lyricが不正です: {note.lyric}"
-                raise TalkSingInvalidInputError(msg)
-
-            consonant, vowel = mora_phonemes
-            if consonant is None:
-                consonant_id = -1
-            else:
-                consonant_id = Phoneme(consonant).id
-            vowel_id = Phoneme(vowel).id
-
-            note_lengths.append(note.frame_length)
-            note_consonants.append(consonant_id)
-            note_vowels.append(vowel_id)
-            if consonant_id != -1:
-                phonemes.append(consonant_id)
-                phoneme_keys.append(note.key)
-                phoneme_note_ids.append(note.id)
-            phonemes.append(vowel_id)
-            phoneme_keys.append(note.key)
-            phoneme_note_ids.append(note.id)
-
-    # 各データをnumpy配列に変換する
-    note_lengths_array = np.array(note_lengths, dtype=np.int64)
-    note_consonants_array = np.array(note_consonants, dtype=np.int64)
-    note_vowels_array = np.array(note_vowels, dtype=np.int64)
-    phonemes_array = np.array(phonemes, dtype=np.int64)
-    phoneme_keys_array = np.array(phoneme_keys, dtype=np.int64)
-
-    return (
-        note_lengths_array,
-        note_consonants_array,
-        note_vowels_array,
-        phonemes_array,
-        phoneme_keys_array,
-        phoneme_note_ids,
-    )
-
-
-def _frame_query_to_sf_decoder_feature(
-    query: FrameAudioQuery,
-) -> tuple[NDArray[np.int64], NDArray[np.float32], NDArray[np.float32]]:
-    """歌声合成用のクエリからフレームごとの音素・音高・音量を得る"""
-
-    # 各データを分解・numpy配列に変換する
-    phonemes = []
-    phoneme_lengths = []
-
-    for phoneme in query.phonemes:
-        if phoneme.phoneme not in Phoneme._PHONEME_LIST:
-            msg = f"phoneme {phoneme.phoneme} is not valid"
-            raise TalkSingInvalidInputError(msg)
-
-        phonemes.append(Phoneme(phoneme.phoneme).id)
-        phoneme_lengths.append(phoneme.frame_length)
-
-    phonemes_array = np.array(phonemes, dtype=np.int64)
-    phoneme_lengths_array = np.array(phoneme_lengths, dtype=np.int64)
-
-    frame_phonemes = np.repeat(phonemes_array, phoneme_lengths_array)
-    f0s = np.array(query.f0, dtype=np.float32)
-    volumes = np.array(query.volume, dtype=np.float32)
-
-    return frame_phonemes, f0s, volumes
 
 
 class TTSEngine:
@@ -598,181 +381,6 @@ class TTSEngine:
         """指定されたスタイル ID に関する合成機能が初期化済みか否かを取得する。"""
         return self._core.is_initialized_style_id_synthesis(style_id)
 
-    # FIXME: sing用のエンジンに移すかクラス名変える
-    # 返す値の総称を考え、関数名を変更する
-    def create_sing_phoneme_and_f0_and_volume(
-        self,
-        score: Score,
-        style_id: StyleId,
-    ) -> tuple[list[FramePhoneme], list[float], list[float]]:
-        """歌声合成用の楽譜・スタイルIDに基づいてフレームごとの音素・音高・音量を生成する"""
-        notes = score.notes
-
-        (
-            note_lengths_array,
-            note_consonants_array,
-            note_vowels_array,
-            phonemes_array,
-            phoneme_keys_array,
-            phoneme_note_ids,
-        ) = _notes_to_keys_and_phonemes(notes)
-
-        # コアを用いて子音長を生成する
-        consonant_lengths = self._core.safe_predict_sing_consonant_length_forward(
-            note_consonants_array, note_vowels_array, note_lengths_array, style_id
-        )
-
-        # 予測した子音長を元に、すべての音素長を計算する
-        phoneme_lengths = _calc_phoneme_lengths(consonant_lengths, note_lengths_array)
-
-        # 時間スケールを変更する（音素 → フレーム）
-        frame_phonemes = np.repeat(phonemes_array, phoneme_lengths)
-        frame_keys = np.repeat(phoneme_keys_array, phoneme_lengths)
-
-        # コアを用いて音高を生成する
-        f0s = self._core.safe_predict_sing_f0_forward(
-            frame_phonemes, frame_keys, style_id
-        )
-
-        # コアを用いて音量を生成する
-        # FIXME: 変数名のsいらない？
-        volumes = self._core.safe_predict_sing_volume_forward(
-            frame_phonemes, frame_keys, f0s, style_id
-        )
-
-        phoneme_data_list = [
-            FramePhoneme(
-                phoneme=Phoneme._PHONEME_LIST[phoneme_id],
-                frame_length=phoneme_duration,
-                note_id=phoneme_note_id,
-            )
-            for phoneme_id, phoneme_duration, phoneme_note_id in zip(
-                phonemes_array, phoneme_lengths, phoneme_note_ids, strict=True
-            )
-        ]
-
-        # mypyの型チェックを通すために明示的に型を付ける
-        f0_list: list[float] = f0s.tolist()  # type: ignore
-        volume_list: list[float] = volumes.tolist()  # type: ignore
-
-        return phoneme_data_list, f0_list, volume_list
-
-    def create_sing_f0_from_phoneme(
-        self,
-        score: Score,
-        phonemes: list[FramePhoneme],
-        style_id: StyleId,
-    ) -> list[float]:
-        """歌声合成用の音素・スタイルIDに基づいて基本周波数を生成する"""
-        notes = score.notes
-
-        (
-            _,
-            _,
-            _,
-            phonemes_array_from_notes,
-            phoneme_keys_array,
-            _,
-        ) = _notes_to_keys_and_phonemes(notes)
-
-        phonemes_array = np.array(
-            [Phoneme(p.phoneme).id for p in phonemes], dtype=np.int64
-        )
-        phoneme_lengths = np.array([p.frame_length for p in phonemes], dtype=np.int64)
-
-        # notesから生成した音素系列と、FrameAudioQueryが持つ音素系列が一致しているか確認
-        # この確認によって、phoneme_keys_arrayが使用可能かを間接的に確認する
-        try:
-            all_equals = np.all(phonemes_array == phonemes_array_from_notes)
-        except ValueError:
-            # 長さが異なる場合はValueErrorが発生するので、Falseとする
-            # mypyを通すためにnp.bool_でラップする
-            all_equals = np.bool_(False)
-
-        if not all_equals:
-            msg = "Scoreから抽出した音素列とFrameAudioQueryから抽出した音素列が一致しません。"
-            raise TalkSingInvalidInputError(msg)
-
-        # 時間スケールを変更する（音素 → フレーム）
-        frame_phonemes = np.repeat(phonemes_array, phoneme_lengths)
-        frame_keys = np.repeat(phoneme_keys_array, phoneme_lengths)
-
-        # コアを用いて音高を生成する
-        f0s = self._core.safe_predict_sing_f0_forward(
-            frame_phonemes, frame_keys, style_id
-        )
-
-        # mypyの型チェックを通すために明示的に型を付ける
-        f0_list: list[float] = f0s.tolist()  # type: ignore
-
-        return f0_list
-
-    def create_sing_volume_from_phoneme_and_f0(
-        self,
-        score: Score,
-        phonemes: list[FramePhoneme],
-        f0s: list[float],
-        style_id: StyleId,
-    ) -> list[float]:
-        """歌声合成用の音素・音高・スタイルIDに基づいて音量を生成する"""
-        notes = score.notes
-
-        (
-            _,
-            _,
-            _,
-            phonemes_array_from_notes,
-            phoneme_keys_array,
-            _,
-        ) = _notes_to_keys_and_phonemes(notes)
-
-        phonemes_array = np.array(
-            [Phoneme(p.phoneme).id for p in phonemes], dtype=np.int64
-        )
-        phoneme_lengths = np.array([p.frame_length for p in phonemes], dtype=np.int64)
-        f0_array = np.array(f0s, dtype=np.float32)
-
-        # notesから生成した音素系列と、FrameAudioQueryが持つ音素系列が一致しているか確認
-        # この確認によって、phoneme_keys_arrayが使用可能かを間接的に確認する
-        try:
-            all_equals = np.all(phonemes_array == phonemes_array_from_notes)
-        except ValueError:
-            # 長さが異なる場合はValueErrorが発生するので、Falseとする
-            # mypyを通すためにnp.bool_でラップする
-            all_equals = np.bool_(False)
-
-        if not all_equals:
-            msg = "Scoreから抽出した音素列とFrameAudioQueryから抽出した音素列が一致しません。"
-            raise TalkSingInvalidInputError(msg)
-
-        # 時間スケールを変更する（音素 → フレーム）
-        frame_phonemes = np.repeat(phonemes_array, phoneme_lengths)
-        frame_keys = np.repeat(phoneme_keys_array, phoneme_lengths)
-
-        # コアを用いて音量を生成する
-        volumes = self._core.safe_predict_sing_volume_forward(
-            frame_phonemes, frame_keys, f0_array, style_id
-        )
-
-        # mypyの型チェックを通すために明示的に型を付ける
-        volume_list: list[float] = volumes.tolist()  # type: ignore
-
-        return volume_list
-
-    def frame_synthesize_wave(
-        self,
-        query: FrameAudioQuery,
-        style_id: StyleId,
-    ) -> NDArray[np.float32]:
-        """歌声合成用のクエリ・スタイルIDに基づいて音声波形を生成する"""
-
-        phoneme, f0, volume = _frame_query_to_sf_decoder_feature(query)
-        raw_wave, sr_raw_wave = self._core.safe_sf_decode_forward(
-            phoneme, f0, volume, style_id
-        )
-        wave = raw_wave_to_output_wave(query, raw_wave, sr_raw_wave)
-        return wave
-
 
 class TTSEngineNotFound(Exception):
     """TTSEngine が見つからないエラー"""
@@ -808,7 +416,7 @@ class TTSEngineManager:
         """エンジンを登録する。"""
         self._engines[version] = engine
 
-    def get_engine(self, version: str | LatestVersion) -> TTSEngine:
+    def get_tts_engine(self, version: str | LatestVersion) -> TTSEngine:
         """指定バージョンのエンジンを取得する。"""
         if version == LATEST_VERSION:
             return self._engines[self._latest_version()]


### PR DESCRIPTION
## 内容
- tss_pipeline の中に song_engine.py を追加して、コードを分離しました
- 共通部分は audio_postprocessing.py に分離しました

たたき台レベルなので、色々ツッコミよろしくお願いします。
例えば、クラス名は Song なのに、API は sing とか…
## 関連 Issue

close #1032