### PR TITLE
fix: [project-e2k] `from_english_kana`で作成する`NjdFeature`の`string`をアルファベットに修正

### DIFF
--- a/voicevox_engine/tts_pipeline/njd_feature_processor.py
+++ b/voicevox_engine/tts_pipeline/njd_feature_processor.py
@@ -48,7 +48,7 @@ class NjdFeature:
             )
         )
         return cls(
-            string=kana,
+            string=english,
             pos="名詞",
             pos_group1="固有名詞",
             pos_group2="一般",


### PR DESCRIPTION
## 内容

題の通りです。
stringに入るのは読みのカタカナではなくアルファベットが適切なので修正します。

```
>>> import pyopenjtalk
>>> pyopenjtalk.run_frontend("Test") 
[{'string': 'Ｔｅｓｔ', 'pos': '名詞', 'pos_group1': 'サ変接続', 'pos_group2': '*', 'pos_group3': '*', 'ctype': '*', 'cform': '*', 'orig': 'Ｔｅｓｔ', 'read': 'テスト', 'pron': 'テス’ト', 'acc': 1, 'mora_size': 3, 'chain_rule': 'C1', 'chain_flag': -1}]
```

## 関連 Issue

ref #1524 
ref #1548 

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
