### PR TITLE
refactor: generate_licenses.py

### DIFF
--- a/tools/generate_licenses.py
+++ b/tools/generate_licenses.py
@@ -99,14 +99,17 @@ def generate_licenses() -> list[License]:
             text_url = "https://raw.githubusercontent.com/dofuuz/python-soxr/v0.3.6/LICENSE.txt"
             license_json["LicenseText"] = get_license_text(text_url)
 
-        license = License(
-            package_name=license_json["Name"],
-            package_version=license_json["Version"],
-            license_name=license_json["License"],
-            license_text=license_json["LicenseText"],
-            license_text_type="raw",
+        licenses.append(
+            License(
+                package_name=license_json["Name"],
+                package_version=license_json["Version"],
+                license_name=license_json["License"],
+                license_text=license_json["LicenseText"],
+                license_text_type="raw",
+            )
         )
 
+    for license in licenses:
         # ライセンスを確認する
         license_names_str = license.license_name or ""
         license_names = license_names_str.split("; ")
@@ -120,8 +123,6 @@ def generate_licenses() -> list[License]:
                 raise LicenseError(
                     f"ライセンス違反: {license.package_name} is {license.license_name}"
                 )
-
-        licenses.append(license)
 
     python_version = "3.11.9"
 

--- a/tools/generate_licenses.py
+++ b/tools/generate_licenses.py
@@ -70,15 +70,15 @@ def generate_licenses() -> list[License]:
     licenses_json = json.loads(pip_licenses_output)
 
     package_to_license_url = {
+        "distlib": "https://bitbucket.org/pypa/distlib/raw/7d93712134b28401407da27382f2b6236c87623a/LICENSE.txt",
         "future": "https://raw.githubusercontent.com/PythonCharmers/python-future/master/LICENSE.txt",
+        "jsonschema": "https://raw.githubusercontent.com/python-jsonschema/jsonschema/dbc398245a583cb2366795dc529ae042d10c1577/COPYING",
+        "lockfile": "https://opendev.org/openstack/pylockfile/raw/tag/0.12.2/LICENSE",
         "pefile": "https://raw.githubusercontent.com/erocarrera/pefile/master/LICENSE",
+        "platformdirs": "https://raw.githubusercontent.com/platformdirs/platformdirs/aa671aaa97913c7b948567f4d9c77d4f98bfa134/LICENSE",
         "pyopenjtalk": "https://raw.githubusercontent.com/r9y9/pyopenjtalk/master/LICENSE.md",
         "python-multipart": "https://raw.githubusercontent.com/andrew-d/python-multipart/master/LICENSE.txt",
         "romkan": "https://raw.githubusercontent.com/soimort/python-romkan/master/LICENSE",
-        "distlib": "https://bitbucket.org/pypa/distlib/raw/7d93712134b28401407da27382f2b6236c87623a/LICENSE.txt",
-        "jsonschema": "https://raw.githubusercontent.com/python-jsonschema/jsonschema/dbc398245a583cb2366795dc529ae042d10c1577/COPYING",
-        "lockfile": "https://opendev.org/openstack/pylockfile/raw/tag/0.12.2/LICENSE",
-        "platformdirs": "https://raw.githubusercontent.com/platformdirs/platformdirs/aa671aaa97913c7b948567f4d9c77d4f98bfa134/LICENSE",
         "webencodings": "https://raw.githubusercontent.com/gsnedders/python-webencodings/fa2cb5d75ab41e63ace691bc0825d3432ba7d694/LICENSE",
     }
 

--- a/tools/generate_licenses.py
+++ b/tools/generate_licenses.py
@@ -24,15 +24,16 @@ class License:
         self.package_version = package_version
         self.license_name = license_name
 
-        if license_text_type == "raw":
-            self.license_text = license_text
-        elif license_text_type == "local_address":
-            # ライセンステキストをローカルのライセンスファイルから抽出する
-            self.license_text = Path(license_text).read_text(encoding="utf8")
-        elif license_text_type == "remote_address":
-            self.license_text = get_license_text(license_text)
-        else:
-            assert_never("型で保護され実行されないはずのパスが実行されました")
+        match license_text_type:
+            case "raw":
+                self.license_text = license_text
+            case "local_address":
+                # ライセンステキストをローカルのライセンスファイルから抽出する
+                self.license_text = Path(license_text).read_text(encoding="utf8")
+            case "remote_address":
+                self.license_text = get_license_text(license_text)
+            case _:
+                assert_never("型で保護され実行されないはずのパスが実行されました")
 
 
 def get_license_text(text_url: str) -> str:

--- a/tools/generate_licenses.py
+++ b/tools/generate_licenses.py
@@ -68,49 +68,32 @@ def generate_licenses() -> list[License]:
         ) from err
 
     licenses_json = json.loads(pip_licenses_output)
+
+    package_to_license_url = {
+        "future": "https://raw.githubusercontent.com/PythonCharmers/python-future/master/LICENSE.txt",
+        "pefile": "https://raw.githubusercontent.com/erocarrera/pefile/master/LICENSE",
+        "pyopenjtalk": "https://raw.githubusercontent.com/r9y9/pyopenjtalk/master/LICENSE.md",
+        "python-multipart": "https://raw.githubusercontent.com/andrew-d/python-multipart/master/LICENSE.txt",
+        "romkan": "https://raw.githubusercontent.com/soimort/python-romkan/master/LICENSE",
+        "distlib": "https://bitbucket.org/pypa/distlib/raw/7d93712134b28401407da27382f2b6236c87623a/LICENSE.txt",
+        "jsonschema": "https://raw.githubusercontent.com/python-jsonschema/jsonschema/dbc398245a583cb2366795dc529ae042d10c1577/COPYING",
+        "lockfile": "https://opendev.org/openstack/pylockfile/raw/tag/0.12.2/LICENSE",
+        "platformdirs": "https://raw.githubusercontent.com/platformdirs/platformdirs/aa671aaa97913c7b948567f4d9c77d4f98bfa134/LICENSE",
+        "webencodings": "https://raw.githubusercontent.com/gsnedders/python-webencodings/fa2cb5d75ab41e63ace691bc0825d3432ba7d694/LICENSE",
+    }
+
     for license_json in licenses_json:
         # ライセンス文を pip 外で取得されたもので上書きする
         package_name: str = license_json["Name"].lower()
         if license_json["LicenseText"] == "UNKNOWN":
             if package_name == "core" and license_json["Version"] == "0.0.0":
                 continue
-            elif package_name == "future":
-                text_url = "https://raw.githubusercontent.com/PythonCharmers/python-future/master/LICENSE.txt"
-                license_json["LicenseText"] = get_license_text(text_url)
-            elif package_name == "pefile":
-                text_url = (
-                    "https://raw.githubusercontent.com/erocarrera/pefile/master/LICENSE"
-                )
-                license_json["LicenseText"] = get_license_text(text_url)
-            elif package_name == "pyopenjtalk":
-                text_url = "https://raw.githubusercontent.com/r9y9/pyopenjtalk/master/LICENSE.md"
-                license_json["LicenseText"] = get_license_text(text_url)
-            elif package_name == "python-multipart":
-                text_url = "https://raw.githubusercontent.com/andrew-d/python-multipart/master/LICENSE.txt"
-                license_json["LicenseText"] = get_license_text(text_url)
-            elif package_name == "romkan":
-                text_url = "https://raw.githubusercontent.com/soimort/python-romkan/master/LICENSE"
-                license_json["LicenseText"] = get_license_text(text_url)
-            elif package_name == "distlib":
-                text_url = "https://bitbucket.org/pypa/distlib/raw/7d93712134b28401407da27382f2b6236c87623a/LICENSE.txt"
-                license_json["LicenseText"] = get_license_text(text_url)
-            elif package_name == "jsonschema":
-                text_url = "https://raw.githubusercontent.com/python-jsonschema/jsonschema/dbc398245a583cb2366795dc529ae042d10c1577/COPYING"
-                license_json["LicenseText"] = get_license_text(text_url)
-            elif package_name == "lockfile":
-                text_url = (
-                    "https://opendev.org/openstack/pylockfile/raw/tag/0.12.2/LICENSE"
-                )
-                license_json["LicenseText"] = get_license_text(text_url)
-            elif package_name == "platformdirs":
-                text_url = "https://raw.githubusercontent.com/platformdirs/platformdirs/aa671aaa97913c7b948567f4d9c77d4f98bfa134/LICENSE"
-                license_json["LicenseText"] = get_license_text(text_url)
-            elif package_name == "webencodings":
-                text_url = "https://raw.githubusercontent.com/gsnedders/python-webencodings/fa2cb5d75ab41e63ace691bc0825d3432ba7d694/LICENSE"
-                license_json["LicenseText"] = get_license_text(text_url)
-            else:
+            if package_name not in package_to_license_url:
                 # ライセンスがpypiに無い
                 raise Exception(f"No License info provided for {package_name}")
+            text_url = package_to_license_url[package_name]
+            license_json["LicenseText"] = get_license_text(text_url)
+
         # soxr
         if package_name == "soxr":
             text_url = "https://raw.githubusercontent.com/dofuuz/python-soxr/v0.3.6/LICENSE.txt"

--- a/tools/generate_licenses.py
+++ b/tools/generate_licenses.py
@@ -69,60 +69,8 @@ def generate_licenses() -> list[License]:
 
     licenses_json = json.loads(pip_licenses_output)
 
-    package_to_license_url = {
-        "distlib": "https://bitbucket.org/pypa/distlib/raw/7d93712134b28401407da27382f2b6236c87623a/LICENSE.txt",
-        "future": "https://raw.githubusercontent.com/PythonCharmers/python-future/master/LICENSE.txt",
-        "jsonschema": "https://raw.githubusercontent.com/python-jsonschema/jsonschema/dbc398245a583cb2366795dc529ae042d10c1577/COPYING",
-        "lockfile": "https://opendev.org/openstack/pylockfile/raw/tag/0.12.2/LICENSE",
-        "pefile": "https://raw.githubusercontent.com/erocarrera/pefile/master/LICENSE",
-        "platformdirs": "https://raw.githubusercontent.com/platformdirs/platformdirs/aa671aaa97913c7b948567f4d9c77d4f98bfa134/LICENSE",
-        "pyopenjtalk": "https://raw.githubusercontent.com/r9y9/pyopenjtalk/master/LICENSE.md",
-        "python-multipart": "https://raw.githubusercontent.com/andrew-d/python-multipart/master/LICENSE.txt",
-        "romkan": "https://raw.githubusercontent.com/soimort/python-romkan/master/LICENSE",
-        "webencodings": "https://raw.githubusercontent.com/gsnedders/python-webencodings/fa2cb5d75ab41e63ace691bc0825d3432ba7d694/LICENSE",
-    }
-
-    for license_json in licenses_json:
-        # ライセンス文を pip 外で取得されたもので上書きする
-        package_name: str = license_json["Name"].lower()
-        if license_json["LicenseText"] == "UNKNOWN":
-            if package_name == "core" and license_json["Version"] == "0.0.0":
-                continue
-            if package_name not in package_to_license_url:
-                # ライセンスがpypiに無い
-                raise Exception(f"No License info provided for {package_name}")
-            text_url = package_to_license_url[package_name]
-            license_json["LicenseText"] = get_license_text(text_url)
-
-        # soxr
-        if package_name == "soxr":
-            text_url = "https://raw.githubusercontent.com/dofuuz/python-soxr/v0.3.6/LICENSE.txt"
-            license_json["LicenseText"] = get_license_text(text_url)
-
-        licenses.append(
-            License(
-                package_name=license_json["Name"],
-                package_version=license_json["Version"],
-                license_name=license_json["License"],
-                license_text=license_json["LicenseText"],
-                license_text_type="raw",
-            )
-        )
-
-    for license in licenses:
-        # ライセンスを確認する
-        license_names_str = license.license_name or ""
-        license_names = license_names_str.split("; ")
-        for license_name in license_names:
-            if license_name in [
-                "GNU General Public License v2 (GPLv2)",
-                "GNU General Public License (GPL)",
-                "GNU General Public License v3 (GPLv3)",
-                "GNU Affero General Public License v3 (AGPL-3)",
-            ]:
-                raise LicenseError(
-                    f"ライセンス違反: {license.package_name} is {license.license_name}"
-                )
+    licenses = generate_licenses_from_licenses_json(licenses_json)
+    validate_license_compliance(licenses)
 
     python_version = "3.11.9"
 
@@ -275,6 +223,69 @@ def generate_licenses() -> list[License]:
             license_text_type="local_address",
         ),
     ]
+
+    return licenses
+
+
+def validate_license_compliance(licenses: list[License]) -> None:
+    for license in licenses:
+        # ライセンスを確認する
+        license_names_str = license.license_name or ""
+        license_names = license_names_str.split("; ")
+        for license_name in license_names:
+            if license_name in [
+                "GNU General Public License v2 (GPLv2)",
+                "GNU General Public License (GPL)",
+                "GNU General Public License v3 (GPLv3)",
+                "GNU Affero General Public License v3 (AGPL-3)",
+            ]:
+                raise LicenseError(
+                    f"ライセンス違反: {license.package_name} is {license.license_name}"
+                )
+
+
+def generate_licenses_from_licenses_json(licenses_json: dict) -> list[License]:
+    package_to_license_url = {
+        "distlib": "https://bitbucket.org/pypa/distlib/raw/7d93712134b28401407da27382f2b6236c87623a/LICENSE.txt",
+        "future": "https://raw.githubusercontent.com/PythonCharmers/python-future/master/LICENSE.txt",
+        "jsonschema": "https://raw.githubusercontent.com/python-jsonschema/jsonschema/dbc398245a583cb2366795dc529ae042d10c1577/COPYING",
+        "lockfile": "https://opendev.org/openstack/pylockfile/raw/tag/0.12.2/LICENSE",
+        "pefile": "https://raw.githubusercontent.com/erocarrera/pefile/master/LICENSE",
+        "platformdirs": "https://raw.githubusercontent.com/platformdirs/platformdirs/aa671aaa97913c7b948567f4d9c77d4f98bfa134/LICENSE",
+        "pyopenjtalk": "https://raw.githubusercontent.com/r9y9/pyopenjtalk/master/LICENSE.md",
+        "python-multipart": "https://raw.githubusercontent.com/andrew-d/python-multipart/master/LICENSE.txt",
+        "romkan": "https://raw.githubusercontent.com/soimort/python-romkan/master/LICENSE",
+        "webencodings": "https://raw.githubusercontent.com/gsnedders/python-webencodings/fa2cb5d75ab41e63ace691bc0825d3432ba7d694/LICENSE",
+    }
+
+    licenses = []
+
+    for license_json in licenses_json:
+        # ライセンス文を pip 外で取得されたもので上書きする
+        package_name: str = license_json["Name"].lower()
+        if license_json["LicenseText"] == "UNKNOWN":
+            if package_name == "core" and license_json["Version"] == "0.0.0":
+                continue
+            if package_name not in package_to_license_url:
+                # ライセンスがpypiに無い
+                raise Exception(f"No License info provided for {package_name}")
+            text_url = package_to_license_url[package_name]
+            license_json["LicenseText"] = get_license_text(text_url)
+
+        # soxr
+        if package_name == "soxr":
+            text_url = "https://raw.githubusercontent.com/dofuuz/python-soxr/v0.3.6/LICENSE.txt"
+            license_json["LicenseText"] = get_license_text(text_url)
+
+        licenses.append(
+            License(
+                package_name=license_json["Name"],
+                package_version=license_json["Version"],
+                license_name=license_json["License"],
+                license_text=license_json["LicenseText"],
+                license_text_type="raw",
+            )
+        )
 
     return licenses
 

--- a/tools/generate_licenses.py
+++ b/tools/generate_licenses.py
@@ -68,10 +68,14 @@ def generate_licenses() -> list[License]:
         ) from err
 
     licenses_json = json.loads(pip_licenses_output)
-
     licenses = generate_licenses_from_licenses_json(licenses_json)
     validate_license_compliance(licenses)
+    add_licenses_manually(licenses)
 
+    return licenses
+
+
+def add_licenses_manually(licenses: list[License]) -> None:
     python_version = "3.11.9"
 
     licenses += [
@@ -224,8 +228,6 @@ def generate_licenses() -> list[License]:
         ),
     ]
 
-    return licenses
-
 
 def validate_license_compliance(licenses: list[License]) -> None:
     for license in licenses:
@@ -261,14 +263,15 @@ def generate_licenses_from_licenses_json(licenses_json: dict) -> list[License]:
     licenses = []
 
     for license_json in licenses_json:
-        # ライセンス文を pip 外で取得されたもので上書きする
         package_name: str = license_json["Name"].lower()
+
         if license_json["LicenseText"] == "UNKNOWN":
             if package_name == "core" and license_json["Version"] == "0.0.0":
                 continue
             if package_name not in package_to_license_url:
                 # ライセンスがpypiに無い
                 raise Exception(f"No License info provided for {package_name}")
+            # ライセンス文を pip 外で取得されたもので上書きする
             text_url = package_to_license_url[package_name]
             license_json["LicenseText"] = get_license_text(text_url)
 

--- a/tools/generate_licenses.py
+++ b/tools/generate_licenses.py
@@ -44,8 +44,6 @@ def get_license_text(text_url: str) -> str:
 
 
 def generate_licenses() -> list[License]:
-    licenses: list[License] = []
-
     # pip
     try:
         pip_licenses_output = subprocess.run(


### PR DESCRIPTION
## 内容
`generate_licenses.py` のリファクタリングを行いました。
リファクタリング前後で`tools/create_venv_and_generate_licenses.bash`から生成されるjsonにdiffが生じないことを確認しています。

主にやったこととしては`generate_licenses`の中の処理を以下の３つの関数に切り分けました。

1. generate_licenses_from_licenses_json: licenses_json から list[License] を生成する
2. validate_license_compliance: 与えられた list[License] がライセンス違反していないかをチェック
3. add_licenses_manually: piplicenses でカバーできないライセンスを手動で追加する

またif-elifで場合分けをしていた部分をdictによるマップを使って書き換えることで、重複を削減しました。
これにより、将来的にUNKNOWNなライセンスが増えた際の対応も`package_to_license_url`に一行追加するだけでよくなり、メンテナンス性も向上するのではないかと考えます。

なお、2を分けたことでforループが余分に１回回ってしまいますがライセンスの数は50個ほどでパフォーマンスへの影響は微々たるもので問題無いと考えています。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
