### PR TITLE
refactor: エラーインスタンス用の変数名を `e` に統一

### DIFF
--- a/test/unit/tts_pipeline/test_kana_converter.py
+++ b/test/unit/tts_pipeline/test_kana_converter.py
@@ -543,9 +543,9 @@ def test_interrogative_accent_phrase_marks() -> None:
 
 class TestParseKanaException(TestCase):
     def _assert_error_code(self, kana: str, code: ParseKanaErrorCode) -> None:
-        with self.assertRaises(ParseKanaError) as err:
+        with self.assertRaises(ParseKanaError) as e:
             parse_kana(kana)
-        self.assertEqual(err.exception.errcode, code)
+        self.assertEqual(e.exception.errcode, code)
 
     def test_exceptions(self) -> None:
         self._assert_error_code("アクセント", ParseKanaErrorCode.ACCENT_NOTFOUND)
@@ -557,20 +557,20 @@ class TestParseKanaException(TestCase):
         self._assert_error_code("/ア'", ParseKanaErrorCode.EMPTY_PHRASE)
         self._assert_error_code("", ParseKanaErrorCode.EMPTY_PHRASE)
 
-        with self.assertRaises(ParseKanaError) as err:
+        with self.assertRaises(ParseKanaError) as e:
             parse_kana("ヒト'ツメ/フタツメ")
-        self.assertEqual(err.exception.errcode, ParseKanaErrorCode.ACCENT_NOTFOUND)
-        self.assertEqual(err.exception.kwargs, {"text": "フタツメ"})
+        self.assertEqual(e.exception.errcode, ParseKanaErrorCode.ACCENT_NOTFOUND)
+        self.assertEqual(e.exception.kwargs, {"text": "フタツメ"})
 
-        with self.assertRaises(ParseKanaError) as err:
+        with self.assertRaises(ParseKanaError) as e:
             parse_kana("ア'/")
-        self.assertEqual(err.exception.errcode, ParseKanaErrorCode.EMPTY_PHRASE)
-        self.assertEqual(err.exception.kwargs, {"position": "2"})
+        self.assertEqual(e.exception.errcode, ParseKanaErrorCode.EMPTY_PHRASE)
+        self.assertEqual(e.exception.kwargs, {"position": "2"})
 
-        with self.assertRaises(ParseKanaError) as err:
+        with self.assertRaises(ParseKanaError) as e:
             kana_converter.parse_kana("ア？ア'")
         self.assertEqual(
-            err.exception.errcode, ParseKanaErrorCode.INTERROGATION_MARK_NOT_AT_END
+            e.exception.errcode, ParseKanaErrorCode.INTERROGATION_MARK_NOT_AT_END
         )
 
 

--- a/tools/generate_licenses.py
+++ b/tools/generate_licenses.py
@@ -62,9 +62,7 @@ def generate_licenses() -> list[License]:
             check=True,
         ).stdout.decode()
     except subprocess.CalledProcessError as e:
-        raise Exception(
-            f"command output:\n{e.stderr and e.stderr.decode()}"
-        ) from e
+        raise Exception(f"command output:\n{e.stderr and e.stderr.decode()}") from e
 
     licenses_json = json.loads(pip_licenses_output)
     for license_json in licenses_json:

--- a/tools/generate_licenses.py
+++ b/tools/generate_licenses.py
@@ -61,10 +61,10 @@ def generate_licenses() -> list[License]:
             capture_output=True,
             check=True,
         ).stdout.decode()
-    except subprocess.CalledProcessError as err:
+    except subprocess.CalledProcessError as e:
         raise Exception(
-            f"command output:\n{err.stderr and err.stderr.decode()}"
-        ) from err
+            f"command output:\n{e.stderr and e.stderr.decode()}"
+        ) from e
 
     licenses_json = json.loads(pip_licenses_output)
     for license_json in licenses_json:

--- a/voicevox_engine/app/routers/character.py
+++ b/voicevox_engine/app/routers/character.py
@@ -97,8 +97,8 @@ def generate_character_router(
         """
         try:
             resource_path = resource_manager.resource_path(resource_hash)
-        except ResourceManagerError as err:
-            raise HTTPException(status_code=404) from err
+        except ResourceManagerError as e:
+            raise HTTPException(status_code=404) from e
         return FileResponse(
             resource_path,
             headers={"Cache-Control": "max-age=2592000"},  # 30日

--- a/voicevox_engine/app/routers/preset.py
+++ b/voicevox_engine/app/routers/preset.py
@@ -30,10 +30,10 @@ def generate_preset_router(
         """
         try:
             presets = preset_manager.load_presets()
-        except PresetInputError as err:
-            raise HTTPException(status_code=422, detail=str(err)) from err
-        except PresetInternalError as err:
-            raise HTTPException(status_code=500, detail=str(err)) from err
+        except PresetInputError as e:
+            raise HTTPException(status_code=422, detail=str(e)) from e
+        except PresetInternalError as e:
+            raise HTTPException(status_code=500, detail=str(e)) from e
         return presets
 
     @router.post(
@@ -54,10 +54,10 @@ def generate_preset_router(
         """
         try:
             id = preset_manager.add_preset(preset)
-        except PresetInputError as err:
-            raise HTTPException(status_code=422, detail=str(err)) from err
-        except PresetInternalError as err:
-            raise HTTPException(status_code=500, detail=str(err)) from err
+        except PresetInputError as e:
+            raise HTTPException(status_code=422, detail=str(e)) from e
+        except PresetInternalError as e:
+            raise HTTPException(status_code=500, detail=str(e)) from e
         return id
 
     @router.post(
@@ -78,10 +78,10 @@ def generate_preset_router(
         """
         try:
             id = preset_manager.update_preset(preset)
-        except PresetInputError as err:
-            raise HTTPException(status_code=422, detail=str(err)) from err
-        except PresetInternalError as err:
-            raise HTTPException(status_code=500, detail=str(err)) from err
+        except PresetInputError as e:
+            raise HTTPException(status_code=422, detail=str(e)) from e
+        except PresetInternalError as e:
+            raise HTTPException(status_code=500, detail=str(e)) from e
         return id
 
     @router.post(
@@ -97,9 +97,9 @@ def generate_preset_router(
         """
         try:
             preset_manager.delete_preset(id)
-        except PresetInputError as err:
-            raise HTTPException(status_code=422, detail=str(err)) from err
-        except PresetInternalError as err:
-            raise HTTPException(status_code=500, detail=str(err)) from err
+        except PresetInputError as e:
+            raise HTTPException(status_code=422, detail=str(e)) from e
+        except PresetInternalError as e:
+            raise HTTPException(status_code=500, detail=str(e)) from e
 
     return router

--- a/voicevox_engine/app/routers/tts_pipeline.py
+++ b/voicevox_engine/app/routers/tts_pipeline.py
@@ -52,13 +52,13 @@ class ParseKanaBadRequest(BaseModel):
         description="エラー名\n\n"
         "|name|description|\n|---|---|\n"
         + "\n".join(
-            [f"| {err.name} | {err.value} |" for err in list(ParseKanaErrorCode)]
+            [f"| {e.name} | {e.value} |" for e in list(ParseKanaErrorCode)]
         ),
     )
     error_args: dict[str, str] = Field(description="エラーを起こした箇所")
 
-    def __init__(self, err: ParseKanaError):
-        super().__init__(text=err.text, error_name=err.errname, error_args=err.kwargs)
+    def __init__(self, e: ParseKanaError):
+        super().__init__(text=e.text, error_name=e.errname, error_args=e.kwargs)
 
 
 class SupportedDevicesInfo(BaseModel):
@@ -136,10 +136,10 @@ def generate_tts_pipeline_router(
         engine = tts_engines.get_engine(version)
         try:
             presets = preset_manager.load_presets()
-        except PresetInputError as err:
-            raise HTTPException(status_code=422, detail=str(err)) from err
-        except PresetInternalError as err:
-            raise HTTPException(status_code=500, detail=str(err)) from err
+        except PresetInputError as e:
+            raise HTTPException(status_code=422, detail=str(e)) from e
+        except PresetInternalError as e:
+            raise HTTPException(status_code=500, detail=str(e)) from e
         for preset in presets:
             if preset.id == preset_id:
                 selected_preset = preset
@@ -196,10 +196,10 @@ def generate_tts_pipeline_router(
         if is_kana:
             try:
                 return engine.create_accent_phrases_from_kana(text, style_id)
-            except ParseKanaError as err:
+            except ParseKanaError as e:
                 raise HTTPException(
-                    status_code=400, detail=ParseKanaBadRequest(err).model_dump()
-                ) from err
+                    status_code=400, detail=ParseKanaBadRequest(e).model_dump()
+                ) from e
         else:
             return engine.create_accent_phrases(text, style_id)
 
@@ -505,8 +505,8 @@ def generate_tts_pipeline_router(
         """
         try:
             waves_nparray, sampling_rate = connect_base64_waves(waves)
-        except ConnectBase64WavesException as err:
-            raise HTTPException(status_code=422, detail=str(err)) from err
+        except ConnectBase64WavesException as e:
+            raise HTTPException(status_code=422, detail=str(e)) from e
 
         with NamedTemporaryFile(delete=False) as f:
             soundfile.write(
@@ -543,11 +543,11 @@ def generate_tts_pipeline_router(
         try:
             parse_kana(text)
             return True
-        except ParseKanaError as err:
+        except ParseKanaError as e:
             raise HTTPException(
                 status_code=400,
-                detail=ParseKanaBadRequest(err).model_dump(),
-            ) from err
+                detail=ParseKanaBadRequest(e).model_dump(),
+            ) from e
 
     @router.post("/initialize_speaker", status_code=204, tags=["その他"])
     def initialize_speaker(

--- a/voicevox_engine/app/routers/tts_pipeline.py
+++ b/voicevox_engine/app/routers/tts_pipeline.py
@@ -51,9 +51,7 @@ class ParseKanaBadRequest(BaseModel):
     error_name: str = Field(
         description="エラー名\n\n"
         "|name|description|\n|---|---|\n"
-        + "\n".join(
-            [f"| {e.name} | {e.value} |" for e in list(ParseKanaErrorCode)]
-        ),
+        + "\n".join([f"| {e.name} | {e.value} |" for e in list(ParseKanaErrorCode)]),
     )
     error_args: dict[str, str] = Field(description="エラーを起こした箇所")
 

--- a/voicevox_engine/app/routers/user_dict.py
+++ b/voicevox_engine/app/routers/user_dict.py
@@ -35,12 +35,12 @@ def generate_user_dict_router(
         """
         try:
             return user_dict.read_dict()
-        except UserDictInputError as err:
-            raise HTTPException(status_code=422, detail=str(err)) from err
-        except Exception as err:
+        except UserDictInputError as e:
+            raise HTTPException(status_code=422, detail=str(e)) from e
+        except Exception as e:
             raise HTTPException(
                 status_code=500, detail="辞書の読み込みに失敗しました。"
-            ) from err
+            ) from e
 
     # TODO: CsvSafeStrを使う
     @router.post("/user_dict_word", dependencies=[Depends(verify_mutability)])
@@ -90,12 +90,12 @@ def generate_user_dict_router(
             raise HTTPException(
                 status_code=422, detail="パラメータに誤りがあります。\n" + str(e)
             ) from e
-        except UserDictInputError as err:
-            raise HTTPException(status_code=422, detail=str(err)) from err
-        except Exception as err:
+        except UserDictInputError as e:
+            raise HTTPException(status_code=422, detail=str(e)) from e
+        except Exception as e:
             raise HTTPException(
                 status_code=500, detail="ユーザー辞書への追加に失敗しました。"
-            ) from err
+            ) from e
 
     @router.put(
         "/user_dict_word/{word_uuid}",
@@ -149,12 +149,12 @@ def generate_user_dict_router(
             raise HTTPException(
                 status_code=422, detail="パラメータに誤りがあります。\n" + str(e)
             ) from e
-        except UserDictInputError as err:
-            raise HTTPException(status_code=422, detail=str(err)) from err
-        except Exception as err:
+        except UserDictInputError as e:
+            raise HTTPException(status_code=422, detail=str(e)) from e
+        except Exception as e:
             raise HTTPException(
                 status_code=500, detail="ユーザー辞書の更新に失敗しました。"
-            ) from err
+            ) from e
 
     @router.delete(
         "/user_dict_word/{word_uuid}",
@@ -169,12 +169,12 @@ def generate_user_dict_router(
         """
         try:
             user_dict.delete_word(word_uuid=word_uuid)
-        except UserDictInputError as err:
-            raise HTTPException(status_code=422, detail=str(err)) from err
-        except Exception as err:
+        except UserDictInputError as e:
+            raise HTTPException(status_code=422, detail=str(e)) from e
+        except Exception as e:
             raise HTTPException(
                 status_code=500, detail="ユーザー辞書の更新に失敗しました。"
-            ) from err
+            ) from e
 
     @router.post(
         "/import_user_dict",
@@ -195,11 +195,11 @@ def generate_user_dict_router(
         """
         try:
             user_dict.import_user_dict(dict_data=import_dict_data, override=override)
-        except UserDictInputError as err:
-            raise HTTPException(status_code=422, detail=str(err)) from err
-        except Exception as err:
+        except UserDictInputError as e:
+            raise HTTPException(status_code=422, detail=str(e)) from e
+        except Exception as e:
             raise HTTPException(
                 status_code=500, detail="ユーザー辞書のインポートに失敗しました。"
-            ) from err
+            ) from e
 
     return router

--- a/voicevox_engine/cancellable_engine.py
+++ b/voicevox_engine/cancellable_engine.py
@@ -145,10 +145,10 @@ class CancellableEngine:
             if not isinstance(audio_file_name, str):
                 # ここには来ないはず
                 raise CancellableEngineInternalError("不正な値が生成されました")
-        except EOFError as err:
+        except EOFError as e:
             raise CancellableEngineInternalError(
                 "既にサブプロセスは終了されています"
-            ) from err
+            ) from e
         except Exception:
             self._finalize_con(request, synth_process, synth_connection)
             raise

--- a/voicevox_engine/core/core_wrapper.py
+++ b/voicevox_engine/core/core_wrapper.py
@@ -373,8 +373,8 @@ def load_core(core_dir: Path, use_gpu: bool) -> CDLL:
             # NOTE: CDLL クラスのコンストラクタの引数 name には文字列を渡す必要がある。
             #       Windows 環境では PathLike オブジェクトを引数として渡すと初期化に失敗する。
             return CDLL(str((core_dir / core_name).resolve(strict=True)))
-        except OSError as err:
-            raise RuntimeError(f"コアの読み込みに失敗しました：{err}") from err
+        except OSError as e:
+            raise RuntimeError(f"コアの読み込みに失敗しました：{e}") from e
 
     # Core<0.12
     model_type = _check_core_type(core_dir)
@@ -397,15 +397,15 @@ def load_core(core_dir: Path, use_gpu: bool) -> CDLL:
     if core_name:
         try:
             return CDLL(str((core_dir / core_name).resolve(strict=True)))
-        except OSError as err:  # noqa: F841
+        except OSError as e:  # noqa: F841
             if model_type == "libtorch":
                 core_name = _get_suitable_core_name(model_type, gpu_type=GPUType.CUDA)
                 if core_name:
                     try:
                         return CDLL(str((core_dir / core_name).resolve(strict=True)))
-                    except OSError as err_:
-                        err = err_
-            raise RuntimeError(f"コアの読み込みに失敗しました：{err}") from err
+                    except OSError as _e:
+                        e = _e
+            raise RuntimeError(f"コアの読み込みに失敗しました：{e}") from e
     else:
         raise RuntimeError(
             f"このコンピュータのアーキテクチャ {platform.machine()} で利用可能なコアがありません"

--- a/voicevox_engine/library/library_manager.py
+++ b/voicevox_engine/library/library_manager.py
@@ -166,21 +166,21 @@ class LibraryManager:
                     zf.read("vvlib_manifest.json").decode("utf-8")
                 )
             # マニフェストファイルをもたないライブラリはインストールを拒否する
-            except KeyError as err:
+            except KeyError as e:
                 msg = (
                     f"音声ライブラリ {library_id} にvvlib_manifest.jsonが存在しません。"
                 )
-                raise LibraryFormatInvalidError(msg) from err
-            except Exception as err:
+                raise LibraryFormatInvalidError(msg) from e
+            except Exception as e:
                 msg = f"音声ライブラリ {library_id} のvvlib_manifest.jsonは不正です。"
-                raise LibraryFormatInvalidError(msg) from err
+                raise LibraryFormatInvalidError(msg) from e
 
             # 不正な形式のマニフェストファイルをもつライブラリはインストールを拒否する
             try:
                 VvlibManifest.model_validate(vvlib_manifest)
-            except ValidationError as err:
+            except ValidationError as e:
                 msg = f"音声ライブラリ {library_id} のvvlib_manifest.jsonが不正な形式です。"
-                raise LibraryFormatInvalidError(msg) from err
+                raise LibraryFormatInvalidError(msg) from e
 
             # 不正な `version` 形式のマニフェストファイルもつライブラリはインストールを拒否する
             if not Version.is_valid(vvlib_manifest["version"]):
@@ -190,9 +190,9 @@ class LibraryManager:
             # 不正な形式あるいは対応範囲外のマニフェストバージョンをもつライブラリはインストールを拒否する
             try:
                 manifest_version = Version.parse(vvlib_manifest["manifest_version"])
-            except ValueError as err:
+            except ValueError as e:
                 msg = f"音声ライブラリ {library_id} のmanifest_version形式が不正です。"
-                raise LibraryFormatInvalidError(msg) from err
+                raise LibraryFormatInvalidError(msg) from e
             if manifest_version > self.supported_vvlib_version:
                 msg = f"音声ライブラリ {library_id} は未対応です。"
                 raise LibraryUnsupportedError(msg)
@@ -225,6 +225,6 @@ class LibraryManager:
         try:
             # NOTE: 当該ライブラリのディレクトリを削除してアンインストールする
             shutil.rmtree(self.library_root_dir / library_id)
-        except Exception as err:
+        except Exception as e:
             msg = f"音声ライブラリ {library_id} の削除に失敗しました。"
-            raise LibraryInternalError(msg) from err
+            raise LibraryInternalError(msg) from e

--- a/voicevox_engine/metas/MetasStore.py
+++ b/voicevox_engine/metas/MetasStore.py
@@ -206,10 +206,10 @@ class MetasStore:
                         "voice_samples": voice_samples,
                     }
                 )
-        except (FileNotFoundError, ResourceManagerError) as err:
+        except (FileNotFoundError, ResourceManagerError) as e:
             # FIXME: HTTPExceptionはこのファイルとドメインが合わないので辞める
             msg = "追加情報が見つかりませんでした"
-            raise HTTPException(status_code=500, detail=msg) from err
+            raise HTTPException(status_code=500, detail=msg) from e
 
         character_info = SpeakerInfo(
             policy=policy, portrait=portrait, style_infos=style_infos

--- a/voicevox_engine/morphing/morphing.py
+++ b/voicevox_engine/morphing/morphing.py
@@ -71,12 +71,12 @@ def is_morphable(
 
     try:
         character_1 = style_id_to_character[style_id_1]
-    except KeyError as err:
-        raise StyleIdNotFoundError(style_id_1) from err
+    except KeyError as e:
+        raise StyleIdNotFoundError(style_id_1) from e
     try:
         character_2 = style_id_to_character[style_id_2]
-    except KeyError as err:
-        raise StyleIdNotFoundError(style_id_2) from err
+    except KeyError as e:
+        raise StyleIdNotFoundError(style_id_2) from e
 
     sing_style_ids_1 = [sing_style.id for sing_style in character_1.sing_styles]
     sing_style_ids_2 = [sing_style.id for sing_style in character_2.sing_styles]

--- a/voicevox_engine/preset/preset_manager.py
+++ b/voicevox_engine/preset/preset_manager.py
@@ -65,20 +65,20 @@ class PresetManager:
             # データベースの読み込み
             with open(self.preset_path, encoding="utf-8") as f:
                 obj = yaml.safe_load(f)
-        except OSError as err:
-            raise PresetInternalError("プリセットの読み込みに失敗しました") from err
-        except yaml.YAMLError as err:
-            raise PresetInternalError("プリセットのパースに失敗しました") from err
+        except OSError as e:
+            raise PresetInternalError("プリセットの読み込みに失敗しました") from e
+        except yaml.YAMLError as e:
+            raise PresetInternalError("プリセットのパースに失敗しました") from e
         if obj is None:
             raise PresetInternalError("プリセットの設定ファイルが空の内容です")
 
         try:
             preset_list_adapter = TypeAdapter(list[Preset])
             _presets = preset_list_adapter.validate_python(obj)
-        except ValidationError as err:
+        except ValidationError as e:
             raise PresetInternalError(
                 "プリセットの設定ファイルにミスがあります"
-            ) from err
+            ) from e
 
         # 全idの一意性をバリデーション
         if len([preset.id for preset in _presets]) != len(
@@ -105,12 +105,12 @@ class PresetManager:
         # 変更の反映。失敗時はリバート。
         try:
             self._write_on_file()
-        except Exception as err:
+        except Exception as e:
             self.presets.pop()
-            if isinstance(err, OSError):
-                raise PresetInternalError("プリセットの書き込みに失敗しました") from err
+            if isinstance(e, OSError):
+                raise PresetInternalError("プリセットの書き込みに失敗しました") from e
             else:
-                raise err
+                raise e
 
         return preset.id
 
@@ -141,12 +141,12 @@ class PresetManager:
         # 変更の反映。失敗時はリバート。
         try:
             self._write_on_file()
-        except Exception as err:
+        except Exception as e:
             self.presets[prev_preset[0]] = prev_preset[1]
-            if isinstance(err, OSError):
-                raise PresetInternalError("プリセットの書き込みに失敗しました") from err
+            if isinstance(e, OSError):
+                raise PresetInternalError("プリセットの書き込みに失敗しました") from e
             else:
-                raise err
+                raise e
 
         return preset.id
 
@@ -170,9 +170,9 @@ class PresetManager:
         # 変更の反映。失敗時はリバート。
         try:
             self._write_on_file()
-        except OSError as err:
+        except OSError as e:
             self.presets.insert(buf_index, buf)
-            raise PresetInternalError("プリセットの書き込みに失敗しました") from err
+            raise PresetInternalError("プリセットの書き込みに失敗しました") from e
 
         return id
 

--- a/voicevox_engine/preset/preset_manager.py
+++ b/voicevox_engine/preset/preset_manager.py
@@ -76,9 +76,7 @@ class PresetManager:
             preset_list_adapter = TypeAdapter(list[Preset])
             _presets = preset_list_adapter.validate_python(obj)
         except ValidationError as e:
-            raise PresetInternalError(
-                "プリセットの設定ファイルにミスがあります"
-            ) from e
+            raise PresetInternalError("プリセットの設定ファイルにミスがあります") from e
 
         # 全idの一意性をバリデーション
         if len([preset.id for preset in _presets]) != len(

--- a/voicevox_engine/tts_pipeline/connect_base64_waves.py
+++ b/voicevox_engine/tts_pipeline/connect_base64_waves.py
@@ -33,14 +33,14 @@ def decode_base64_waves(waves: list[str]) -> list[tuple[NDArray[np.float64], int
     for wave in waves:
         try:
             wav_bin = base64.standard_b64decode(wave)
-        except ValueError as err:
-            raise ConnectBase64WavesException("base64デコードに失敗しました") from err
+        except ValueError as e:
+            raise ConnectBase64WavesException("base64デコードに失敗しました") from e
         try:
             _data = soundfile.read(io.BytesIO(wav_bin))
-        except Exception as err:
+        except Exception as e:
             raise ConnectBase64WavesException(
                 "wavファイルを読み込めませんでした"
-            ) from err
+            ) from e
         waves_nparray_sr.append(_data)
 
     return waves_nparray_sr


### PR DESCRIPTION
## 内容
エラーインスタンス用の変数名を `e` に統一するリファクタリングを提案します。  

`tts_pipeline.py` ではエラーインスタンスを直接扱うコードがあるため、ここでも同様に `err` → `e` への置き換えをおこないました。

## 関連 Issue
resolve #1595