### PR TITLE
add: ライセンス情報JSONをバリデーション

### DIFF
--- a/tools/generate_licenses.py
+++ b/tools/generate_licenses.py
@@ -2,8 +2,11 @@ import json
 import subprocess
 import sys
 import urllib.request
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal, assert_never
+
+from pydantic import TypeAdapter
 
 
 class LicenseError(Exception):
@@ -44,9 +47,33 @@ def get_license_text(text_url: str) -> str:
 
 
 def generate_licenses() -> list[License]:
-    # pip
+    raw_licenses = acquire_licenses_of_pip_managed_libraries()
+    licenses = update_licenses(raw_licenses)
+    validate_license_compliance(licenses)
+    add_licenses_manually(licenses)
+
+    return licenses
+
+
+@dataclass
+class PipLicense:
+    """`pip-license` により得られる依存ライブラリの情報"""
+
+    License: str
+    Name: str
+    URL: str
+    Version: str
+    LicenseText: str
+
+
+_pip_licenses_adapter = TypeAdapter(list[PipLicense])
+
+
+def acquire_licenses_of_pip_managed_libraries() -> list[PipLicense]:
+    """Pipで管理されている依存ライブラリのライセンス情報を取得する。"""
+    # ライセンス一覧を取得する
     try:
-        pip_licenses_output = subprocess.run(
+        pip_licenses_json = subprocess.run(
             [
                 sys.executable,
                 "-m",
@@ -62,16 +89,13 @@ def generate_licenses() -> list[License]:
         ).stdout.decode()
     except subprocess.CalledProcessError as e:
         raise Exception(f"command output:\n{e.stderr and e.stderr.decode()}") from e
-
-    licenses_json = json.loads(pip_licenses_output)
-    licenses = generate_licenses_from_licenses_json(licenses_json)
-    validate_license_compliance(licenses)
-    add_licenses_manually(licenses)
-
+    # ライセンス情報の形式をチェックする
+    licenses = _pip_licenses_adapter.validate_json(pip_licenses_json)
     return licenses
 
 
-def generate_licenses_from_licenses_json(licenses_json: dict) -> list[License]:
+def update_licenses(raw_licenses: list[PipLicense]) -> list[License]:
+    """pip から取得したライセンス情報を更新する。"""
     package_to_license_url = {
         "distlib": "https://bitbucket.org/pypa/distlib/raw/7d93712134b28401407da27382f2b6236c87623a/LICENSE.txt",
         "future": "https://raw.githubusercontent.com/PythonCharmers/python-future/master/LICENSE.txt",
@@ -85,37 +109,37 @@ def generate_licenses_from_licenses_json(licenses_json: dict) -> list[License]:
         "webencodings": "https://raw.githubusercontent.com/gsnedders/python-webencodings/fa2cb5d75ab41e63ace691bc0825d3432ba7d694/LICENSE",
     }
 
-    licenses = []
+    updated_licenses = []
 
-    for license_json in licenses_json:
-        package_name: str = license_json["Name"].lower()
+    for raw_license in raw_licenses:
+        package_name = raw_license.Name.lower()
 
-        if license_json["LicenseText"] == "UNKNOWN":
-            if package_name == "core" and license_json["Version"] == "0.0.0":
+        # ライセンス文が pip から取得できていない場合、pip 外から補う
+        if raw_license.LicenseText == "UNKNOWN":
+            if package_name == "core" and raw_license.Version == "0.0.0":
                 continue
             if package_name not in package_to_license_url:
                 # ライセンスがpypiに無い
                 raise Exception(f"No License info provided for {package_name}")
-            # ライセンス文を pip 外で取得されたもので上書きする
             text_url = package_to_license_url[package_name]
-            license_json["LicenseText"] = get_license_text(text_url)
+            raw_license.LicenseText = get_license_text(text_url)
 
         # soxr
         if package_name == "soxr":
             text_url = "https://raw.githubusercontent.com/dofuuz/python-soxr/v0.3.6/LICENSE.txt"
-            license_json["LicenseText"] = get_license_text(text_url)
+            raw_license.LicenseText = get_license_text(text_url)
 
-        licenses.append(
+        updated_licenses.append(
             License(
-                package_name=license_json["Name"],
-                package_version=license_json["Version"],
-                license_name=license_json["License"],
-                license_text=license_json["LicenseText"],
+                package_name=raw_license.Name,
+                package_version=raw_license.Version,
+                license_name=raw_license.License,
+                license_text=raw_license.LicenseText,
                 license_text_type="raw",
             )
         )
 
-    return licenses
+    return updated_licenses
 
 
 def validate_license_compliance(licenses: list[License]) -> None:


### PR DESCRIPTION
## 内容
### 概要
ライセンス情報JSONをバリデーションすることを提案します。  

### 詳細
現在の `generate_licenses.py` では pip から取得した JSON をバリデーション無しで `list[dict]` 的に扱っている。これは pip 側の仕様変更によって容易に壊れうる、危険な取り回しである。本来であれば外部入力はまずバリデーションすべきである。  
また型保証の無いオブジェクトに型付けしているため、型ヒントのミスが実際に起きている（ https://github.com/VOICEVOX/voicevox_engine/pull/1580#issuecomment-2796069652 ）。これはバリデーションをしていればテスト時に異常が見つかる。  
すなわち、バリデーションの不足によって今現在かつ今後も不安定なコードとなっている。  

VOICEVOX ENGINE は `pydantic` を用いているため、`TypeAdapter` 機能により容易にバリデーションが可能である。よってこれを用いたJSONバリデーションにより、上記の問題を解決できる。  

このような背景から、ライセンス情報JSONのバリデーションを提案します。  

## 関連 Issue
ref https://github.com/VOICEVOX/voicevox_engine/pull/1580#issuecomment-2796069652

## その他
出力されるライセンス情報に影響が無いことを確認済みです。