### PR TITLE
chore: mypyの設定をpyproject.tomlに移動

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,7 +1,0 @@
-# TODO: Move it to pyproject.toml after the review is done
-[mypy]
-strict = True
-plugins = numpy.typing.mypy_plugin,pydantic.mypy
-python_version = 3.11
-ignore_missing_imports = True
-warn_unreachable = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,13 @@ unfixable = [
 known-first-party = ["voicevox_engine"]
 known-third-party = ["numpy"]
 
+[tool.mypy]
+strict = true
+plugins = "numpy.typing.mypy_plugin,pydantic.mypy"
+python_version = "3.11"
+ignore_missing_imports = true
+warn_unreachable = true
+
 [tool.typos.default.extend-words]
 datas = "datas" # PyInstaller's argument
 


### PR DESCRIPTION
## 内容
表題の通り、mypyの設定をpyproject.tomlに移動し、mypy.iniを削除しました。
これにより、静的解析ツールの設定が全てpyproject.tomlだけで完結するようになります。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
