### PR TITLE
build: [project-e2k] ビルド時にe2kのファイルを含めるようにする

### DIFF
--- a/run.spec
+++ b/run.spec
@@ -8,8 +8,8 @@ datas = [
     ('engine_manifest.json', '.'),
     ('licenses.json', '.'),
 ]
-datas += collect_data_files('pyopenjtalk')
 datas += collect_data_files('e2k')
+datas += collect_data_files('pyopenjtalk')
 
 core_model_dir_path = os.environ.get('CORE_MODEL_DIR_PATH')
 if core_model_dir_path:

--- a/run.spec
+++ b/run.spec
@@ -9,6 +9,7 @@ datas = [
     ('licenses.json', '.'),
 ]
 datas += collect_data_files('pyopenjtalk')
+datas += collect_data_files('e2k')
 
 core_model_dir_path = os.environ.get('CORE_MODEL_DIR_PATH')
 if core_model_dir_path:


### PR DESCRIPTION
## 内容

題の通りです。
e2kのモデルファイルが成果物に含まれておらず、エラーになっていたので修正します。

## 関連 Issue

ref #1524 
https://github.com/VOICEVOX/voicevox_engine/issues/1524#issuecomment-2805356262

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
