### PR TITLE
refactor: ドキュメント生成スクリプトを構造化

### DIFF
--- a/tools/make_docs.py
+++ b/tools/make_docs.py
@@ -1,4 +1,5 @@
 """ドキュメントファイルを生成する。"""
+# TODO: 目的を「ドキュメント生成」から「API ドキュメント生成」へ変更し、ファイル名等をそれに合わせられるか検討
 
 import json
 from pathlib import Path

--- a/tools/make_docs.py
+++ b/tools/make_docs.py
@@ -69,13 +69,11 @@ def _generate_api_docs_html(schema: str) -> str:
 
 
 def _generate_api_docs() -> None:
-    # app インスタンスをモック設定で生成する
     app = _generate_mock_app()
 
     # FastAPI の機能を用いて OpenAPI schema を生成する
     api_schema = json.dumps(app.openapi())
 
-    # API ドキュメント HTML を生成する
     api_docs_html = _generate_api_docs_html(api_schema)
 
     # HTML ファイルとして保存する
@@ -87,7 +85,6 @@ def _generate_api_docs() -> None:
 
 def main() -> None:
     """ドキュメントファイルを生成する。"""
-    # API ドキュメント HTML ファイルを生成する
     _generate_api_docs()
 
 

--- a/tools/make_docs.py
+++ b/tools/make_docs.py
@@ -49,6 +49,12 @@ def _generate_mock_app() -> FastAPI:
     return app
 
 
+def _get_openapi_schema(app: FastAPI) -> str:
+    """OpenAPI スキーマを取得する。"""
+    # FastAPI の機能を用いる
+    return json.dumps(app.openapi())
+
+
 def _generate_api_docs_html(schema: str) -> str:
     """OpenAPI schema から API ドキュメント HTML を生成する"""
     return f"""<!DOCTYPE html>
@@ -68,19 +74,19 @@ def _generate_api_docs_html(schema: str) -> str:
 </html>"""
 
 
-def _generate_api_docs() -> None:
-    app = _generate_mock_app()
-
-    # FastAPI の機能を用いて OpenAPI schema を生成する
-    api_schema = json.dumps(app.openapi())
-
-    api_docs_html = _generate_api_docs_html(api_schema)
-
-    # HTML ファイルとして保存する
+def _save_as_html_file(api_docs_str: str) -> None:
+    """HTML 文字列を HTML ファイルとして保存する。"""
     api_docs_root = Path("docs/api")  # 'upload-docs' workflow の対象
     output_path = api_docs_root / "index.html"
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    output_path.write_text(api_docs_html)
+    output_path.write_text(api_docs_str)
+
+
+def _generate_api_docs() -> None:
+    app = _generate_mock_app()
+    api_schema = _get_openapi_schema(app)
+    api_docs_html = _generate_api_docs_html(api_schema)
+    _save_as_html_file(api_docs_html)
 
 
 def main() -> None:


### PR DESCRIPTION
## 内容
ドキュメント生成スクリプトを構造化するリファクタリングを提案します。  

`tools/make_docs.py` はビルド時にドキュメント生成を担う Python スクリプトである。  
機能的には充分であるが、コード品質に以下の課題があった：  

- `make_docs.py` つまり「ドキュメント生成」を名乗るが「API ドキュメント生成」が前提
- 関数名の private/public が曖昧
- module docstring が不足
- 関数への切り出し基準が曖昧

これらの品質を向上させるために、以下のリファクタリングが可能である：

- API ドキュメント生成を関数に切り出し、main 関数から呼び出し（他ドキュメント追加時に関数を足すだけで良い）
- main 以外の関数を private 化
- module docstring を追加
- ステップごとに関数へ切り出し

本 PR では上記のリファクタリングによりドキュメント生成スクリプトを構造化することを提案します。

## 関連 Issue
#1605 実装中に派生