### PR TITLE
refactor: ruff D403 の無効化理由を追加

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,14 +5,14 @@ target-version = "py311"
 select = ["E", "F", "B", "I", "W", "UP", "D"]
 ignore = [
   "E501", # line-too-long
-  "D400", # missing-trailing-period。日本語の「。」に対応していないため
+  "D400", # missing-trailing-period。日本語の「。」に対応していないため。
+  "D403", # first-word-uncapitalized。日本語とは無関係であるため。また、日英混合時の挙動に一貫性が無いため。
   "D100", # NOTE: 段階的に有効化する可能性がある。
   "D102", # NOTE: 段階的に有効化する可能性がある。
   "D103", # NOTE: 段階的に有効化する可能性がある。
   "D104", # NOTE: 段階的に有効化する可能性がある。
   "D105", # NOTE: 段階的に有効化する可能性がある。
   "D200", # NOTE: 段階的に有効化する可能性がある。
-  "D403", # NOTE: 段階的に有効化する可能性がある。
 ]
 unfixable = [
   "F401", # unused-import

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ select = ["E", "F", "B", "I", "W", "UP", "D"]
 ignore = [
   "E501", # line-too-long
   "D400", # missing-trailing-period。日本語の「。」に対応していないため。
-  "D403", # first-word-uncapitalized。日本語とは無関係であるため。また、日英混合時の挙動に一貫性が無いため。
+  "D403", # first-word-uncapitalized。日本語とは無関係であるため。日英混合時の挙動に一貫性が無いため。
   "D100", # NOTE: 段階的に有効化する可能性がある。
   "D102", # NOTE: 段階的に有効化する可能性がある。
   "D103", # NOTE: 段階的に有効化する可能性がある。


### PR DESCRIPTION
## 内容
ruff D403 の無効化理由を追加し、「段階的に有効化する可能性がある。」を削除するリファクタリングを提案します。  

## 関連 Issue
part of 1605, ref https://github.com/VOICEVOX/voicevox_engine/issues/1605#issuecomment-2799124604