### PR TITLE
refactor: ライセンス情報の生成を整理

### DIFF
--- a/tools/generate_licenses.py
+++ b/tools/generate_licenses.py
@@ -82,7 +82,7 @@ class _License:
 
 
 def _update_licenses(pip_licenses: list[_PipLicense]) -> list[_License]:
-    """pip から取得したライセンス情報を更新する。"""
+    """pip から取得したライセンス情報の抜けを補完する。"""
     package_to_license_url = {
         "distlib": "https://bitbucket.org/pypa/distlib/raw/7d93712134b28401407da27382f2b6236c87623a/LICENSE.txt",
         "future": "https://raw.githubusercontent.com/PythonCharmers/python-future/master/LICENSE.txt",

--- a/tools/generate_licenses.py
+++ b/tools/generate_licenses.py
@@ -131,6 +131,7 @@ def _update_licenses(pip_licenses: list[_PipLicense]) -> list[_License]:
 
 class _LicenseError(Exception):
     """License違反が検出された。"""
+
     pass
 
 

--- a/tools/generate_licenses.py
+++ b/tools/generate_licenses.py
@@ -81,7 +81,7 @@ class _License:
                 assert_never("型で保護され実行されないはずのパスが実行されました")
 
 
-def _update_licenses(raw_licenses: list[_PipLicense]) -> list[_License]:
+def _update_licenses(pip_licenses: list[_PipLicense]) -> list[_License]:
     """pip から取得したライセンス情報を更新する。"""
     package_to_license_url = {
         "distlib": "https://bitbucket.org/pypa/distlib/raw/7d93712134b28401407da27382f2b6236c87623a/LICENSE.txt",
@@ -98,30 +98,30 @@ def _update_licenses(raw_licenses: list[_PipLicense]) -> list[_License]:
 
     updated_licenses = []
 
-    for raw_license in raw_licenses:
-        package_name = raw_license.Name.lower()
+    for pip_license in pip_licenses:
+        package_name = pip_license.Name.lower()
 
         # ライセンス文が pip から取得できていない場合、pip 外から補う
-        if raw_license.LicenseText == "UNKNOWN":
-            if package_name == "core" and raw_license.Version == "0.0.0":
+        if pip_license.LicenseText == "UNKNOWN":
+            if package_name == "core" and pip_license.Version == "0.0.0":
                 continue
             if package_name not in package_to_license_url:
                 # ライセンスがpypiに無い
                 raise Exception(f"No License info provided for {package_name}")
             text_url = package_to_license_url[package_name]
-            raw_license.LicenseText = _get_license_text(text_url)
+            pip_license.LicenseText = _get_license_text(text_url)
 
         # soxr
         if package_name == "soxr":
             text_url = "https://raw.githubusercontent.com/dofuuz/python-soxr/v0.3.6/LICENSE.txt"
-            raw_license.LicenseText = _get_license_text(text_url)
+            pip_license.LicenseText = _get_license_text(text_url)
 
         updated_licenses.append(
             _License(
-                package_name=raw_license.Name,
-                package_version=raw_license.Version,
-                license_name=raw_license.License,
-                license_text=raw_license.LicenseText,
+                package_name=pip_license.Name,
+                package_version=pip_license.Version,
+                license_name=pip_license.License,
+                license_text=pip_license.LicenseText,
                 license_text_type="raw",
             )
         )


### PR DESCRIPTION
## 内容
ライセンス情報の生成を整理するリファクタリングを提案します。  

以下の3点の変更をおこなっています：  

- 定義順序を利用順に並べ替え （https://github.com/VOICEVOX/voicevox_engine/pull/1602#discussion_r2039484255 ）
- 変数名を単純化（https://github.com/VOICEVOX/voicevox_engine/pull/1602#discussion_r2039485267 ）
- エラー docstring を追加

## 関連 Issue
successor of #1602