### PR TITLE
add: モーフィング API に upspeak 設定を追加

### DIFF
--- a/test/e2e/__snapshots__/test_openapi/test_OpenAPIの形が変わっていないことを確認.json
+++ b/test/e2e/__snapshots__/test_openapi/test_OpenAPIの形が変わっていないことを確認.json
@@ -3057,6 +3057,18 @@
             }
           },
           {
+            "description": "疑問系のテキストが与えられたら語尾を自動調整する",
+            "in": "query",
+            "name": "enable_interrogative_upspeak",
+            "required": false,
+            "schema": {
+              "default": true,
+              "description": "疑問系のテキストが与えられたら語尾を自動調整する",
+              "title": "Enable Interrogative Upspeak",
+              "type": "boolean"
+            }
+          },
+          {
             "in": "query",
             "name": "core_version",
             "required": false,

--- a/voicevox_engine/app/routers/morphing.py
+++ b/voicevox_engine/app/routers/morphing.py
@@ -112,9 +112,9 @@ def generate_morphing_router(
         morph_param = synthesis_morphing_parameter(
             engine=engine,
             query=query,
-            enable_interrogative_upspeak=enable_interrogative_upspeak,
             base_style_id=base_style_id,
             target_style_id=target_style_id,
+            enable_interrogative_upspeak=enable_interrogative_upspeak,
         )
 
         morph_wave = synthesize_morphed_wave(

--- a/voicevox_engine/app/routers/morphing.py
+++ b/voicevox_engine/app/routers/morphing.py
@@ -91,6 +91,9 @@ def generate_morphing_router(
         version = core_version or LATEST_VERSION
         engine = tts_engines.get_tts_engine(version)
 
+        # TODO: `enable_interrogative_upspeak` を API の引数へ追加する (voicevox engine #534)
+        enable_interrogative_upspeak = True
+
         # モーフィングが許可されないキャラクターペアを拒否する
         characters = metas_store.characters(core_version)
         try:
@@ -106,6 +109,7 @@ def generate_morphing_router(
         morph_param = synthesis_morphing_parameter(
             engine=engine,
             query=query,
+            enable_interrogative_upspeak=enable_interrogative_upspeak,
             base_style_id=base_style_id,
             target_style_id=target_style_id,
         )

--- a/voicevox_engine/app/routers/morphing.py
+++ b/voicevox_engine/app/routers/morphing.py
@@ -81,12 +81,12 @@ def generate_morphing_router(
         base_style_id: Annotated[StyleId, Query(alias="base_speaker")],
         target_style_id: Annotated[StyleId, Query(alias="target_speaker")],
         morph_rate: Annotated[float, Query(ge=0.0, le=1.0)],
-        # enable_interrogative_upspeak: Annotated[
-        #     bool,
-        #     Query(
-        #         description="疑問系のテキストが与えられたら語尾を自動調整する",
-        #     ),
-        # ] = True,
+        enable_interrogative_upspeak: Annotated[
+            bool,
+            Query(
+                description="疑問系のテキストが与えられたら語尾を自動調整する",
+            ),
+        ] = True,
         core_version: str | SkipJsonSchema[None] = None,
     ) -> FileResponse:
         """
@@ -96,9 +96,6 @@ def generate_morphing_router(
         """
         version = core_version or LATEST_VERSION
         engine = tts_engines.get_tts_engine(version)
-
-        # TODO: `enable_interrogative_upspeak` を API の引数へ追加する (voicevox engine #534)
-        enable_interrogative_upspeak = True
 
         # モーフィングが許可されないキャラクターペアを拒否する
         characters = metas_store.characters(core_version)

--- a/voicevox_engine/app/routers/morphing.py
+++ b/voicevox_engine/app/routers/morphing.py
@@ -81,6 +81,12 @@ def generate_morphing_router(
         base_style_id: Annotated[StyleId, Query(alias="base_speaker")],
         target_style_id: Annotated[StyleId, Query(alias="target_speaker")],
         morph_rate: Annotated[float, Query(ge=0.0, le=1.0)],
+        # enable_interrogative_upspeak: Annotated[
+        #     bool,
+        #     Query(
+        #         description="疑問系のテキストが与えられたら語尾を自動調整する",
+        #     ),
+        # ] = True,
         core_version: str | SkipJsonSchema[None] = None,
     ) -> FileResponse:
         """

--- a/voicevox_engine/morphing/morphing.py
+++ b/voicevox_engine/morphing/morphing.py
@@ -108,6 +108,7 @@ def is_morphable(
 def synthesis_morphing_parameter(
     engine: TTSEngine,
     query: AudioQuery,
+    enable_interrogative_upspeak: bool,
     base_style_id: StyleId,
     target_style_id: StyleId,
 ) -> _MorphingParameter:
@@ -120,8 +121,14 @@ def synthesis_morphing_parameter(
     # WORLDに掛けるため合成はモノラルで行う
     query.outputStereo = False
 
-    base_wave = engine.synthesize_wave(query, base_style_id).astype(np.double)
-    target_wave = engine.synthesize_wave(query, target_style_id).astype(np.double)
+    base_wave = engine.synthesize_wave(
+        query, base_style_id, enable_interrogative_upspeak=enable_interrogative_upspeak
+    ).astype(np.double)
+    target_wave = engine.synthesize_wave(
+        query,
+        target_style_id,
+        enable_interrogative_upspeak=enable_interrogative_upspeak,
+    ).astype(np.double)
 
     fs = query.outputSamplingRate
     frame_period = 1.0

--- a/voicevox_engine/morphing/morphing.py
+++ b/voicevox_engine/morphing/morphing.py
@@ -108,9 +108,9 @@ def is_morphable(
 def synthesis_morphing_parameter(
     engine: TTSEngine,
     query: AudioQuery,
-    enable_interrogative_upspeak: bool,
     base_style_id: StyleId,
     target_style_id: StyleId,
+    enable_interrogative_upspeak: bool,
 ) -> _MorphingParameter:
     """音声を合成しモーフィング用パラメータへ変換する。"""
     query = deepcopy(query)


### PR DESCRIPTION
## 内容
モーフィング API に upspeak 設定（`enable_interrogative_upspeak`）を追加することを提案します。  

## 関連 Issue
resolve #534

## その他
この設定を引数に追加することは既存の動作に影響を与えません。  

モーフィング機能が内部で呼んでいる `engine.synthesize_wave()` は `enable_interrogative_upspeak` のデフォルト引数が `True` です。そのため現在のモーフィング機能は「常時 enable_interrogative_upspeak」状態にあります。つまり #534 の主題である「疑似疑問文に対応する」は最初から（部分的に）達成されています。  
不足していたのはこの設定の ON/OFF を管理する機能で、それが API における `enable_interrogative_upspeak` 引数です。この PR は欠けていたAPI 引数 `enable_interrogative_upspeak` を追加しています。  
API 引数 `enable_interrogative_upspeak` はデフォルト引数に `True` を採用したため、特に指定しなければ現行の動作と完全に一致します。  
この PR によってモーフィング API のベース音声合成機能（≠ 音声混合機能）は `/synthesis` API の音声合成機能と同一レベルになります。  