### PR TITLE
refactor: assert をエラーで置き換え

### DIFF
--- a/run.py
+++ b/run.py
@@ -327,8 +327,10 @@ def main() -> None:
     )
     tts_engines = make_tts_engines_from_cores(core_manager)
     song_engines = make_song_engines_from_cores(core_manager)
-    assert len(tts_engines.versions()) != 0, "音声合成エンジンがありません。"
-    assert len(song_engines.versions()) != 0, "音声合成エンジンがありません。"
+    if len(tts_engines.versions()) == 0:
+        raise Exception("音声合成エンジンがありません。")
+    if len(song_engines.versions()) == 0:
+        raise Exception("音声合成エンジンがありません。")
 
     cancellable_engine: CancellableEngine | None = None
     if args.enable_cancellable_synthesis:

--- a/test/unit/user_dict/test_user_dict.py
+++ b/test/unit/user_dict/test_user_dict.py
@@ -253,7 +253,7 @@ def test_import_invalid_word(tmp_path: Path) -> None:
         json.dumps(valid_dict_dict_json, ensure_ascii=False), encoding="utf-8"
     )
     user_dict = UserDictionary(user_dict_path=user_dict_path)
-    with pytest.raises(AssertionError):
+    with pytest.raises(UserDictInputError):
         user_dict.import_user_dict(
             {
                 "aab7dda2-0d97-43c8-8cb7-3f440dab9b4e": invalid_accent_associative_rule_word

--- a/tools/check_release_build.py
+++ b/tools/check_release_build.py
@@ -25,11 +25,14 @@ def _test_release_build(
     # マニフェストファイルの確認
     if not skip_check_manifest:
         manifest_file = dist_dir / "engine_manifest.json"
-        assert manifest_file.is_file()
+        if not manifest_file.is_file():
+            raise Exception
         manifest = json.loads(manifest_file.read_text(encoding="utf-8"))
-        assert "manifest_version" in manifest
+        if "manifest_version" not in manifest:
+            raise Exception
         command_filename = shlex.split(manifest["command"])[0]
-        assert (dist_dir / command_filename).exists()
+        if not (dist_dir / command_filename).exists():
+            raise Exception
 
     # 起動
     process = None
@@ -72,12 +75,15 @@ def _test_release_build(
     req = Request(base_url + "engine_manifest", method="GET")
     with urlopen(req) as res:
         manifest = json.loads(res.read().decode("utf-8"))
-        assert "uuid" in manifest
+        if "uuid" not in manifest:
+            raise Exception
 
     if not skip_run_process:
         # プロセスが稼働中であることを確認
-        assert process is not None
-        assert process.poll() is None
+        if process is None:
+            raise Exception
+        if process.poll() is not None:
+            raise Exception
 
         # 停止
         process.terminate()

--- a/tools/get_cost_candidates.py
+++ b/tools/get_cost_candidates.py
@@ -58,7 +58,8 @@ def _get_candidates(
                 pos_detail_3,
             ):
                 costs.append(int(_cost))
-    assert len(costs) > 0
+    if len(costs) <= 0:
+        raise Exception
     cost_min = min(costs) - 1
     cost_1per = np.quantile(costs, 0.01).astype(np.int64)
     cost_mode = statistics.mode(costs)

--- a/tools/merge_engine_manifest.py
+++ b/tools/merge_engine_manifest.py
@@ -12,19 +12,24 @@ def _merge_json_string(src: str, dst: str) -> str:
     dst_json: dict[str, JsonValue | dict[str, dict[str, JsonValue]]] = json.loads(dst)
 
     for key, dst_value in dst_json.items():
-        assert key in src_json, f"Key {key} is not found in src_json"
+        if key not in src_json:
+            raise Exception(f"Key {key} is not found in src_json")
 
         # `manage_library` のみdictなので特別に処理
         if key == "supported_features":
-            assert isinstance(dst_value, dict)
+            if not isinstance(dst_value, dict):
+                raise Exception("dst_value が dict 以外である。")
             src_value = src_json[key]
-            assert isinstance(src_value, dict)
+            if not isinstance(src_value, dict):
+                raise Exception("src_value が dict 以外である。")
             src_value.update(dst_value)
 
         else:
             src_value = src_json[key]
-            assert isinstance(src_value, JsonValue)
-            assert isinstance(dst_value, JsonValue)
+            if not isinstance(src_value, JsonValue):
+                raise Exception("src_value が JsonValue 以外である。")
+            if not isinstance(dst_value, JsonValue):
+                raise Exception("dst_value が JsonValue 以外である。")
             src_json[key] = dst_value
 
     return json.dumps(src_json, ensure_ascii=False)

--- a/tools/merge_update_infos.py
+++ b/tools/merge_update_infos.py
@@ -35,8 +35,10 @@ def merge_json_string(src: str, dst: str) -> str:
 
                     src_value = src_item[key]
                     dst_value = dst_item[key]
-                    assert isinstance(src_value, list)
-                    assert isinstance(dst_value, list)
+                    if not isinstance(src_value, list):
+                        raise Exception("src_value が list 以外である。")
+                    if not isinstance(dst_value, list):
+                        raise Exception("dst_value が list 以外である。")
 
                     # 異なるものがあった場合だけ後ろに付け足す
                     src_item[key] = list(OrderedDict.fromkeys(src_value + dst_value))

--- a/voicevox_engine/cancellable_engine.py
+++ b/voicevox_engine/cancellable_engine.py
@@ -202,7 +202,8 @@ def start_synthesis_subprocess(
         enable_mock=enable_mock,
     )
     tts_engines = make_tts_engines_from_cores(core_manager)
-    assert len(tts_engines.versions()) != 0, "音声合成エンジンがありません。"
+    if len(tts_engines.versions()) == 0:
+        raise CancellableEngineInternalError("音声合成エンジンがありません。")
 
     while True:
         try:

--- a/voicevox_engine/core/core_adapter.py
+++ b/voicevox_engine/core/core_adapter.py
@@ -10,7 +10,7 @@ from numpy.typing import NDArray
 from pydantic import TypeAdapter
 
 from ..metas.Metas import StyleId
-from .core_wrapper import CoreWrapper, OldCoreError
+from .core_wrapper import CoreError, CoreWrapper, OldCoreError
 
 CoreStyleId = NewType("CoreStyleId", int)
 CoreStyleType = Literal["talk", "singing_teacher", "frame_decode", "sing"]
@@ -75,7 +75,8 @@ class CoreAdapter:
         """デバイスサポート情報（None: 情報無し）"""
         try:
             supported_devices = json.loads(self.core.supported_devices())
-            assert isinstance(supported_devices, dict)
+            if not isinstance(supported_devices, dict):
+                raise CoreError()
             device_support = DeviceSupport(
                 cpu=supported_devices["cpu"],
                 cuda=supported_devices["cuda"],

--- a/voicevox_engine/core/core_wrapper.py
+++ b/voicevox_engine/core/core_wrapper.py
@@ -599,7 +599,8 @@ class CoreWrapper:
             model_type = "onnxruntime"
         else:
             model_type = _check_core_type(core_dir)
-        assert model_type is not None
+        if model_type is None:
+            raise CoreError
 
         if model_type == "onnxruntime":
             exist_cpu_num_threads = True

--- a/voicevox_engine/dev/core/mock.py
+++ b/voicevox_engine/dev/core/mock.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import numpy as np
 from numpy.typing import NDArray
 
-from ...core.core_wrapper import CoreWrapper
+from ...core.core_wrapper import CoreError, CoreWrapper
 
 
 class MockCoreWrapper(CoreWrapper):
@@ -95,7 +95,8 @@ class MockCoreWrapper(CoreWrapper):
         style_id: NDArray[np.int64],
     ) -> NDArray[np.float32]:
         """モーラ系列サイズ・母音系列・子音系列・アクセント位置・アクセント句区切り・スタイルIDからモーラ音高系列を生成する"""
-        assert length > 1, "前後無音を必ず付与しなければならない"
+        if length <= 1:
+            raise CoreError("前後無音を必ず付与しなければならない")
 
         # TODO: トークスタイル以外はエラーにする
 

--- a/voicevox_engine/tts_pipeline/connect_base64_waves.py
+++ b/voicevox_engine/tts_pipeline/connect_base64_waves.py
@@ -56,7 +56,9 @@ def connect_base64_waves(waves: list[str]) -> tuple[NDArray[np.float64], int]:
 
     max_sampling_rate = max([sr for _, sr in waves_nparray_sr])
     max_channels = max([x.ndim for x, _ in waves_nparray_sr])
-    assert 0 < max_channels <= 2
+    if not 0 < max_channels <= 2:
+        msg = "音声波形のチャンネル数が正常範囲を超えています。"
+        raise ConnectBase64WavesException(msg)
 
     waves_nparray_list = []
     for nparray, sr in waves_nparray_sr:

--- a/voicevox_engine/user_dict/user_dict_manager.py
+++ b/voicevox_engine/user_dict/user_dict_manager.py
@@ -259,23 +259,33 @@ class UserDictionary:
             UUID(word_uuid)
             for pos_detail in part_of_speech_data.values():
                 if word.context_id == pos_detail.context_id:
-                    assert word.part_of_speech == pos_detail.part_of_speech
-                    assert (
+                    if word.part_of_speech != pos_detail.part_of_speech:
+                        msg = f"単語 {word.surface} の part_of_speech 属性が不正です。"
+                        raise UserDictInputError(msg)
+                    if (
                         word.part_of_speech_detail_1
-                        == pos_detail.part_of_speech_detail_1
-                    )
-                    assert (
+                        != pos_detail.part_of_speech_detail_1
+                    ):
+                        msg = f"単語 {word.surface} の part_of_speech_detail_1 属性が不正です。"
+                        raise UserDictInputError(msg)
+                    if (
                         word.part_of_speech_detail_2
-                        == pos_detail.part_of_speech_detail_2
-                    )
-                    assert (
+                        != pos_detail.part_of_speech_detail_2
+                    ):
+                        msg = f"単語 {word.surface} の part_of_speech_detail_2 属性が不正です。"
+                        raise UserDictInputError(msg)
+                    if (
                         word.part_of_speech_detail_3
-                        == pos_detail.part_of_speech_detail_3
-                    )
-                    assert (
+                        != pos_detail.part_of_speech_detail_3
+                    ):
+                        msg = f"単語 {word.surface} の part_of_speech_detail_3 属性が不正です。"
+                        raise UserDictInputError(msg)
+                    if (
                         word.accent_associative_rule
-                        in pos_detail.accent_associative_rules
-                    )
+                        not in pos_detail.accent_associative_rules
+                    ):
+                        msg = f"単語 {word.surface} の accent_associative_rule 属性が不正です。"
+                        raise UserDictInputError(msg)
                     break
             else:
                 raise ValueError("対応していない品詞です")

--- a/voicevox_engine/user_dict/user_dict_word.py
+++ b/voicevox_engine/user_dict/user_dict_word.py
@@ -140,7 +140,9 @@ def _search_cost_candidates(context_id: int) -> list[int]:
 
 
 def _cost2priority(context_id: int, cost: int) -> int:
-    assert -32768 <= cost <= 32767
+    if not -32768 <= cost <= 32767:
+        raise UserDictInputError(f"コスト {cost} は正常範囲を超えています。")
+
     cost_candidates = _search_cost_candidates(context_id)
     # cost_candidatesの中にある値で最も近い値を元にpriorityを返す
     # 参考: https://qiita.com/Krypf/items/2eada91c37161d17621d
@@ -153,7 +155,9 @@ def _cost2priority(context_id: int, cost: int) -> int:
 
 def priority2cost(context_id: int, priority: int) -> int:
     """優先度をコストへ変換する。"""
-    assert USER_DICT_MIN_PRIORITY <= priority <= USER_DICT_MAX_PRIORITY
+    if not USER_DICT_MIN_PRIORITY <= priority <= USER_DICT_MAX_PRIORITY:
+        raise UserDictInputError(f"優先度 {priority} は正常範囲を超えています。")
+
     cost_candidates = _search_cost_candidates(context_id)
     return cost_candidates[USER_DICT_MAX_PRIORITY - priority]
 


### PR DESCRIPTION
## 内容
assert をエラーで置き換えるリファクタリングを提案します。  

Python の組み込み `assert` は実行時の設定により無視される/実行されない場合があります。そのため `assert` の利用は基本的にテストのみに限られるべきです（例: ruff rule [S101](https://docs.astral.sh/ruff/rules/assert/)）。  

## 関連 Issue
無し