### PR TITLE
refactor: ruff ルール `A` を適用

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 target-version = "py311"
 
 [tool.ruff.lint]
-select = ["E", "F", "B", "I", "W", "UP", "D"]
+select = ["E", "F", "B", "I", "W", "UP", "D", "A"]
 ignore = [
   "E501", # line-too-long
   "D400", # missing-trailing-period。日本語の「。」に対応していないため。

--- a/test/unit/preset/test_preset.py
+++ b/test/unit/preset/test_preset.py
@@ -81,11 +81,11 @@ def test_add_preset(tmp_path: Path) -> None:
             "pauseLengthScale": 1.0,
         }
     )
-    id = preset_manager.add_preset(preset)
-    assert id == 10
+    preset_id = preset_manager.add_preset(preset)
+    assert preset_id == 10
     assert len(preset_manager.presets) == 3
     for _preset in preset_manager.presets:
-        if _preset.id == id:
+        if _preset.id == preset_id:
             assert _preset == preset
     remove(preset_path)
 
@@ -134,11 +134,11 @@ def test_add_preset_conflict_id(tmp_path: Path) -> None:
             "pauseLengthScale": 1.0,
         }
     )
-    id = preset_manager.add_preset(preset)
-    assert id == 3
+    preset_id = preset_manager.add_preset(preset)
+    assert preset_id == 3
     assert len(preset_manager.presets) == 3
     for _preset in preset_manager.presets:
-        if _preset.id == id:
+        if _preset.id == preset_id:
             assert _preset == preset
     remove(preset_path)
 
@@ -163,11 +163,11 @@ def test_add_preset_conflict_id2(tmp_path: Path) -> None:
             "pauseLengthScale": 1.0,
         }
     )
-    id = preset_manager.add_preset(preset)
-    assert id == 3
+    preset_id = preset_manager.add_preset(preset)
+    assert preset_id == 3
     assert len(preset_manager.presets) == 3
     for _preset in preset_manager.presets:
-        if _preset.id == id:
+        if _preset.id == preset_id:
             assert _preset == preset
     remove(preset_path)
 
@@ -222,11 +222,11 @@ def test_update_preset(tmp_path: Path) -> None:
             "pauseLengthScale": 1.0,
         }
     )
-    id = preset_manager.update_preset(preset)
-    assert id == 1
+    preset_id = preset_manager.update_preset(preset)
+    assert preset_id == 1
     assert len(preset_manager.presets) == 2
     for _preset in preset_manager.presets:
-        if _preset.id == id:
+        if _preset.id == preset_id:
             assert _preset == preset
     remove(preset_path)
 
@@ -317,8 +317,8 @@ def test_delete_preset(tmp_path: Path) -> None:
     preset_path = tmp_path / "presets.yaml"
     copyfile(presets_test_1_yaml_path, preset_path)
     preset_manager = PresetManager(preset_path=preset_path)
-    id = preset_manager.delete_preset(1)
-    assert id == 1
+    preset_id = preset_manager.delete_preset(1)
+    assert preset_id == 1
     assert len(preset_manager.presets) == 1
     remove(preset_path)
 

--- a/tools/generate_licenses.py
+++ b/tools/generate_licenses.py
@@ -133,9 +133,9 @@ class _LicenseError(Exception):
 
 
 def _validate_license_compliance(licenses: list[_License]) -> None:
-    for license in licenses:
+    for _license in licenses:
         # ライセンスを確認する
-        license_names_str = license.license_name or ""
+        license_names_str = _license.license_name or ""
         license_names = license_names_str.split("; ")
         for license_name in license_names:
             if license_name in [
@@ -145,7 +145,7 @@ def _validate_license_compliance(licenses: list[_License]) -> None:
                 "GNU Affero General Public License v3 (AGPL-3)",
             ]:
                 raise _LicenseError(
-                    f"ライセンス違反: {license.package_name} is {license.license_name}"
+                    f"ライセンス違反: {_license.package_name} is {_license.license_name}"
                 )
 
 
@@ -326,12 +326,12 @@ if __name__ == "__main__":
     json.dump(
         [
             {
-                "name": license.package_name,
-                "version": license.package_version,
-                "license": license.license_name,
-                "text": license.license_text,
+                "name": _license.package_name,
+                "version": _license.package_version,
+                "license": _license.license_name,
+                "text": _license.license_text,
             }
-            for license in licenses
+            for _license in licenses
         ],
         out,
     )

--- a/voicevox_engine/app/routers/preset.py
+++ b/voicevox_engine/app/routers/preset.py
@@ -49,12 +49,12 @@ def generate_preset_router(
     ) -> int:
         """新しいプリセットを追加します。"""
         try:
-            id = preset_manager.add_preset(preset)
+            preset_id = preset_manager.add_preset(preset)
         except PresetInputError as e:
             raise HTTPException(status_code=422, detail=str(e)) from e
         except PresetInternalError as e:
             raise HTTPException(status_code=500, detail=str(e)) from e
-        return id
+        return preset_id
 
     @router.post(
         "/update_preset",
@@ -71,12 +71,12 @@ def generate_preset_router(
     ) -> int:
         """既存のプリセットを更新します。"""
         try:
-            id = preset_manager.update_preset(preset)
+            preset_id = preset_manager.update_preset(preset)
         except PresetInputError as e:
             raise HTTPException(status_code=422, detail=str(e)) from e
         except PresetInternalError as e:
             raise HTTPException(status_code=500, detail=str(e)) from e
-        return id
+        return preset_id
 
     @router.post(
         "/delete_preset",
@@ -84,7 +84,7 @@ def generate_preset_router(
         dependencies=[Depends(verify_mutability)],
     )
     def delete_preset(
-        id: Annotated[int, Query(description="削除するプリセットのプリセットID")],
+        id: Annotated[int, Query(description="削除するプリセットのプリセットID")],  # noqa: A002 - API を優先
     ) -> None:
         """既存のプリセットを削除します。"""
         try:

--- a/voicevox_engine/metas/MetasStore.py
+++ b/voicevox_engine/metas/MetasStore.py
@@ -196,14 +196,14 @@ class MetasStore:
             # スタイル情報を取得する
             style_infos = []
             for style in character.talk_styles + character.sing_styles:
-                id = style.id
+                sid = style.id
 
                 # style icon
-                style_icon_path = character_path / "icons" / f"{id}.png"
+                style_icon_path = character_path / "icons" / f"{sid}.png"
                 icon = _resource_str(style_icon_path)
 
                 # style portrait
-                style_portrait_path = character_path / "portraits" / f"{id}.png"
+                style_portrait_path = character_path / "portraits" / f"{sid}.png"
                 style_portrait = None
                 if style_portrait_path.exists():
                     style_portrait = _resource_str(style_portrait_path)
@@ -212,12 +212,12 @@ class MetasStore:
                 voice_samples: list[str] = []
                 for j in range(3):
                     num = str(j + 1).zfill(3)
-                    voice_path = character_path / "voice_samples" / f"{id}_{num}.wav"
+                    voice_path = character_path / "voice_samples" / f"{sid}_{num}.wav"
                     voice_samples.append(_resource_str(voice_path))
 
                 style_infos.append(
                     {
-                        "id": id,
+                        "id": sid,
                         "icon": icon,
                         "portrait": style_portrait,
                         "voice_samples": voice_samples,

--- a/voicevox_engine/preset/preset_manager.py
+++ b/voicevox_engine/preset/preset_manager.py
@@ -143,7 +143,7 @@ class PresetManager:
 
         return preset.id
 
-    def delete_preset(self, id: int) -> int:
+    def delete_preset(self, preset_id: int) -> int:
         """ID で指定されたプリセットを削除し、その ID を取得する。"""
         # データベース更新の反映
         self._refresh_cache()
@@ -152,7 +152,7 @@ class PresetManager:
         buf = None
         buf_index = -1
         for i in range(len(self.presets)):
-            if self.presets[i].id == id:
+            if self.presets[i].id == preset_id:
                 buf = self.presets.pop(i)
                 buf_index = i
                 break
@@ -166,7 +166,7 @@ class PresetManager:
             self.presets.insert(buf_index, buf)
             raise PresetInternalError("プリセットの書き込みに失敗しました") from e
 
-        return id
+        return preset_id
 
     def _write_on_file(self) -> None:
         """プリセット情報のファイル（簡易データベース）書き込み"""


### PR DESCRIPTION
## 内容
ruff ルール `A` を適用するリファクタリングを提案します。  

ルール `A` は「built-in と同名を使う」に関するルールであり、一般論としてレビューでよく指摘される内容です。これらルールを適用することでレビュー負荷が低減できると考えます。  

## 関連 Issue
無し