### PR TITLE
refactor: テストをリント

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 target-version = "py311"
 
 [tool.ruff.lint]
-select = ["E", "F", "B", "I", "W", "UP", "D"]
+select = ["E", "F", "B", "I", "W", "UP", "D", "PT"]
 ignore = [
   "E501", # line-too-long
   "D400", # missing-trailing-period。日本語の「。」に対応していないため。

--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -32,7 +32,7 @@ def _copy_under_dir(file_path: Path, dir_path: Path) -> Path:
     return copied_file_path
 
 
-@pytest.fixture()
+@pytest.fixture
 def app_params(tmp_path: Path) -> dict[str, Any]:
     """`generate_app` の全ての引数を生成する。"""
     core_manager = initialize_cores(use_gpu=False, enable_mock=True)
@@ -72,13 +72,13 @@ def app_params(tmp_path: Path) -> dict[str, Any]:
     }
 
 
-@pytest.fixture()
+@pytest.fixture
 def app(app_params: dict[str, Any]) -> FastAPI:
     """app インスタンスを生成する。"""
     return generate_app(**app_params)
 
 
-@pytest.fixture()
+@pytest.fixture
 def client(app: FastAPI) -> TestClient:
     """HTTP リクエストを VOICEVOX ENGINE へ送信するクライアントを生成する。"""
     return TestClient(app)

--- a/test/e2e/single_api/tts_pipeline/test_cancellable_synthesis.py
+++ b/test/e2e/single_api/tts_pipeline/test_cancellable_synthesis.py
@@ -12,7 +12,7 @@ from voicevox_engine.app.application import generate_app
 from voicevox_engine.cancellable_engine import CancellableEngine
 
 
-@pytest.fixture()
+@pytest.fixture
 def cancellable_client(app_params: dict[str, Any]) -> TestClient:
     app_params["cancellable_engine"] = CancellableEngine(
         init_processes=1,

--- a/test/unit/library/test_library_manager.py
+++ b/test/unit/library/test_library_manager.py
@@ -11,6 +11,8 @@ from typing import Any
 from unittest import TestCase
 from zipfile import ZipFile
 
+import pytest
+
 from voicevox_engine.library.library_manager import (
     LibraryFormatInvalidError,
     LibraryManager,
@@ -79,29 +81,30 @@ class _TestLibraryManager(TestCase):
         self.library_filename.unlink()
 
     def test_installed_libraries(self) -> None:
-        self.assertEqual(self.library_manger.installed_libraries(), {})
+        assert self.library_manger.installed_libraries() == {}
 
         self.library_manger.install_library(
             self.library_uuid,
             self.library_file,
         )
         # 内容はdownloadable_library.jsonを元に生成されるので、内容は確認しない
-        self.assertEqual(
-            list(self.library_manger.installed_libraries().keys())[0], self.library_uuid
+        assert (
+            list(self.library_manger.installed_libraries().keys())[0]
+            == self.library_uuid
         )
 
         self.library_manger.uninstall_library(self.library_uuid)
-        self.assertEqual(self.library_manger.installed_libraries(), {})
+        assert self.library_manger.installed_libraries() == {}
 
     def test_install_unauthorized_library(self) -> None:
         """エンジンの受け入れリストに ID の無い音声ライブラリはインストールできない。"""
         invalid_uuid = "52398bd5-3cc3-406c-a159-dfec5ace4bab"
-        with self.assertRaises(LibraryNotFoundError):
+        with pytest.raises(LibraryNotFoundError):
             self.library_manger.install_library(invalid_uuid, self.library_file)
 
     def test_install_non_zip_file(self) -> None:
         """非 ZIP ファイルは音声ライブラリとしてインストールできない。"""
-        with self.assertRaises(LibraryFormatInvalidError):
+        with pytest.raises(LibraryFormatInvalidError):
             self.library_manger.install_library(self.library_uuid, BytesIO())
 
     def test_install_manifest_less_library(self) -> None:
@@ -110,7 +113,7 @@ class _TestLibraryManager(TestCase):
         create_vvlib_without_manifest(invalid_vvlib_name, self.library_filename)
         with (
             open(invalid_vvlib_name, "br") as f,
-            self.assertRaises(LibraryFormatInvalidError),
+            pytest.raises(LibraryFormatInvalidError),
         ):
             self.library_manger.install_library(self.library_uuid, f)
 
@@ -128,7 +131,7 @@ class _TestLibraryManager(TestCase):
 
         with (
             open(invalid_vvlib_name, "br") as f,
-            self.assertRaises(LibraryFormatInvalidError),
+            pytest.raises(LibraryFormatInvalidError),
         ):
             self.library_manger.install_library(self.library_uuid, f)
 
@@ -148,7 +151,7 @@ class _TestLibraryManager(TestCase):
         # Tests
         with (
             open(invalid_vvlib_name, "br") as f,
-            self.assertRaises(LibraryFormatInvalidError),
+            pytest.raises(LibraryFormatInvalidError),
         ):
             self.library_manger.install_library(self.library_uuid, f)
 
@@ -169,7 +172,7 @@ class _TestLibraryManager(TestCase):
         # Tests
         with (
             open(invalid_vvlib_name, "br") as f,
-            self.assertRaises(LibraryFormatInvalidError),
+            pytest.raises(LibraryFormatInvalidError),
         ):
             self.library_manger.install_library(self.library_uuid, f)
 
@@ -190,7 +193,7 @@ class _TestLibraryManager(TestCase):
         # Tests
         with (
             open(invalid_vvlib_name, "br") as f,
-            self.assertRaises(LibraryFormatInvalidError),
+            pytest.raises(LibraryFormatInvalidError),
         ):
             self.library_manger.install_library(self.library_uuid, f)
 
@@ -211,7 +214,7 @@ class _TestLibraryManager(TestCase):
         # Tests
         with (
             open(invalid_vvlib_name, "br") as f,
-            self.assertRaises(LibraryUnsupportedError),
+            pytest.raises(LibraryUnsupportedError),
         ):
             self.library_manger.install_library(self.library_uuid, f)
 
@@ -233,7 +236,7 @@ class _TestLibraryManager(TestCase):
         # Tests
         with (
             open(invalid_vvlib_name, "br") as f,
-            self.assertRaises(LibraryUnsupportedError),
+            pytest.raises(LibraryUnsupportedError),
         ):
             self.library_manger.install_library(self.library_uuid, f)
 
@@ -245,13 +248,13 @@ class _TestLibraryManager(TestCase):
         library_path = self.library_manger.install_library(
             self.library_uuid, self.library_file
         )
-        self.assertEqual(self.tmp_dir_path / self.library_uuid, library_path)
+        assert self.tmp_dir_path / self.library_uuid == library_path
 
         self.library_manger.uninstall_library(self.library_uuid)
 
     def test_uninstall_library(self) -> None:
         # TODO: アンインストール出来ないライブラリをテストできるようにしたい
-        with self.assertRaises(LibraryNotFoundError):
+        with pytest.raises(LibraryNotFoundError):
             self.library_manger.uninstall_library(self.library_uuid)
 
         self.library_manger.install_library(self.library_uuid, self.library_file)

--- a/test/unit/tts_pipeline/test_kana_converter.py
+++ b/test/unit/tts_pipeline/test_kana_converter.py
@@ -2,6 +2,8 @@
 
 from unittest import TestCase
 
+import pytest
+
 from voicevox_engine.tts_pipeline import kana_converter
 from voicevox_engine.tts_pipeline.kana_converter import ParseKanaError, create_kana
 from voicevox_engine.tts_pipeline.model import AccentPhrase, Mora, ParseKanaErrorCode
@@ -545,9 +547,9 @@ def test_interrogative_accent_phrase_marks() -> None:
 
 class _TestParseKanaException(TestCase):
     def _assert_error_code(self, kana: str, code: ParseKanaErrorCode) -> None:
-        with self.assertRaises(ParseKanaError) as e:
+        with pytest.raises(ParseKanaError) as e:
             parse_kana(kana)
-        self.assertEqual(e.exception.errcode, code)
+        assert e.value.errcode == code
 
     def test_exceptions(self) -> None:
         self._assert_error_code("アクセント", ParseKanaErrorCode.ACCENT_NOTFOUND)
@@ -559,21 +561,19 @@ class _TestParseKanaException(TestCase):
         self._assert_error_code("/ア'", ParseKanaErrorCode.EMPTY_PHRASE)
         self._assert_error_code("", ParseKanaErrorCode.EMPTY_PHRASE)
 
-        with self.assertRaises(ParseKanaError) as e:
+        with pytest.raises(ParseKanaError) as e:
             parse_kana("ヒト'ツメ/フタツメ")
-        self.assertEqual(e.exception.errcode, ParseKanaErrorCode.ACCENT_NOTFOUND)
-        self.assertEqual(e.exception.kwargs, {"text": "フタツメ"})
+        assert e.value.errcode == ParseKanaErrorCode.ACCENT_NOTFOUND
+        assert e.value.kwargs == {"text": "フタツメ"}
 
-        with self.assertRaises(ParseKanaError) as e:
+        with pytest.raises(ParseKanaError) as e:
             parse_kana("ア'/")
-        self.assertEqual(e.exception.errcode, ParseKanaErrorCode.EMPTY_PHRASE)
-        self.assertEqual(e.exception.kwargs, {"position": "2"})
+        assert e.value.errcode == ParseKanaErrorCode.EMPTY_PHRASE
+        assert e.value.kwargs == {"position": "2"}
 
-        with self.assertRaises(ParseKanaError) as e:
+        with pytest.raises(ParseKanaError) as e:
             kana_converter.parse_kana("ア？ア'")
-        self.assertEqual(
-            e.exception.errcode, ParseKanaErrorCode.INTERROGATION_MARK_NOT_AT_END
-        )
+        assert e.value.errcode == ParseKanaErrorCode.INTERROGATION_MARK_NOT_AT_END
 
 
 def test_create_kana_interrogative() -> None:

--- a/test/unit/tts_pipeline/test_phoneme.py
+++ b/test/unit/tts_pipeline/test_phoneme.py
@@ -13,7 +13,7 @@ def test_unknown_phoneme() -> None:
     unknown_phoneme = Phoneme("xx")
 
     # Tests
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="not in tuple"):
         _ = unknown_phoneme.id
 
 

--- a/test/unit/tts_pipeline/test_text_analyzer.py
+++ b/test/unit/tts_pipeline/test_text_analyzer.py
@@ -385,8 +385,7 @@ def test_label_unknown_phoneme() -> None:
     """`Label` は unknown 音素 `xx` をパース失敗する"""
     unknown_feature = stub_unknown_features_koxx("dummy")[3]
     with pytest.raises(OjtUnknownPhonemeError):
-        unknown_label = Label.from_feature(unknown_feature)
-        _ = unknown_label.phoneme
+        _ = Label.from_feature(unknown_feature).phoneme
 
 
 def test_text_to_accent_phrases_unknown() -> None:

--- a/test/unit/user_dict/test_user_dict.py
+++ b/test/unit/user_dict/test_user_dict.py
@@ -266,7 +266,7 @@ def test_import_invalid_word(tmp_path: Path) -> None:
     invalid_pos_word.part_of_speech_detail_1 = "*"
     invalid_pos_word.part_of_speech_detail_2 = "*"
     invalid_pos_word.part_of_speech_detail_3 = "*"
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="対応していない品詞です"):
         user_dict.import_user_dict(
             {"aab7dda2-0d97-43c8-8cb7-3f440dab9b4e": invalid_pos_word},
             override=True,


### PR DESCRIPTION
## 内容
テストをリントするリファクタリングを提案します。  

現在の VOICEVOX ENGINE は歴史的経緯からテストコードに古い記法が混じっている。  
これはレビューで複数回指摘されており、広域の TODO として残っている。  
ruff がルール `PT` により pytest の linting をサポートしているため、これを導入し適用することにより、現在のコード品質が向上し将来の品質低下を予防できる。  

このような背景から、テストをリントするリファクタリングを提案します。  

## 関連 Issue
無し