### PR TITLE
refactor: TTS upspeak のデフォルト引数を内部的に削除

### DIFF
--- a/test/unit/test_mock_tts_engine.py
+++ b/test/unit/test_mock_tts_engine.py
@@ -76,4 +76,5 @@ def test_synthesize_wave() -> None:
             kana=create_kana(_gen_accent_phrases()),
         ),
         StyleId(0),
+        enable_interrogative_upspeak=True,
     )

--- a/test/unit/tts_pipeline/test_tts_engine.py
+++ b/test/unit/tts_pipeline/test_tts_engine.py
@@ -266,7 +266,9 @@ def test_mocked_synthesize_wave_output(snapshot_json: SnapshotAssertion) -> None
     tts_engine = TTSEngine(MockCoreWrapper())
     hello_hiho = _gen_hello_hiho_query()
     # Outputs
-    result = tts_engine.synthesize_wave(hello_hiho, StyleId(1))
+    result = tts_engine.synthesize_wave(
+        hello_hiho, StyleId(1), enable_interrogative_upspeak=True
+    )
     # Tests
     assert snapshot_json == summarize_big_ndarray(round_floats(result, round_value=2))
 

--- a/voicevox_engine/app/routers/tts_pipeline.py
+++ b/voicevox_engine/app/routers/tts_pipeline.py
@@ -360,6 +360,7 @@ def generate_tts_pipeline_router(
                         )
 
                     with TemporaryFile() as wav_file:
+                        # TODO: enable_interrogative_upspeak を API 引数化する。
                         wave = engine.synthesize_wave(
                             queries[i], style_id, enable_interrogative_upspeak=True
                         )

--- a/voicevox_engine/app/routers/tts_pipeline.py
+++ b/voicevox_engine/app/routers/tts_pipeline.py
@@ -360,7 +360,9 @@ def generate_tts_pipeline_router(
                         )
 
                     with TemporaryFile() as wav_file:
-                        wave = engine.synthesize_wave(queries[i], style_id)
+                        wave = engine.synthesize_wave(
+                            queries[i], style_id, enable_interrogative_upspeak=True
+                        )
                         soundfile.write(
                             file=wav_file,
                             data=wave,

--- a/voicevox_engine/dev/tts_engine/mock.py
+++ b/voicevox_engine/dev/tts_engine/mock.py
@@ -27,7 +27,7 @@ class MockTTSEngine(TTSEngine):
         self,
         query: AudioQuery,
         style_id: StyleId,
-        enable_interrogative_upspeak: bool = True,
+        enable_interrogative_upspeak: bool,
     ) -> NDArray[np.float32]:
         """音声合成用のクエリに含まれる読み仮名に基づいてOpenJTalkで音声波形を生成する。モーラごとの調整は反映されない。"""
         # モーフィング時などに同一参照のqueryで複数回呼ばれる可能性があるので、元の引数のqueryに破壊的変更を行わない

--- a/voicevox_engine/tts_pipeline/tts_engine.py
+++ b/voicevox_engine/tts_pipeline/tts_engine.py
@@ -362,7 +362,7 @@ class TTSEngine:
         self,
         query: AudioQuery,
         style_id: StyleId,
-        enable_interrogative_upspeak: bool = True,
+        enable_interrogative_upspeak: bool,
     ) -> NDArray[np.float32]:
         """音声合成用のクエリ・スタイルID・疑問文語尾自動調整フラグに基づいて音声波形を生成する"""
         # モーフィング時などに同一参照のqueryで複数回呼ばれる可能性があるので、元の引数のqueryに破壊的変更を行わない


### PR DESCRIPTION
## 内容
refactor: TTS upspeak のデフォルト引数を（API では保持しつつ）内部的に削除するリファクタリングを提案します。  

## 関連 Issue
successor of https://github.com/VOICEVOX/voicevox_engine/pull/1634#discussion_r2053610352