### PR TITLE
feat!: キャンセル可能合成 API に upspeak 引数を追加

### DIFF
--- a/test/e2e/__snapshots__/test_openapi/test_OpenAPIの形が変わっていないことを確認.json
+++ b/test/e2e/__snapshots__/test_openapi/test_OpenAPIの形が変わっていないことを確認.json
@@ -1580,6 +1580,16 @@
           },
           {
             "in": "query",
+            "name": "enable_interrogative_upspeak",
+            "required": false,
+            "schema": {
+              "default": true,
+              "title": "Enable Interrogative Upspeak",
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "query",
             "name": "core_version",
             "required": false,
             "schema": {

--- a/voicevox_engine/app/routers/tts_pipeline.py
+++ b/voicevox_engine/app/routers/tts_pipeline.py
@@ -302,6 +302,7 @@ def generate_tts_pipeline_router(
         query: AudioQuery,
         request: Request,
         style_id: Annotated[StyleId, Query(alias="speaker")],
+        enable_interrogative_upspeak: bool = True,
         core_version: str | SkipJsonSchema[None] = None,
     ) -> FileResponse:
         if cancellable_engine is None:
@@ -312,7 +313,11 @@ def generate_tts_pipeline_router(
         try:
             version = core_version or LATEST_VERSION
             f_name = cancellable_engine.synthesize_wave(
-                query, style_id, request, version=version
+                query,
+                style_id,
+                enable_interrogative_upspeak=enable_interrogative_upspeak,
+                request=request,
+                version=version,
             )
         except CancellableEngineInternalError as e:
             raise HTTPException(status_code=500, detail=str(e)) from e

--- a/voicevox_engine/cancellable_engine.py
+++ b/voicevox_engine/cancellable_engine.py
@@ -117,6 +117,7 @@ class CancellableEngine:
         self,
         query: AudioQuery,
         style_id: StyleId,
+        enable_interrogative_upspeak: bool,
         request: Request,
         version: str | LatestVersion,
     ) -> str:
@@ -136,7 +137,9 @@ class CancellableEngine:
 
         # プロセスへ入力を渡して音声を合成する
         try:
-            synth_connection.send((query, style_id, version))
+            synth_connection.send(
+                (query, style_id, enable_interrogative_upspeak, version)
+            )
             audio_file_name = synth_connection.recv()
 
             if not isinstance(audio_file_name, str):
@@ -207,7 +210,7 @@ def start_synthesis_subprocess(
     while True:
         try:
             # キューの入力を受け取る
-            query, style_id, version = connection.recv()
+            query, style_id, enable_interrogative_upspeak, version = connection.recv()
 
             # 音声を合成しファイルへ保存する
             try:
@@ -216,9 +219,10 @@ def start_synthesis_subprocess(
                 # コネクションを介して「バージョンが見つからないエラー」を送信する
                 connection.send("")  # `""` をエラーして扱う
                 continue
-            # FIXME: enable_interrogative_upspeakフラグをWebAPIから受け渡してくる
             wave = _engine.synthesize_wave(
-                query, style_id, enable_interrogative_upspeak=False
+                query,
+                style_id,
+                enable_interrogative_upspeak=enable_interrogative_upspeak,
             )
             with NamedTemporaryFile(delete=False) as f:
                 soundfile.write(


### PR DESCRIPTION
## 内容
キャンセル可能合成の API に upspeak 引数を追加することを提案します。  

## 関連 Issue
個別 issue 無し。  

resolve FIXME  
https://github.com/VOICEVOX/voicevox_engine/blob/38b3224799e0db17873c4107c0f50c25398e75d2/voicevox_engine/cancellable_engine.py#L219

## その他
この API 追加は破壊的変更です。  
既存のキャンセル可能合成は upspeak を（意図的に？）OFF にしていました。  
この変更では（通常）合成 API のデフォルト引数に合わせるため、デフォルト動作を upspeak ON へと破壊的に変更しました。  
キャンセル可能合成が実験的機能であることから、この破壊的変更は許容範囲内であると考えます。  