### PR TITLE
docs: ドキュメントの `DUMMY` を `VOICEVOX OSS` で置き換え

### DIFF
--- a/engine_manifest.json
+++ b/engine_manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": "0.13.1",
-    "name": "DUMMY Engine",
-    "brand_name": "DUMMY",
+    "name": "VOICEVOX ENGINE OSS",
+    "brand_name": "VOICEVOX OSS",
     "uuid": "c7b58856-bd56-4aa1-afb7-b8415f824b06",
     "version": "999.999.999",
     "url": "https://github.com/VOICEVOX/voicevox_engine",

--- a/test/e2e/__snapshots__/test_openapi/test_OpenAPIの形が変わっていないことを確認.json
+++ b/test/e2e/__snapshots__/test_openapi/test_OpenAPIの形が変わっていないことを確認.json
@@ -1286,8 +1286,8 @@
     }
   },
   "info": {
-    "description": "DUMMY の音声合成エンジンです。",
-    "title": "DUMMY Engine",
+    "description": "VOICEVOX OSS の音声合成エンジンです。",
+    "title": "VOICEVOX ENGINE OSS",
     "version": "latest"
   },
   "openapi": "3.1.0",

--- a/test/e2e/single_api/engine_info/__snapshots__/test_engine_manifest/test_get_engine_manifest_200.json
+++ b/test/e2e/single_api/engine_info/__snapshots__/test_engine_manifest/test_get_engine_manifest_200.json
@@ -1,5 +1,5 @@
 {
-  "brand_name": "DUMMY",
+  "brand_name": "VOICEVOX OSS",
   "default_sampling_rate": 24000,
   "dependency_licenses": [
     {
@@ -12,7 +12,7 @@
   "frame_rate": 93.75,
   "icon": "MD5:f957eb4f5daedccb4eb6a5170f384bf4",
   "manifest_version": "0.13.1",
-  "name": "DUMMY Engine",
+  "name": "VOICEVOX ENGINE OSS",
   "supported_features": {
     "adjust_intonation_scale": true,
     "adjust_mora_pitch": true,

--- a/test/e2e/single_api/portal_page/__snapshots__/test_get_root.ambr
+++ b/test/e2e/single_api/portal_page/__snapshots__/test_get_root.ambr
@@ -4,11 +4,11 @@
   
           <html>
               <head>
-                  <title>DUMMY Engine</title>
+                  <title>VOICEVOX ENGINE OSS</title>
               </head>
               <body>
-                  <h1>DUMMY Engine</h1>
-                  DUMMY Engine へようこそ！
+                  <h1>VOICEVOX ENGINE OSS</h1>
+                  VOICEVOX ENGINE OSS へようこそ！
                   <ul>
                       <li><a href='/setting'>設定</a></li>
                       <li><a href='/docs'>API ドキュメント</a></li>

--- a/test/e2e/single_api/setting/__snapshots__/test_setting_api.ambr
+++ b/test/e2e/single_api/setting/__snapshots__/test_setting_api.ambr
@@ -267,7 +267,7 @@
               };
   
               // 表示用の情報
-              const brandName = ref("DUMMY");
+              const brandName = ref("VOICEVOX OSS");
   
               // Vueの準備が完了したら表示・非表示を切り替える
               onMounted(() => {


### PR DESCRIPTION
## 内容
ドキュメントの `DUMMY` を `VOICEVOX OSS` で置き換えるドキュメント改善を提案します。  

VOICEVOX ENGINE レポジトリでは placeholder として `DUMMY` の文字列がいくつか置かれている。  
これはおそらく「製品版 VOICEVOX」と「VOICEVOX OSS」の区別のためと思われる。  
ただ #1445 にあるように public な API docs にも DUMMY の文字列が漏れているため、一般利用者に「偽物...?」のような不安感を与えかねない。  
`DUMMY` の目的が製品版と OSS の区別なのであれば、`OSS` を使うことでこの目的は達成できる。  
レポジトリとしても「OSS レポジトリの設定ファイルに OSS の文字列が入っている」という状態はごく自然である。  
またレポジトリフォークした人が設定ファイルの更新を忘れても「OSS」と表示され「製品版」とは表示されないため、製品版 VOICEVOX への影響は（変わらず）予防できる。  

このような背景から、ドキュメントの `DUMMY` を `VOICEVOX OSS` で置き換えるドキュメント改善を提案します。  

## 関連 Issue
resolve #1445

## スクリーンショット・動画など
after
![image](https://github.com/user-attachments/assets/7c7a9ff3-d7f2-4378-8065-d73fb420b2bf)
