### PR TITLE
feat: multi synthesis API に upspeak 設定を追加

### DIFF
--- a/test/e2e/__snapshots__/test_openapi/test_OpenAPIの形が変わっていないことを確認.json
+++ b/test/e2e/__snapshots__/test_openapi/test_OpenAPIの形が変わっていないことを確認.json
@@ -2371,6 +2371,18 @@
             }
           },
           {
+            "description": "疑問系のテキストが与えられたら語尾を自動調整する",
+            "in": "query",
+            "name": "enable_interrogative_upspeak",
+            "required": false,
+            "schema": {
+              "default": true,
+              "description": "疑問系のテキストが与えられたら語尾を自動調整する",
+              "title": "Enable Interrogative Upspeak",
+              "type": "boolean"
+            }
+          },
+          {
             "in": "query",
             "name": "core_version",
             "required": false,

--- a/voicevox_engine/app/routers/tts_pipeline.py
+++ b/voicevox_engine/app/routers/tts_pipeline.py
@@ -349,6 +349,12 @@ def generate_tts_pipeline_router(
     def multi_synthesis(
         queries: list[AudioQuery],
         style_id: Annotated[StyleId, Query(alias="speaker")],
+        enable_interrogative_upspeak: Annotated[
+            bool,
+            Query(
+                description="疑問系のテキストが与えられたら語尾を自動調整する",
+            ),
+        ] = True,
         core_version: str | SkipJsonSchema[None] = None,
     ) -> FileResponse:
         version = core_version or LATEST_VERSION
@@ -359,15 +365,14 @@ def generate_tts_pipeline_router(
             with zipfile.ZipFile(f, mode="a") as zip_file:
                 for i in range(len(queries)):
                     if queries[i].outputSamplingRate != sampling_rate:
-                        raise HTTPException(
-                            status_code=422,
-                            detail="サンプリングレートが異なるクエリがあります",
-                        )
+                        msg = "サンプリングレートが異なるクエリがあります"
+                        raise HTTPException(status_code=422, detail=msg)
 
                     with TemporaryFile() as wav_file:
-                        # TODO: enable_interrogative_upspeak を API 引数化する。
                         wave = engine.synthesize_wave(
-                            queries[i], style_id, enable_interrogative_upspeak=True
+                            queries[i],
+                            style_id,
+                            enable_interrogative_upspeak=enable_interrogative_upspeak,
                         )
                         soundfile.write(
                             file=wav_file,


### PR DESCRIPTION
## 内容
multi synthesis API に upspeak 設定（`enable_interrogative_upspeak`）を追加することを提案します。  

## 関連 Issue
ref https://github.com/VOICEVOX/voicevox_engine/pull/1647#discussion_r2059000556

## その他
この設定を引数に追加することは既存の動作に影響を与えません。  

この PR によってmulti synthesis API の音声合成機能は `/synthesis` API の音声合成機能と同一レベルになります。  