### PR TITLE
fix: ビルド時にPyInstallerディレクトリ内でuv runしていたのを修正

### DIFF
--- a/tools/modify_pyinstaller.bash
+++ b/tools/modify_pyinstaller.bash
@@ -23,5 +23,5 @@ __declspec(dllexport) DWORD NvOptimusEnablement = 0x00000001;
 __declspec(dllexport) DWORD AmdPowerXpressRequestHighPerformance = 0x00000001;
 #endif
 EOF
-(cd "$tempdir/bootloader" && uv run ./waf all --msvc_targets="x64")
+(cd "$tempdir/bootloader" && python ./waf all --msvc_targets="x64")
 uv pip install -U "$tempdir" # TODO: 可能であればuv addでやる


### PR DESCRIPTION
## 内容

ビルド時にPyInstallerディレクトリ内でuv runしていたのを修正しました。


## 関連 Issue

- https://github.com/VOICEVOX/voicevox_engine/pull/1616#discussion_r2059009591

で間違えて余計な変更をしてしまったので修正しました。


## その他
