### PR TITLE
fix(ci): pull するイメージを docker hub から mirror.gcr.io に

### DIFF
--- a/.github/workflows/build-engine-container.yml
+++ b/.github/workflows/build-engine-container.yml
@@ -55,7 +55,7 @@ jobs:
             buildcache_prefix: "cpu-amd64-ubuntu20.04"
             target: runtime-env
             base_image: ubuntu:20.04
-            base_runtime_image: ubuntu:20.04
+            base_runtime_image: mirror.gcr.io/ubuntu:20.04
             platforms: linux/amd64
           # Ubuntu 20.04 / ARM64
           - os: ubuntu-24.04-arm
@@ -63,7 +63,7 @@ jobs:
             buildcache_prefix: "cpu-arm64-ubuntu20.04"
             target: runtime-env
             base_image: ubuntu:20.04
-            base_runtime_image: ubuntu:20.04
+            base_runtime_image: mirror.gcr.io/ubuntu:20.04
             platforms: linux/arm64/v8
           # Ubuntu 20.04 / AMD64 / NVIDIA
           - os: ubuntu-latest
@@ -71,7 +71,7 @@ jobs:
             buildcache_prefix: "nvidia-amd64-ubuntu20.04"
             target: runtime-nvidia-env
             base_image: ubuntu:20.04
-            base_runtime_image: nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu20.04
+            base_runtime_image: mirror.gcr.io/nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu20.04
             platforms: linux/amd64
           # Ubuntu 22.04 / AMD64
           - os: ubuntu-latest
@@ -79,7 +79,7 @@ jobs:
             buildcache_prefix: "cpu-amd64-ubuntu22.04"
             target: runtime-env
             base_image: ubuntu:22.04
-            base_runtime_image: ubuntu:22.04
+            base_runtime_image: mirror.gcr.io/ubuntu:22.04
             platforms: linux/amd64
           # Ubuntu 22.04 / ARM64
           - os: ubuntu-24.04-arm
@@ -87,7 +87,7 @@ jobs:
             buildcache_prefix: "cpu-arm64-ubuntu22.04"
             target: runtime-env
             base_image: ubuntu:22.04
-            base_runtime_image: ubuntu:22.04
+            base_runtime_image: mirror.gcr.io/ubuntu:22.04
             platforms: linux/arm64/v8
           # Ubuntu 22.04 / AMD64 / NVIDIA
           - os: ubuntu-latest
@@ -95,7 +95,7 @@ jobs:
             buildcache_prefix: "nvidia-amd64-ubuntu22.04"
             target: runtime-nvidia-env
             base_image: ubuntu:22.04
-            base_runtime_image: nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu22.04
+            base_runtime_image: mirror.gcr.io/nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu22.04
             platforms: linux/amd64
 
     steps:

--- a/.github/workflows/build-engine-container.yml
+++ b/.github/workflows/build-engine-container.yml
@@ -54,7 +54,7 @@ jobs:
             prefixes: "cpu-amd64-ubuntu20.04"
             buildcache_prefix: "cpu-amd64-ubuntu20.04"
             target: runtime-env
-            base_image: ubuntu:20.04
+            base_image: mirror.gcr.io/ubuntu:20.04
             base_runtime_image: mirror.gcr.io/ubuntu:20.04
             platforms: linux/amd64
           # Ubuntu 20.04 / ARM64
@@ -62,7 +62,7 @@ jobs:
             prefixes: "cpu-arm64-ubuntu20.04"
             buildcache_prefix: "cpu-arm64-ubuntu20.04"
             target: runtime-env
-            base_image: ubuntu:20.04
+            base_image: mirror.gcr.io/ubuntu:20.04
             base_runtime_image: mirror.gcr.io/ubuntu:20.04
             platforms: linux/arm64/v8
           # Ubuntu 20.04 / AMD64 / NVIDIA
@@ -70,7 +70,7 @@ jobs:
             prefixes: "nvidia-ubuntu20.04,nvidia-amd64-ubuntu20.04"
             buildcache_prefix: "nvidia-amd64-ubuntu20.04"
             target: runtime-nvidia-env
-            base_image: ubuntu:20.04
+            base_image: mirror.gcr.io/ubuntu:20.04
             base_runtime_image: mirror.gcr.io/nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu20.04
             platforms: linux/amd64
           # Ubuntu 22.04 / AMD64
@@ -78,7 +78,7 @@ jobs:
             prefixes: "cpu-amd64,cpu-amd64-ubuntu22.04"
             buildcache_prefix: "cpu-amd64-ubuntu22.04"
             target: runtime-env
-            base_image: ubuntu:22.04
+            base_image: mirror.gcr.io/ubuntu:22.04
             base_runtime_image: mirror.gcr.io/ubuntu:22.04
             platforms: linux/amd64
           # Ubuntu 22.04 / ARM64
@@ -86,7 +86,7 @@ jobs:
             prefixes: "cpu-arm64,cpu-arm64-ubuntu22.04"
             buildcache_prefix: "cpu-arm64-ubuntu22.04"
             target: runtime-env
-            base_image: ubuntu:22.04
+            base_image: mirror.gcr.io/ubuntu:22.04
             base_runtime_image: mirror.gcr.io/ubuntu:22.04
             platforms: linux/arm64/v8
           # Ubuntu 22.04 / AMD64 / NVIDIA
@@ -94,7 +94,7 @@ jobs:
             prefixes: "nvidia,nvidia-amd64,nvidia-ubuntu22.04,nvidia-amd64-ubuntu22.04"
             buildcache_prefix: "nvidia-amd64-ubuntu22.04"
             target: runtime-nvidia-env
-            base_image: ubuntu:22.04
+            base_image: mirror.gcr.io/ubuntu:22.04
             base_runtime_image: mirror.gcr.io/nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu22.04
             platforms: linux/amd64
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # TODO: build-arg と target のドキュメントをこのファイルに書く
 
-ARG BASE_IMAGE=ubuntu:20.04
+ARG BASE_IMAGE=mirror.gcr.io/ubuntu:20.04
 ARG BASE_RUNTIME_IMAGE=$BASE_IMAGE
 
 # Download VOICEVOX Core shared object


### PR DESCRIPTION
## 内容
- Docker ビルドで使用するイメージを Google Cloud がホスティングするミラーサーバ、mirror.gcr.io に変更する
  - Docker Hub のレートリミットに関係なく、pull できるようになる想定
- Dockerfile の ARG も書き換えたのは余計だったかも？

## 関連 Issue

close #1655