### PR TITLE
chore: 依存パッケージコメント追加と修正

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
   "pyworld>=0.3.5",
   "pyyaml>=6.0.1",
   "semver>=3.0.0",
-  "setuptools>=78.1.0",
+  "setuptools>=78.1.0", # NOTE: pyworldがpkg_resourcesを使っている。
   "soundfile>=0.13.1",
   "soxr>=0.5.0",
   "starlette>=0.45.3",
@@ -29,7 +29,7 @@ default-groups = []
 pyopenjtalk = { git = "https://github.com/VOICEVOX/pyopenjtalk", rev = "74703b034dd90a1f199f49bb70bf3b66b1728a86" }
 
 [dependency-groups]
-build = ["pyinstaller>=5.13"]
+build = ["pyinstaller<6"] # NOTE: PyInstaller6ではmacOSのエディタにバンドルすると動作しなくなる (c.f. #1022)
 dev = [
   "coveralls>=4.0.1",
   "httpx>=0.28.1", # NOTE: required by fastapi.testclient.TestClient (fastapi-slim's unmanaged dependency)

--- a/uv.lock
+++ b/uv.lock
@@ -1129,7 +1129,7 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-build = [{ name = "pyinstaller", specifier = ">=5.13" }]
+build = [{ name = "pyinstaller", specifier = "<6" }]
 dev = [
     { name = "coveralls", specifier = ">=4.0.1" },
     { name = "httpx", specifier = ">=0.28.1" },


### PR DESCRIPTION
## 内容

PyInstallerのバージョンに上限が付いていなかったので念のため修正します。

- ref #1616

## その他

setuptoolsが特にコメントもなく依存関係に含まれていたのでコメントを追加しておきました。
05b476f3e4221515eee41611b43e17ca0479e0ad に詳しいコメントがない状態で追加されていました。
@nanae772 このような理由で正しいでしょうか?

---

メモ: Windowsだとsetuptoolsを外しても多分問題は起こらない。
原因はpyworldのwheel内のコードとsdistの内容が異なり`pkg_resources`を使用していないから。