### PR TITLE
refactor(docker): `# syntax`のバージョン指定を`1`にする

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.4
+# syntax=docker/dockerfile:1
 
 # TODO: build-arg と target のドキュメントをこのファイルに書く
 


### PR DESCRIPTION
## 内容

Docker Docsの

> We recommend using `docker/dockerfile:1`

に従う。

経緯は以下。
<https://github.com/VOICEVOX/voicevox_engine/pull/1669#discussion_r2071756067>

## 関連 Issue

## スクリーンショット・動画など

## その他
