### PR TITLE
refactor(ci): github-scriptにセミコロンと末尾カンマを入れる

### DIFF
--- a/.github/workflows/build-latest-dev.yml
+++ b/.github/workflows/build-latest-dev.yml
@@ -23,7 +23,7 @@ jobs:
           script: |
             const latest_release = await github.rest.repos.getLatestRelease({
               owner: context.repo.owner,
-              repo: context.repo.repo
+              repo: context.repo.repo,
             });
             const split_version = latest_release.data.tag_name.split('.');
             const dev_version = `${split_version[0]}.${parseInt(split_version[1]) + 1}.0-dev`;
@@ -34,16 +34,16 @@ jobs:
               ref: 'master',
               inputs: {
                 version: dev_version,
-                prerelease: true
-              }
-            })
+                prerelease: true,
+              },
+            });
             github.rest.actions.createWorkflowDispatch({
               owner: context.repo.owner,
               repo: context.repo.repo,
               workflow_id: 'build-engine-container.yml',
               ref: 'master',
               inputs: {
-                version: dev_version
-              }
-            })
+                version: dev_version,
+              },
+            });
             console.log(`Triggered workflow_dispatch for ${dev_version}`);


### PR DESCRIPTION
## 内容

GHA内でgithub-scriptを使っている箇所にセミコロンと末尾カンマを入れました。

ちなみにこの状態だと

```console
❯ deno fmt --check --line-width 99999 --single-quote true
```

は通ることを確認しています。ESLint的にはどうなのかは調べていませんが。

経緯: <https://github.com/VOICEVOX/voicevox_engine/pull/1669#discussion_r2072511803>

## 関連 Issue

## スクリーンショット・動画など

## その他
