### PR TITLE
fix: soxr ライブラリのライセンスを修正

### DIFF
--- a/tools/generate_licenses.py
+++ b/tools/generate_licenses.py
@@ -108,11 +108,6 @@ def _update_licenses(pip_licenses: list[_PipLicense]) -> list[_License]:
             text_url = package_to_license_url[package_name]
             pip_license.LicenseText = _get_license_text(text_url)
 
-        # soxr
-        if package_name == "soxr":
-            text_url = "https://raw.githubusercontent.com/dofuuz/python-soxr/v0.3.6/LICENSE.txt"
-            pip_license.LicenseText = _get_license_text(text_url)
-
         updated_licenses.append(
             _License(
                 package_name=pip_license.Name,
@@ -300,6 +295,22 @@ def _add_licenses_manually(licenses: list[_License]) -> None:
             license_text="tools/licenses/cudnn/LICENSE",
             license_text_type="local_address",
         ),
+        # Python-SoXR (`soxr`, https://github.com/dofuuz/python-soxr) が依存するライブラリ
+        _License(
+            package_name="libsoxr",
+            package_version=None,
+            license_name="LGPL-2.1 license",
+            license_text="https://raw.githubusercontent.com/dofuuz/soxr/master/LICENCE",
+            license_text_type="remote_address",
+        ),
+        _License(
+            package_name="PFFFT",
+            package_version=None,
+            license_name="BSD-like",
+            license_text="https://raw.githubusercontent.com/dofuuz/python-soxr/main/cmake/LICENSE-PFFFT.txt",
+            license_text_type="remote_address",
+        ),
+        #
     ]
 
 


### PR DESCRIPTION
## 内容
`soxr` ライブラリのライセンスを修正することを提案します。  

この修正により、以下のようにライブラリ情報が取得されます：  

- `soxr` (Python-SoXR): `pip-licenses` で自動取得
- `libsoxr`: `generate_licenses.py` にハードコードされた指定に従ってリモートから取得
- `PFFFT`: `generate_licenses.py` にハードコードされた指定に従ってリモートから取得

## 関連 Issue
fix #1635

## その他
生成されたライセンス一覧ファイルに `soxr` / `libsoxr` / `PFFFT` のライセンス情報が含まれていることを確認済みです。