### PR TITLE
build!: `build-engine-container`でのlatestビルドをできなくする

### DIFF
--- a/.github/workflows/build-engine-container.yml
+++ b/.github/workflows/build-engine-container.yml
@@ -1,8 +1,5 @@
 name: build-docker
 on:
-  push:
-    branches:
-      - master
   release:
     types:
       - created
@@ -26,13 +23,13 @@ jobs:
   config: # 全 jobs で利用する定数の定義. `env` が利用できないコンテキストでも利用できる.
     runs-on: ubuntu-latest
     outputs:
-      version_or_latest: ${{ steps.vars.outputs.version_or_latest }}
+      version: ${{ steps.vars.outputs.version }}
     steps:
       - name: <Setup> Declare variables
         id: vars
         run: |
-          : # releaseタグ名か、workflow_dispatchでのバージョン名か、latestが入る
-          echo "version_or_latest=${{ github.event.release.tag_name || github.event.inputs.version || 'latest' }}" >> "$GITHUB_OUTPUT"
+          : # releaseタグ名か、workflow_dispatchでのバージョン名が入る
+          echo "version=${{ github.event.release.tag_name || github.event.inputs.version }}" >> "$GITHUB_OUTPUT"
 
   build-docker:
     needs: [config]
@@ -145,7 +142,7 @@ jobs:
 
             uv run tools/generate_docker_image_names.py \
               --repository "${{ env.IMAGE_NAME }}" \
-              --version "${{ needs.config.outputs.version_or_latest }}" \
+              --version "${{ needs.config.outputs.version }}" \
               --prefix "${{ matrix.prefixes }}"
 
             echo "EOF"
@@ -163,7 +160,8 @@ jobs:
           # --cache-to に指定するためのDockerイメージ名
           # リリースの場合、ビルドキャッシュを作成しないため、空文字列を格納する
           cache_to=""
-          if [ "${{ needs.config.outputs.version_or_latest }}" = "latest" ]; then
+          # FIXME: "edge"タグの場合のみキャッシュを作るようにする
+          if false; then
             cache_to="type=registry,ref=${{ env.IMAGE_NAME }}:${{ matrix.buildcache_prefix }}-latest-buildcache,mode=max"
           fi
 
@@ -181,7 +179,7 @@ jobs:
             BASE_IMAGE=${{ matrix.base_image }}
             BASE_RUNTIME_IMAGE=${{ matrix.base_runtime_image }}
             PYTHON_VERSION=${{ steps.prepare-python.outputs.python-version }}
-            VOICEVOX_ENGINE_VERSION=${{ needs.config.outputs.version_or_latest }}
+            VOICEVOX_ENGINE_VERSION=${{ needs.config.outputs.version }}
             VOICEVOX_CORE_VERSION=${{ env.VOICEVOX_CORE_VERSION }}
             VOICEVOX_RESOURCE_VERSION=${{ env.VOICEVOX_RESOURCE_VERSION }}
             USE_GPU=${{ matrix.target == 'runtime-nvidia-env' }}
@@ -230,7 +228,7 @@ jobs:
       - name: <Build/Deploy> Build and Deploy multi-platform Docker image
         env:
           IMAGE_NAME: ${{ env.IMAGE_NAME }}
-          VERSION_OR_LATEST: ${{ needs.config.outputs.version_or_latest }}
+          VERSION_OR_LATEST: ${{ needs.config.outputs.version }}
           AMD64_IMAGE_PREFIX: ${{ matrix.amd64_image_prefix }}
           ARM64_IMAGE_PREFIX: ${{ matrix.arm64_image_prefix }}
           MULTI_PLATFORM_IMAGE_PREFIXES: ${{ matrix.multi_platform_image_prefixes }}
@@ -238,10 +236,10 @@ jobs:
           bash ./tools/build_and_push_multi_platform_docker_images.bash
 
   run-release-test-workflow:
-    # version が指定されている場合のみ実行する
-    if: needs.config.outputs.version_or_latest != 'latest'
+    # FIXME: "edge"タグの場合、テストは控えるようにする
+    if: true
     needs: [config, build-docker, build-docker-multi-platform]
     uses: ./.github/workflows/test-engine-container.yml
     with:
-      version: ${{ needs.config.outputs.version_or_latest }}
+      version: ${{ needs.config.outputs.version }}
       repo_url: ${{ format('{0}/{1}', github.server_url, github.repository) }} # このリポジトリのURL

--- a/.github/workflows/build-engine-container.yml
+++ b/.github/workflows/build-engine-container.yml
@@ -237,7 +237,8 @@ jobs:
           bash ./tools/build_and_push_multi_platform_docker_images.bash
 
   run-release-test-workflow:
-    # FIXME: "edge"タグの場合、テストは控えるようにする
+    # NOTE: 一時的にデフォルトブランチでビルドしていないので常にtrueになっている
+    # FIXME: Docker Hubにpushしない場合はfalseになるようにする
     if: true
     needs: [config, build-docker, build-docker-multi-platform]
     uses: ./.github/workflows/test-engine-container.yml

--- a/.github/workflows/build-engine-container.yml
+++ b/.github/workflows/build-engine-container.yml
@@ -160,7 +160,8 @@ jobs:
           # --cache-to に指定するためのDockerイメージ名
           # リリースの場合、ビルドキャッシュを作成しないため、空文字列を格納する
           cache_to=""
-          # FIXME: "edge"タグの場合のみキャッシュを作るようにする
+          # NOTE: 一時的にデフォルトブランチでビルドしていないので常にfalseになっている
+          # FIXME: デフォルトブランチでビルドし、デフォルトブランチでのみtrueになるようにする
           if false; then
             cache_to="type=registry,ref=${{ env.IMAGE_NAME }}:${{ matrix.buildcache_prefix }}-latest-buildcache,mode=max"
           fi

--- a/.github/workflows/build-engine-container.yml
+++ b/.github/workflows/build-engine-container.yml
@@ -1,5 +1,8 @@
 name: build-docker
 on:
+  # FIXME: デフォルトブランチへのpush時にビルドをテストする
+  # https://github.com/VOICEVOX/voicevox_engine/pull/1669#discussion_r2076730954
+  workflow_call:
   release:
     types:
       - created
@@ -160,7 +163,7 @@ jobs:
           # --cache-to に指定するためのDockerイメージ名
           # リリースの場合、ビルドキャッシュを作成しないため、空文字列を格納する
           cache_to=""
-          # NOTE: 一時的にデフォルトブランチでビルドしていないので常にfalseになっている
+          # NOTE: デフォルトブランチでのビルドを一時的にやめているので、常にfalseになっている
           # FIXME: デフォルトブランチでビルドし、デフォルトブランチでのみtrueになるようにする
           if false; then
             cache_to="type=registry,ref=${{ env.IMAGE_NAME }}:${{ matrix.buildcache_prefix }}-latest-buildcache,mode=max"
@@ -237,7 +240,7 @@ jobs:
           bash ./tools/build_and_push_multi_platform_docker_images.bash
 
   run-release-test-workflow:
-    # NOTE: 一時的にデフォルトブランチでビルドしていないので常にtrueになっている
+    # NOTE: デフォルトブランチでのビルドを一時的にやめているので、常にtrueになっている
     # FIXME: Docker Hubにpushしない場合はfalseになるようにする
     if: true
     needs: [config, build-docker, build-docker-multi-platform]

--- a/.github/workflows/build-engine-container.yml
+++ b/.github/workflows/build-engine-container.yml
@@ -229,7 +229,7 @@ jobs:
       - name: <Build/Deploy> Build and Deploy multi-platform Docker image
         env:
           IMAGE_NAME: ${{ env.IMAGE_NAME }}
-          VERSION_OR_LATEST: ${{ needs.config.outputs.version }}
+          VERSION_OR_LATEST: ${{ needs.config.outputs.version }} # TODO: 環境変数名をVERSIONにする？
           AMD64_IMAGE_PREFIX: ${{ matrix.amd64_image_prefix }}
           ARM64_IMAGE_PREFIX: ${{ matrix.arm64_image_prefix }}
           MULTI_PLATFORM_IMAGE_PREFIXES: ${{ matrix.multi_platform_image_prefixes }}


### PR DESCRIPTION
## 内容

経緯: <https://github.com/VOICEVOX/voicevox_engine/pull/1669#discussion_r2085386761>

## 関連 Issue

## スクリーンショット・動画など

## その他

@Hiroshiba 追記　前提と後続タスクのまとめ：

プルリクエスト #1678 の前提と後続タスクの概要は以下の通りです。

**前提**:

現在の `latest` Dockerイメージは不安定な開発版 (`master`ブランチ最新) を指しており、安定版を指すのが一般的 (関連Issue: [VOICEVOX/voicevox_engine#1674](https://github.com/VOICEVOX/voicevox_engine/issues/1674))。
Pull Request #1669 ([VOICEVOX/voicevox_engine#1669](https://github.com/VOICEVOX/voicevox_engine/pull/1669)) でPyInstallerビルド済みエンジンを利用する変更により、従来の `latest` イメージ (masterブランチ最新版のDockerイメージ) のビルドが困難
本プルリクエストは #1669 の複雑化を避けるため、一時的に `build-engine-container` ワークフローでの `latest` ビルドを無効化します (参照: [PR #1669 コメント](https://github.com/VOICEVOX/voicevox_engine/pull/1669#discussion_r2085386761))。

**後続で必要になること**:
Docker Hub上の `latest` タグが「最新の安定版リリース」を指すように変更します (Issue #1674)。
 