### PR TITLE
refactor: ENGINE が独自実装するテキスト分析を1つの関数にまとめテストする

### DIFF
--- a/test/unit/tts_pipeline/test_text_analyzer.py
+++ b/test/unit/tts_pipeline/test_text_analyzer.py
@@ -410,7 +410,7 @@ def test_parse_full_context_labels() -> None:
     #
     #     アクセント句:      |____________________^_P|   |_______________^|
     #
-    #     ※ `^`はアクセント位置、`P`は `.pause_mora` 属性の有無
+    #     ※ `^`はアクセント位置を指し、`P`は`.pause_mora`があることを意味する。
     #
     true_accent_phrases = [
         AccentPhrase(

--- a/voicevox_engine/tts_pipeline/text_analyzer.py
+++ b/voicevox_engine/tts_pipeline/text_analyzer.py
@@ -370,8 +370,10 @@ def _mora_labels_to_moras(mora_labels: list[MoraLabel]) -> list[Mora]:
     ]
 
 
-def _utterance_to_accent_phrases(utterance: UtteranceLabel) -> list[AccentPhrase]:
-    """UtteranceLabelインスタンスをアクセント句系列へドメイン変換する"""
+def _parse_full_context_labels(labels: list[str]) -> list[AccentPhrase]:
+    """フルコンテキストラベルをアクセント句系列へ変換する。"""
+    utterance = UtteranceLabel.from_labels(list(map(Label.from_feature, labels)))
+
     if len(utterance.breath_groups) == 0:
         return []
 
@@ -409,11 +411,9 @@ def text_to_accent_phrases(
     if len(text.strip()) == 0:
         return []
 
-    # 日本語文からUtteranceLabelを抽出する
-    features = text_to_features(text)
-    utterance = UtteranceLabel.from_labels(list(map(Label.from_feature, features)))
+    # 日本語文からフルコンテキストラベル系列を抽出する
+    full_context_labels = text_to_features(text)
 
-    # ドメインを変換する
-    accent_phrases = _utterance_to_accent_phrases(utterance)
+    accent_phrases = _parse_full_context_labels(full_context_labels)
 
     return accent_phrases


### PR DESCRIPTION
## 内容
ENGINE が独自実装するテキスト分析を1つの関数にまとめテストするリファクタリングを提案します。  

VOICEVOX ENGINE のテキスト分析部は OpenJTalk のような外部ライブラリを呼び出している箇所と、VOICEVOX ENGINE が独自実装する箇所に大別される。  
前者はテストが基本的に不要であり、後者は丁寧なテストが求められる。   
現在のテキスト分析部は両者が混じった `text_to_accent_phrases()` 関数を一番外側のテスト対象としており、混ざりを避けるために DI を用いてテストをおこなっている（`pyopenjtalk.extract_fullcontext` を関数の引数にしている）。  

テキスト処理の全体像を整理した結果、フルコンテキストラベルが外部ライブラリ部分と独自実装部分の明確な境界となっていることがわかった（これは project-e2k でも似たような実装になっている）。  
そのため、フルコンテキストラベルをパースしアクセント句系列をつくる関数をまとめれば、テキスト分析の独自実装部分の全体を 1つに関数にまとめられ、それをテストできる。  
これにより複雑だった `pyopenjtalk.extract_fullcontext` の DI も廃止できる。

このような背景から、ENGINE が独自実装するテキスト分析を1つの関数 `_parse_full_context_labels()` にまとめテストするリファクタリングを提案します。  

----------------------------------------------------

なお、このリファクタリングが反映された場合、`xxLabel` クラスが全て `_parse_full_context_labels()` の内部実装になります。またこのリファクタリングは `_parse_full_context_labels()` のテストを実装しています。  
そのため `xxLabel` クラスを削除する（#1686）場合、テストが完備された関数の内部実装を整理するという、安全でわかりやすいリファクタリングになります。  

## 関連 Issue
ref #1686