### PR TITLE
refactor: MOCK_VER を util へ集約

### DIFF
--- a/voicevox_engine/core/core_initializer.py
+++ b/voicevox_engine/core/core_initializer.py
@@ -5,12 +5,10 @@ import os
 import warnings
 from pathlib import Path
 
-from ..utility.core_version_utility import get_latest_version
+from ..utility.core_version_utility import MOCK_VER, get_latest_version
 from ..utility.path_utility import engine_root, get_save_dir
 from .core_adapter import CoreAdapter
 from .core_wrapper import CoreWrapper, load_runtime_lib
-
-MOCK_VER = "0.0.0"
 
 
 def _get_half_logical_cores() -> int:

--- a/voicevox_engine/tts_pipeline/song_engine.py
+++ b/voicevox_engine/tts_pipeline/song_engine.py
@@ -5,12 +5,11 @@ from typing import Any, Final, Literal, TypeAlias
 import numpy as np
 from numpy.typing import NDArray
 
-from voicevox_engine.utility.core_version_utility import get_latest_version
-
 from ..core.core_adapter import CoreAdapter, DeviceSupport
-from ..core.core_initializer import MOCK_VER, CoreManager
+from ..core.core_initializer import CoreManager
 from ..core.core_wrapper import CoreWrapper
 from ..metas.Metas import StyleId
+from ..utility.core_version_utility import MOCK_VER, get_latest_version
 from .audio_postprocessing import raw_wave_to_output_wave
 from .model import (
     FrameAudioQuery,
@@ -442,8 +441,6 @@ class SongEngineManager:
 
 def make_song_engines_from_cores(core_manager: CoreManager) -> SongEngineManager:
     """コア一覧からSongエンジン一覧を生成する"""
-    # FIXME: `MOCK_VER` を循環 import 無しに `initialize_cores()` 関連モジュールから import する
-    MOCK_VER = "0.0.0"
     song_engines = SongEngineManager()
     for ver, core in core_manager.items():
         if ver == MOCK_VER:

--- a/voicevox_engine/tts_pipeline/tts_engine.py
+++ b/voicevox_engine/tts_pipeline/tts_engine.py
@@ -7,13 +7,12 @@ from typing import Any, Final, Literal, TypeAlias
 import numpy as np
 from numpy.typing import NDArray
 
-from voicevox_engine.utility.core_version_utility import get_latest_version
-
 from ..core.core_adapter import CoreAdapter, DeviceSupport
-from ..core.core_initializer import MOCK_VER, CoreManager
+from ..core.core_initializer import CoreManager
 from ..core.core_wrapper import CoreWrapper
 from ..metas.Metas import StyleId
 from ..model import AudioQuery
+from ..utility.core_version_utility import MOCK_VER, get_latest_version
 from .audio_postprocessing import raw_wave_to_output_wave
 from .kana_converter import parse_kana
 from .model import (
@@ -433,8 +432,6 @@ class TTSEngineManager:
 
 def make_tts_engines_from_cores(core_manager: CoreManager) -> TTSEngineManager:
     """コア一覧からTTSエンジン一覧を生成する"""
-    # FIXME: `MOCK_VER` を循環 import 無しに `initialize_cores()` 関連モジュールから import する
-    MOCK_VER = "0.0.0"
     tts_engines = TTSEngineManager()
     for ver, core in core_manager.items():
         if ver == MOCK_VER:

--- a/voicevox_engine/utility/core_version_utility.py
+++ b/voicevox_engine/utility/core_version_utility.py
@@ -1,6 +1,10 @@
 """バージョンに関する utility"""
 
+from typing import Final
+
 from semver.version import Version
+
+MOCK_VER: Final = "0.0.0"
 
 
 def get_latest_version(versions: list[str]) -> str:


### PR DESCRIPTION
## 内容
`MOCK_VER` をバージョンユーティリティモジュールへ集約するリファクタリングを提案します。  

循環 import により FIXME となっていた `MOCK_VER` を、コアバージョンに関するユーティリティモジュールへ移動することで解決した。

## 関連 Issue
無し