### PR TITLE
refactor: キャラクター情報に関する HTTPException をルーターへ移動

### DIFF
--- a/voicevox_engine/app/routers/character.py
+++ b/voicevox_engine/app/routers/character.py
@@ -7,7 +7,13 @@ from fastapi.responses import FileResponse
 from pydantic.json_schema import SkipJsonSchema
 
 from voicevox_engine.metas.Metas import Speaker, SpeakerInfo
-from voicevox_engine.metas.MetasStore import Character, MetasStore, ResourceFormat
+from voicevox_engine.metas.MetasStore import (
+    Character,
+    CharacterInfoNotFoundError,
+    CharacterNotFoundError,
+    MetasStore,
+    ResourceFormat,
+)
 from voicevox_engine.resource_manager import ResourceManager, ResourceManagerError
 
 RESOURCE_ENDPOINT = "_resources"
@@ -57,13 +63,18 @@ def generate_character_router(
 
         画像や音声はresource_formatで指定した形式で返されます。
         """
-        return metas_store.character_info(
-            character_uuid=speaker_uuid,
-            talk_or_sing="talk",
-            core_version=core_version,
-            resource_baseurl=resource_baseurl,
-            resource_format=resource_format,
-        )
+        try:
+            return metas_store.character_info(
+                character_uuid=speaker_uuid,
+                talk_or_sing="talk",
+                core_version=core_version,
+                resource_baseurl=resource_baseurl,
+                resource_format=resource_format,
+            )
+        except CharacterNotFoundError as e:
+            raise HTTPException(status_code=404, detail=str(e)) from e
+        except CharacterInfoNotFoundError as e:
+            raise HTTPException(status_code=500, detail=str(e)) from e
 
     @router.get("/singers")
     def singers(core_version: str | SkipJsonSchema[None] = None) -> list[Speaker]:
@@ -83,13 +94,18 @@ def generate_character_router(
 
         画像や音声はresource_formatで指定した形式で返されます。
         """
-        return metas_store.character_info(
-            character_uuid=speaker_uuid,
-            talk_or_sing="sing",
-            core_version=core_version,
-            resource_baseurl=resource_baseurl,
-            resource_format=resource_format,
-        )
+        try:
+            return metas_store.character_info(
+                character_uuid=speaker_uuid,
+                talk_or_sing="sing",
+                core_version=core_version,
+                resource_baseurl=resource_baseurl,
+                resource_format=resource_format,
+            )
+        except CharacterNotFoundError as e:
+            raise HTTPException(status_code=404, detail=str(e)) from e
+        except CharacterInfoNotFoundError as e:
+            raise HTTPException(status_code=500, detail=str(e)) from e
 
     # リソースはAPIとしてアクセスするものではないことを表明するためOpenAPIスキーマーから除外する
     @router.get(f"/{RESOURCE_ENDPOINT}/{{resource_hash}}", include_in_schema=False)

--- a/voicevox_engine/metas/MetasStore.py
+++ b/voicevox_engine/metas/MetasStore.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Final, Literal, TypeAlias
 
-from fastapi import HTTPException
 from pydantic import BaseModel, Field
 
 from voicevox_engine.core.core_adapter import CoreCharacter, CoreCharacterStyle
@@ -53,6 +52,14 @@ class _EngineCharacter(BaseModel):
 
 
 GetCoreCharacters: TypeAlias = Callable[[str | None], list[CoreCharacter]]
+
+
+class CharacterNotFoundError(Exception):
+    """指定されたキャラクターが見つからない。"""
+
+
+class CharacterInfoNotFoundError(Exception):
+    """指定されたキャラクターが見つからない。"""
 
 
 class MetasStore:
@@ -170,9 +177,7 @@ class MetasStore:
             filter(lambda character: character.uuid == character_uuid, characters), None
         )
         if character is None:
-            # FIXME: HTTPExceptionはこのファイルとドメインが合わないので辞める
-            msg = "該当するキャラクターが見つかりません"
-            raise HTTPException(status_code=404, detail=msg)
+            raise CharacterNotFoundError("該当するキャラクターが見つかりません")
 
         # キャラクター情報を取得する
         try:
@@ -225,9 +230,7 @@ class MetasStore:
                     }
                 )
         except (FileNotFoundError, ResourceManagerError) as e:
-            # FIXME: HTTPExceptionはこのファイルとドメインが合わないので辞める
-            msg = "追加情報が見つかりませんでした"
-            raise HTTPException(status_code=500, detail=msg) from e
+            raise CharacterInfoNotFoundError("キャラクター情報が見つかりません") from e
 
         character_info = SpeakerInfo(
             policy=policy, portrait=portrait, style_infos=style_infos

--- a/voicevox_engine/metas/MetasStore.py
+++ b/voicevox_engine/metas/MetasStore.py
@@ -59,7 +59,7 @@ class CharacterNotFoundError(Exception):
 
 
 class CharacterInfoNotFoundError(Exception):
-    """指定されたキャラクターが見つからない。"""
+    """指定されたキャラクターの情報が見つからない。"""
 
 
 class MetasStore:


### PR DESCRIPTION
## 内容
refactor: キャラクター情報に関する HTTPException をルーターへ移動するリファクタリングを提案します。  

ルーターに関連している `HTTPException` が、機能の実体である `MetasStore.py` 内に存在し、ドメインがズレている FIXME を修正した。  

## 関連 Issue
無し