### PR TITLE
fix(ci): Dockerイメージビルド・テスト時のghcr上のDockerリポジトリ名を小文字に変換

### DIFF
--- a/.github/workflows/build-engine-container.yml
+++ b/.github/workflows/build-engine-container.yml
@@ -45,7 +45,7 @@ jobs:
           echo "version=${{ github.event.release.tag_name || github.event.inputs.version }}" >> "$GITHUB_OUTPUT"
 
           : # GitHub Container RegistryのDockerイメージリポジトリ
-          echo "ghcr_repository=ghcr.io/${{ github.repository }}" | tr "A-Z" "a-z" >> "$GITHUB_OUTPUT"
+          echo "ghcr_repository=ghcr.io/${{ github.repository }}" | tr "[:upper:]" "[:lower:]" >> "$GITHUB_OUTPUT"
 
           : # Docker HubのDockerイメージリポジトリ
           echo "dockerhub_repository=${{ vars.DOCKERHUB_USERNAME }}/voicevox_engine" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build-engine-container.yml
+++ b/.github/workflows/build-engine-container.yml
@@ -45,7 +45,7 @@ jobs:
           echo "version=${{ github.event.release.tag_name || github.event.inputs.version }}" >> "$GITHUB_OUTPUT"
 
           : # GitHub Container RegistryのDockerイメージリポジトリ
-          echo "ghcr_repository=ghcr.io/${{ github.repository_owner }}/voicevox_engine" >> "$GITHUB_OUTPUT"
+          echo "ghcr_repository=ghcr.io/${{ github.repository_owner }}/voicevox_engine" | tr "[A-Z]" "[a-z]" >> "$GITHUB_OUTPUT"
 
           : # Docker HubのDockerイメージリポジトリ
           echo "dockerhub_repository=${{ vars.DOCKERHUB_USERNAME }}/voicevox_engine" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build-engine-container.yml
+++ b/.github/workflows/build-engine-container.yml
@@ -45,7 +45,7 @@ jobs:
           echo "version=${{ github.event.release.tag_name || github.event.inputs.version }}" >> "$GITHUB_OUTPUT"
 
           : # GitHub Container RegistryのDockerイメージリポジトリ
-          echo "ghcr_repository=ghcr.io/${{ github.repository_owner }}/voicevox_engine" | tr "[A-Z]" "[a-z]" >> "$GITHUB_OUTPUT"
+          echo "ghcr_repository=ghcr.io/${{ github.repository }}" | tr "[A-Z]" "[a-z]" >> "$GITHUB_OUTPUT"
 
           : # Docker HubのDockerイメージリポジトリ
           echo "dockerhub_repository=${{ vars.DOCKERHUB_USERNAME }}/voicevox_engine" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build-engine-container.yml
+++ b/.github/workflows/build-engine-container.yml
@@ -45,7 +45,7 @@ jobs:
           echo "version=${{ github.event.release.tag_name || github.event.inputs.version }}" >> "$GITHUB_OUTPUT"
 
           : # GitHub Container RegistryのDockerイメージリポジトリ
-          echo "ghcr_repository=ghcr.io/${{ github.repository }}" | tr "[A-Z]" "[a-z]" >> "$GITHUB_OUTPUT"
+          echo "ghcr_repository=ghcr.io/${{ github.repository }}" | tr "A-Z" "a-z" >> "$GITHUB_OUTPUT"
 
           : # Docker HubのDockerイメージリポジトリ
           echo "dockerhub_repository=${{ vars.DOCKERHUB_USERNAME }}/voicevox_engine" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/test-engine-container.yml
+++ b/.github/workflows/test-engine-container.yml
@@ -49,7 +49,7 @@ jobs:
         id: docker_vars
         run: |
           # NOTE: Docker Hubのレートリミット回避のためGitHub Container Registryを使う
-          REPOSITORY=$(echo "ghcr.io/${{ github.repository }}" | tr "A-Z" "a-z")
+          REPOSITORY=$(echo "ghcr.io/${{ github.repository }}" | tr "[:upper:]" "[:lower:]")
 
           if [ "${{ matrix.tag }}" != "" ]; then
             echo "image_tag=${REPOSITORY}:${{ matrix.tag }}-${{ env.VERSION }}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/test-engine-container.yml
+++ b/.github/workflows/test-engine-container.yml
@@ -49,7 +49,7 @@ jobs:
         id: docker_vars
         run: |
           # NOTE: Docker Hubのレートリミット回避のためGitHub Container Registryを使う
-          REPOSITORY=$(echo "ghcr.io/${{ github.repository_owner }}/voicevox_engine" | tr "[A-Z]" "[a-z]")
+          REPOSITORY=$(echo "ghcr.io/${{ github.repository }}" | tr "[A-Z]" "[a-z]")
 
           if [ "${{ matrix.tag }}" != "" ]; then
             echo "image_tag=${REPOSITORY}:${{ matrix.tag }}-${{ env.VERSION }}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/test-engine-container.yml
+++ b/.github/workflows/test-engine-container.yml
@@ -49,7 +49,7 @@ jobs:
         id: docker_vars
         run: |
           # NOTE: Docker Hubのレートリミット回避のためGitHub Container Registryを使う
-          REPOSITORY=$(echo "ghcr.io/${{ github.repository }}" | tr "[A-Z]" "[a-z]")
+          REPOSITORY=$(echo "ghcr.io/${{ github.repository }}" | tr "A-Z" "a-z")
 
           if [ "${{ matrix.tag }}" != "" ]; then
             echo "image_tag=${REPOSITORY}:${{ matrix.tag }}-${{ env.VERSION }}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/test-engine-container.yml
+++ b/.github/workflows/test-engine-container.yml
@@ -17,7 +17,6 @@ on:
         required: true
 
 env:
-  IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/voicevox_engine # NOTE: Docker Hubのレートリミット回避のためGitHub Container Registryを使う
   VERSION: |- # version指定時はversionを、それ以外はタグ名を使用
     ${{ (github.event.inputs || inputs).version }}
 
@@ -49,10 +48,13 @@ jobs:
       - name: <Setup> Declare variables
         id: docker_vars
         run: |
+          # NOTE: Docker Hubのレートリミット回避のためGitHub Container Registryを使う
+          IMAGE_NAME=$(echo "ghcr.io/${{ github.repository_owner }}/voicevox_engine" | tr "[A-Z]" "[a-z]")
+
           if [ "${{ matrix.tag }}" != "" ]; then
-            echo "image_tag=${{ env.IMAGE_NAME }}:${{ matrix.tag }}-${{ env.VERSION }}" >> "$GITHUB_OUTPUT"
+            echo "image_tag=${IMAGE_NAME}:${{ matrix.tag }}-${{ env.VERSION }}" >> "$GITHUB_OUTPUT"
           else
-            echo "image_tag=${{ env.IMAGE_NAME }}:${{ env.VERSION }}" >> "$GITHUB_OUTPUT"
+            echo "image_tag=${IMAGE_NAME}:${{ env.VERSION }}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: <Setup> Login to GitHub Container Registry

--- a/.github/workflows/test-engine-container.yml
+++ b/.github/workflows/test-engine-container.yml
@@ -49,12 +49,12 @@ jobs:
         id: docker_vars
         run: |
           # NOTE: Docker Hubのレートリミット回避のためGitHub Container Registryを使う
-          IMAGE_NAME=$(echo "ghcr.io/${{ github.repository_owner }}/voicevox_engine" | tr "[A-Z]" "[a-z]")
+          REPOSITORY=$(echo "ghcr.io/${{ github.repository_owner }}/voicevox_engine" | tr "[A-Z]" "[a-z]")
 
           if [ "${{ matrix.tag }}" != "" ]; then
-            echo "image_tag=${IMAGE_NAME}:${{ matrix.tag }}-${{ env.VERSION }}" >> "$GITHUB_OUTPUT"
+            echo "image_tag=${REPOSITORY}:${{ matrix.tag }}-${{ env.VERSION }}" >> "$GITHUB_OUTPUT"
           else
-            echo "image_tag=${IMAGE_NAME}:${{ env.VERSION }}" >> "$GITHUB_OUTPUT"
+            echo "image_tag=${REPOSITORY}:${{ env.VERSION }}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: <Setup> Login to GitHub Container Registry


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->

- https://github.com/VOICEVOX/voicevox_engine/pull/1662

のマージで発生した、GitHubリポジトリのオーナー名が大文字を含む場合に、Dockerイメージのビルドに失敗する問題を修正します。

Dockerイメージビルド・テスト時のDockerリポジトリ名を小文字に変換します。

VOICEVOX ENGINEのGitHubリポジトリ名は、`VOICEVOX/voicevox_engine`ですが、
`ghcr.io`上のDockerリポジトリ名は、`ghcr.io/voicevox/voicevox_engine`なので、
Dockerリポジトリ名を小文字に変換する必要がありました。

ついでに、`ghcr.io`上のDockerリポジトリ名に`voicevox_engine`をハードコードしていたのを廃止して、
`ghcr.io/{GitHubリポジトリ名}`に変更しました。

フォークリポジトリの名前を`voicevox_engine`から変更したとき、変更後の名前に対応するDockerリポジトリにイメージがpushされるようになります（他の問題 https://github.com/VOICEVOX/voicevox_engine/pull/1662#issuecomment-2901441850 で、まだフォークリポジトリでは動作しません）

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

- https://github.com/VOICEVOX/voicevox_engine/pull/1662#issuecomment-2901963048

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
