### PR TITLE
docs: `AccentPhrase.pause_mora` のドキュメントを実態に合わせる

### DIFF
--- a/test/e2e/__snapshots__/test_openapi/test_OpenAPIの形が変わっていないことを確認.json
+++ b/test/e2e/__snapshots__/test_openapi/test_OpenAPIの形が変わっていないことを確認.json
@@ -25,7 +25,7 @@
           },
           "pause_mora": {
             "$ref": "#/components/schemas/Mora",
-            "description": "後ろに無音を付けるかどうか",
+            "description": "アクセント句の末尾につく無音モーラ。null の場合は無音モーラを付けない。",
             "title": "Pause Mora"
           }
         },

--- a/voicevox_engine/tts_pipeline/model.py
+++ b/voicevox_engine/tts_pipeline/model.py
@@ -47,7 +47,8 @@ class AccentPhrase(BaseModel):
     moras: list[Mora] = Field(description="モーラのリスト")
     accent: int = Field(description="アクセント箇所")
     pause_mora: Mora | SkipJsonSchema[None] = Field(
-        default=None, description="アクセント句の末尾につく無音モーラ。null の場合は無音モーラを付けない。"
+        default=None,
+        description="アクセント句の末尾につく無音モーラ。null の場合は無音モーラを付けない。",
     )
     is_interrogative: bool = Field(default=False, description="疑問系かどうか")
 

--- a/voicevox_engine/tts_pipeline/model.py
+++ b/voicevox_engine/tts_pipeline/model.py
@@ -47,7 +47,7 @@ class AccentPhrase(BaseModel):
     moras: list[Mora] = Field(description="モーラのリスト")
     accent: int = Field(description="アクセント箇所")
     pause_mora: Mora | SkipJsonSchema[None] = Field(
-        default=None, description="後ろに無音を付けるかどうか"
+        default=None, description="アクセント句の末尾につく無音モーラ。null の場合は無音モーラを付けない。"
     )
     is_interrogative: bool = Field(default=False, description="疑問系かどうか")
 


### PR DESCRIPTION
## 内容
`AccentPhrase.pause_mora` のドキュメントを実態に合わせる修正を提案します。  

## 関連 Issue
resolve #1682