### PR TITLE
refactor: e2k の変換を整理

### DIFF
--- a/test/unit/tts_pipeline/test_katakana_english.py
+++ b/test/unit/tts_pipeline/test_katakana_english.py
@@ -1,10 +1,34 @@
 """英単語のカタカナ変換機能の単体テスト。"""
 
+import pytest
+
 from voicevox_engine.tts_pipeline.katakana_english import (
+    HankakuAlphabet,
+    _convert_as_char_wise_katakana,
+    _split_into_words,
     convert_english_to_katakana,
     is_hankaku_alphabet,
     should_convert_english_to_katakana,
 )
+
+
+@pytest.mark.parametrize(
+    "string,true_words",
+    [
+        ("voicevox", ["voicevox"]),
+        ("VoiceVox", ["Voice", "Vox"]),
+        ("VoiceVOX", ["Voice", "V", "O", "X"]),
+        ("VOICEVOX", ["V", "O", "I", "C", "E", "V", "O", "X"]),
+    ],
+)
+def test_split_into_words(string: str, true_words: list[str]) -> None:
+    """`_split_into_words()` はアルファベット列を単語列へ分割する。"""
+    # outputs
+    words = _split_into_words(HankakuAlphabet(string))
+    # expects
+    true_words_typed = list(map(HankakuAlphabet, true_words))
+    # tests
+    assert true_words_typed == words
 
 
 def test_should_convert_english_to_katakana_normal() -> None:
@@ -35,6 +59,24 @@ def test_should_convert_english_to_katakana_short() -> None:
     should_convert = should_convert_english_to_katakana(string)
 
     assert not should_convert
+
+
+@pytest.mark.parametrize(
+    "alphabets,true_yomi",
+    [
+        ("aa", "エーエー"),
+        ("Aa", "エーエー"),
+        ("aA", "エーエー"),
+        ("AA", "エーエー"),
+        ("VOICE", "ブイオーアイシーイー"),
+    ],
+)
+def test_convert_as_char_wise_katakana(alphabets: str, true_yomi: str) -> None:
+    """`_convert_as_char_wise_katakana()` はアルファベット列を文字ごとにカタカナ読みする。"""
+    # outputs
+    yomi = _convert_as_char_wise_katakana(HankakuAlphabet(alphabets))
+    # tests
+    assert true_yomi == yomi
 
 
 def test_convert_english_to_katakana() -> None:

--- a/voicevox_engine/tts_pipeline/katakana_english.py
+++ b/voicevox_engine/tts_pipeline/katakana_english.py
@@ -46,6 +46,20 @@ def is_hankaku_alphabet(text: str) -> TypeGuard[HankakuAlphabet]:
     return bool(re.fullmatch("[a-zA-Z]+", text))
 
 
+def _split_into_words(string: HankakuAlphabet) -> list[HankakuAlphabet]:
+    """
+    アルファベット列を単語列へ分割する。
+
+    Examples
+    --------
+    >>> _split_into_words("VoiceVox")
+    ["Voice", "Vox"]
+    """
+    # TODO: 「全て大文字で書かれた英単語は、バラバラの文字へ分割される」という動作がユーザーにとって最適か検討 (ref: https://github.com/VOICEVOX/voicevox_engine/issues/1524#issuecomment-2849254324)
+    # NOTE: キャメルケース的な単語に対応させるため、大文字で分割する
+    return list(map(HankakuAlphabet, re.findall("[a-zA-Z][a-z]*", string)))
+
+
 def should_convert_english_to_katakana(string: HankakuAlphabet) -> bool:
     """読みが不明な英単語をカタカナに変換するべきか否かを判定する"""
     if len(string) < 3:
@@ -58,18 +72,28 @@ def should_convert_english_to_katakana(string: HankakuAlphabet) -> bool:
     return True
 
 
+def _convert_as_char_wise_katakana(alphabets: HankakuAlphabet) -> str:
+    """
+    アルファベット列を文字ごとのカタカナ読みへ変換する。
+
+    Examples
+    --------
+    >>> _split_into_words("VOICE")
+    "ブイオーアイシーイー"
+    """
+    yomi = ""
+    for alphabet in alphabets:
+        yomi += ojt_alphabet_kana_mapping[alphabet.upper()]
+    return yomi
+
+
 def convert_english_to_katakana(string: HankakuAlphabet) -> str:
-    """kanalizerを用いて、読みが不明な英単語をカタカナに変換する"""
+    """英単語をカタカナ読みに変換する。"""
     kana = ""
-    # キャメルケース的な単語に対応させるため、大文字で分割する
-    for word in re.findall("[a-zA-Z][a-z]*", string):
-        word = HankakuAlphabet(word)
-
-        # 大文字のみ、もしくは短いワードの場合は、kanalizerでの変換を行わない
-        if not should_convert_english_to_katakana(word):
-            for alphabet in word:
-                kana += ojt_alphabet_kana_mapping[alphabet.upper()]
-        else:
+    for word in _split_into_words(string):
+        if should_convert_english_to_katakana(word):
+            # 単語を英単語とみなして読みを生成する
             kana += kanalizer.convert(word.lower())
-
+        else:
+            kana += _convert_as_char_wise_katakana(word)
     return kana

--- a/voicevox_engine/tts_pipeline/katakana_english.py
+++ b/voicevox_engine/tts_pipeline/katakana_english.py
@@ -78,7 +78,7 @@ def _convert_as_char_wise_katakana(alphabets: HankakuAlphabet) -> str:
 
     Examples
     --------
-    >>> _split_into_words("VOICE")
+    >>> _convert_as_char_wise_katakana("VOICE")
     "ブイオーアイシーイー"
     """
     yomi = ""


### PR DESCRIPTION
## 内容
e2k の変換をリファクタリングすることを提案します。  

e2k はリファクタリングをある程度進めた時点で master merge されたため、更なる品質向上が求められる。  
特に「アルファベットを変換する部分」と「変換の種類を判断する部分」は e2k の核となる機能であり、関数へ切り出して詳細にドキュメントを用意し、テストすべきである。  

これらの根拠に基づき、e2k の変換をリファクタリングすることを提案します。  

核となる機能、かつ、関数名から動作がぱっとわからない関数について、docstring example を用いて例を書いています。  
メンテが不足するとコードと乖離しやすい & tests と被っているため、最小の手間でわかりやすさを得られるよう、1例のみの例示にとどめています。  

## 関連 Issue
part of #1524