### PR TITLE
refactor: `should_convert_english_to_katakana()` の呼び出しを減らす

### DIFF
--- a/test/unit/tts_pipeline/test_katakana_english.py
+++ b/test/unit/tts_pipeline/test_katakana_english.py
@@ -5,10 +5,10 @@ import pytest
 from voicevox_engine.tts_pipeline.katakana_english import (
     HankakuAlphabet,
     _convert_as_char_wise_katakana,
+    _should_convert_english_to_katakana,
     _split_into_words,
     convert_english_to_katakana,
     is_hankaku_alphabet,
-    should_convert_english_to_katakana,
 )
 
 
@@ -31,34 +31,20 @@ def test_split_into_words(string: str, true_words: list[str]) -> None:
     assert true_words_typed == words
 
 
-def test_should_convert_english_to_katakana_normal() -> None:
-    """`should_convert_english_to_katakana`は英単語を変換すべきであると判定する"""
-    string = "Voivo"
-    assert is_hankaku_alphabet(string)
-
-    should_convert = should_convert_english_to_katakana(string)
-
-    assert should_convert
-
-
-def test_should_convert_english_to_katakana_uppercase() -> None:
-    """`should_convert_english_to_katakana`は大文字のみの英単語を変換すべきではないと判定する"""
-    string = "VOIVO"
-    assert is_hankaku_alphabet(string)
-
-    should_convert = should_convert_english_to_katakana(string)
-
-    assert not should_convert
-
-
-def test_should_convert_english_to_katakana_short() -> None:
-    """`should_convert_english_to_katakana`は2文字以下の英単語を変換すべきではないと判定する"""
-    string = "Vo"
-    assert is_hankaku_alphabet(string)
-
-    should_convert = should_convert_english_to_katakana(string)
-
-    assert not should_convert
+@pytest.mark.parametrize(
+    "string,true_should",
+    [
+        ("voivo", True),
+        ("Voivo", True),
+        ("VOIVO", False),  # 大文字のみの英単語は変換すべきではない
+        ("Vo", False),  # 2文字以下の英単語は変換すべきではない
+    ],
+)
+def test_should_convert_english_to_katakana(string: str, true_should: bool) -> None:
+    # outputs
+    should = _should_convert_english_to_katakana(HankakuAlphabet(string))
+    # tests
+    assert true_should == should
 
 
 @pytest.mark.parametrize(

--- a/voicevox_engine/tts_pipeline/katakana_english.py
+++ b/voicevox_engine/tts_pipeline/katakana_english.py
@@ -60,12 +60,13 @@ def _split_into_words(string: HankakuAlphabet) -> list[HankakuAlphabet]:
     return list(map(HankakuAlphabet, re.findall("[a-zA-Z][a-z]*", string)))
 
 
-def should_convert_english_to_katakana(string: HankakuAlphabet) -> bool:
-    """読みが不明な英単語をカタカナに変換するべきか否かを判定する"""
+def _should_convert_english_to_katakana(string: HankakuAlphabet) -> bool:
+    """読みが不明な英単語をカタカナに変換するべきか否かを判定する。"""
+    # 2文字以下の場合はカタカナへ変換しない
     if len(string) < 3:
         return False
 
-    # 全て大文字の場合は、e2kでの解析を行わない
+    # 全て大文字の場合はカタカナへ変換しない
     if string == string.upper():
         return False
 
@@ -91,7 +92,7 @@ def convert_english_to_katakana(string: HankakuAlphabet) -> str:
     """英単語をカタカナ読みに変換する。"""
     kana = ""
     for word in _split_into_words(string):
-        if should_convert_english_to_katakana(word):
+        if _should_convert_english_to_katakana(word):
             # 単語を英単語とみなして読みを生成する
             kana += kanalizer.convert(word.lower())
         else:

--- a/voicevox_engine/tts_pipeline/njd_feature_processor.py
+++ b/voicevox_engine/tts_pipeline/njd_feature_processor.py
@@ -5,11 +5,7 @@ from dataclasses import asdict, dataclass
 import pyopenjtalk
 
 from ..utility.text_utility import count_mora, replace_zenkaku_alphabets_with_hankaku
-from .katakana_english import (
-    convert_english_to_katakana,
-    is_hankaku_alphabet,
-    should_convert_english_to_katakana,
-)
+from .katakana_english import convert_english_to_katakana, is_hankaku_alphabet
 
 
 @dataclass
@@ -101,13 +97,9 @@ def text_to_full_context_labels(text: str, enable_e2k: bool) -> list[str]:
 
     if enable_e2k:
         for i, feature in enumerate(njd_features):
-            hankaku_string = replace_zenkaku_alphabets_with_hankaku(feature.string)
-            if (
-                _is_unknown_reading_word(feature)
-                and is_hankaku_alphabet(hankaku_string)
-                and should_convert_english_to_katakana(hankaku_string)
-            ):
-                new_pron = convert_english_to_katakana(hankaku_string)
+            hankakus = replace_zenkaku_alphabets_with_hankaku(feature.string)
+            if _is_unknown_reading_word(feature) and is_hankaku_alphabet(hankakus):
+                new_pron = convert_english_to_katakana(hankakus)
                 njd_features[i] = NjdFeature.from_english_kana(feature.string, new_pron)
 
         # 英単語間のスペースがpauとして扱われて読みが不自然になるため、削除する

--- a/voicevox_engine/tts_pipeline/njd_feature_processor.py
+++ b/voicevox_engine/tts_pipeline/njd_feature_processor.py
@@ -97,9 +97,9 @@ def text_to_full_context_labels(text: str, enable_e2k: bool) -> list[str]:
 
     if enable_e2k:
         for i, feature in enumerate(njd_features):
-            hankakus = replace_zenkaku_alphabets_with_hankaku(feature.string)
-            if _is_unknown_reading_word(feature) and is_hankaku_alphabet(hankakus):
-                new_pron = convert_english_to_katakana(hankakus)
+            string = replace_zenkaku_alphabets_with_hankaku(feature.string)
+            if _is_unknown_reading_word(feature) and is_hankaku_alphabet(string):
+                new_pron = convert_english_to_katakana(string)
                 njd_features[i] = NjdFeature.from_english_kana(feature.string, new_pron)
 
         # 英単語間のスペースがpauとして扱われて読みが不自然になるため、削除する


### PR DESCRIPTION
## 内容
`should_convert_english_to_katakana()` の呼び出しを減らすリファクタリングを提案します。  

呼び出しを減らしたことで `should_convert_english_to_katakana()` がモジュールに閉じるようになったため、プライベート関数へとリネームしています。  
またテストを pytest の parametrize で簡略化しました。  

## 関連 Issue
resolve #1712