### PR TITLE
feat: 辞書・キャラクター情報以外の500エラーの詳細をレスポンスに含めないようにする

### DIFF
--- a/voicevox_engine/app/middlewares.py
+++ b/voicevox_engine/app/middlewares.py
@@ -24,7 +24,7 @@ def configure_middlewares(
         print_exception(exc)
         return JSONResponse(
             status_code=500,
-            content="Internal Server Error",
+            content={"detail": "Internal Server Error"},
         )
 
     app.add_middleware(ServerErrorMiddleware, handler=global_execution_handler)

--- a/voicevox_engine/app/routers/library.py
+++ b/voicevox_engine/app/routers/library.py
@@ -2,6 +2,7 @@
 
 import asyncio
 from io import BytesIO
+from traceback import print_exception
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Request
@@ -74,7 +75,8 @@ def generate_library_router(
         except LibraryOperationUnauthorizedError as e:
             raise HTTPException(status_code=403, detail=str(e)) from e
         except LibraryInternalError as e:
-            raise HTTPException(status_code=500, detail=str(e)) from e
+            print_exception(e)
+            raise HTTPException(status_code=500) from e
 
     @router.post(
         "/uninstall_library/{library_uuid}",
@@ -96,6 +98,7 @@ def generate_library_router(
         except LibraryOperationUnauthorizedError as e:
             raise HTTPException(status_code=403, detail=str(e)) from e
         except LibraryInternalError as e:
-            raise HTTPException(status_code=500, detail=str(e)) from e
+            print_exception(e)
+            raise HTTPException(status_code=500) from e
 
     return router

--- a/voicevox_engine/app/routers/preset.py
+++ b/voicevox_engine/app/routers/preset.py
@@ -1,5 +1,6 @@
 """プリセット機能を提供する API Router"""
 
+from traceback import print_exception
 from typing import Annotated
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Query
@@ -31,7 +32,8 @@ def generate_preset_router(
         except PresetInputError as e:
             raise HTTPException(status_code=422, detail=str(e)) from e
         except PresetInternalError as e:
-            raise HTTPException(status_code=500, detail=str(e)) from e
+            print_exception(e)
+            raise HTTPException(status_code=500) from e
         return presets
 
     @router.post(
@@ -53,7 +55,8 @@ def generate_preset_router(
         except PresetInputError as e:
             raise HTTPException(status_code=422, detail=str(e)) from e
         except PresetInternalError as e:
-            raise HTTPException(status_code=500, detail=str(e)) from e
+            print_exception(e)
+            raise HTTPException(status_code=500) from e
         return id
 
     @router.post(
@@ -75,7 +78,8 @@ def generate_preset_router(
         except PresetInputError as e:
             raise HTTPException(status_code=422, detail=str(e)) from e
         except PresetInternalError as e:
-            raise HTTPException(status_code=500, detail=str(e)) from e
+            print_exception(e)
+            raise HTTPException(status_code=500) from e
         return id
 
     @router.post(
@@ -92,6 +96,7 @@ def generate_preset_router(
         except PresetInputError as e:
             raise HTTPException(status_code=422, detail=str(e)) from e
         except PresetInternalError as e:
-            raise HTTPException(status_code=500, detail=str(e)) from e
+            print_exception(e)
+            raise HTTPException(status_code=500) from e
 
     return router

--- a/voicevox_engine/app/routers/tts_pipeline.py
+++ b/voicevox_engine/app/routers/tts_pipeline.py
@@ -2,6 +2,7 @@
 
 import zipfile
 from tempfile import NamedTemporaryFile, TemporaryFile
+from traceback import print_exception
 from typing import Annotated, Self
 
 import soundfile
@@ -139,7 +140,8 @@ def generate_tts_pipeline_router(
         except PresetInputError as e:
             raise HTTPException(status_code=422, detail=str(e)) from e
         except PresetInternalError as e:
-            raise HTTPException(status_code=500, detail=str(e)) from e
+            print_exception(e)
+            raise HTTPException(status_code=500) from e
         for preset in presets:
             if preset.id == preset_id:
                 selected_preset = preset
@@ -327,7 +329,8 @@ def generate_tts_pipeline_router(
                 version=version,
             )
         except CancellableEngineInternalError as e:
-            raise HTTPException(status_code=500, detail=str(e)) from e
+            print_exception(e)
+            raise HTTPException(status_code=500) from e
 
         if f_name == "":
             raise HTTPException(status_code=422, detail="不明なバージョンです")


### PR DESCRIPTION
## 内容

500エラーが発生した場合`print_exception()`でエラー内容をコンソールにのみ表示してレスポンスには`Internal Server Error`のみを返すように変更します。

## 関連 Issue

- ref #1490

## その他

キャラクター情報と辞書に関してはリファクタリングが行われているため保留
- ref #1701 
- ref #1702
