### PR TITLE
build!: drop `windows-2019`

### DIFF
--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -58,20 +58,20 @@ jobs:
       matrix:
         include:
           # Windows CPU
-          - os: windows-2019
+          - os: windows-2022
             architecture: "x64"
             voicevox_core_asset_prefix: voicevox_core-windows-x64-cpu
             onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.13.1/onnxruntime-win-x64-1.13.1.zip
             target: windows-cpu
           # Windows DirectML
-          - os: windows-2019
+          - os: windows-2022
             architecture: "x64"
             voicevox_core_asset_prefix: voicevox_core-windows-x64-directml
             onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.13.1/Microsoft.ML.OnnxRuntime.DirectML.1.13.1.zip
             directml_url: https://www.nuget.org/api/v2/package/Microsoft.AI.DirectML/1.10.0
             target: windows-directml
           # Windows NVIDIA GPU
-          - os: windows-2019
+          - os: windows-2022
             architecture: "x64"
             voicevox_core_asset_prefix: voicevox_core-windows-x64-cuda
             onnxruntime_url: https://github.com/microsoft/onnxruntime/releases/download/v1.13.1/onnxruntime-win-x64-gpu-1.13.1.zip

--- a/.github/workflows/test-engine-package.yml
+++ b/.github/workflows/test-engine-package.yml
@@ -47,11 +47,11 @@ jobs:
             target: macos-x64
           - os: macos-14
             target: macos-arm64
-          - os: windows-2019
+          - os: windows-2022
             target: windows-cpu
-          - os: windows-2019
+          - os: windows-2022
             target: windows-nvidia
-          - os: windows-2019
+          - os: windows-2022
             target: windows-directml
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## 内容

[brownoutが始まった](https://github.com/actions/runner-images/issues/12045)ため。

BREAKING-CHANGE: リリースにおけるWindowsのランナーが`windows-2022`になる。

## 関連 Issue

## スクリーンショット・動画など

## その他
