### PR TITLE
build(ci): Dockerイメージのlatestタグをプッシュする`inputs.with_latest`フラグを追加

### DIFF
--- a/.github/workflows/build-engine-container.yml
+++ b/.github/workflows/build-engine-container.yml
@@ -7,10 +7,10 @@ on:
       version:
         type: string
         required: true
-      prerelease:
-        type: boolean
-        default: true
       push_dockerhub:
+        type: boolean
+        default: false
+      with_latest:
         type: boolean
         default: false
     secrets:
@@ -21,12 +21,12 @@ on:
       version:
         description: "バージョン情報（A.BB.C / A.BB.C-preview.D）"
         required: true
-      prerelease:
-        description: "プレリリースかどうか"
-        type: boolean
-        default: true
       push_dockerhub:
         description: "Docker Hubにプッシュする"
+        type: boolean
+        default: false
+      with_latest:
+        description: "latestタグをプッシュする"
         type: boolean
         default: false
 
@@ -152,9 +152,9 @@ jobs:
       - name: <Build> Generate Docker image names
         id: generate-docker-image-names
         run: |
-          # NOTE: workflow_call・workflow_dispatch以外では、 `{{ inputs.prerelease }} == "null"` であるため、 `if [[ false ]]` となる
+          # NOTE: workflow_call・workflow_dispatch以外では、 `{{ inputs.with_latest }} == "null"` であるため、 `if [[ false ]]` となる
           WITH_LATEST_ARG=""
-          if [[ "${{ inputs.prerelease }}" == "false" ]]; then
+          if [[ "${{ inputs.with_latest }}" == "true" ]]; then
             WITH_LATEST_ARG="--with_latest"
           fi
 

--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -27,6 +27,10 @@ on:
         description: "Docker Hubにプッシュする"
         type: boolean
         default: false
+      with_latest:
+        description: "Dockerイメージのlatestタグをプッシュする"
+        type: boolean
+        default: false
 
 env:
   VOICEVOX_RESOURCE_VERSION: "0.23.1"
@@ -673,9 +677,9 @@ jobs:
     uses: ./.github/workflows/build-engine-container.yml
     with:
       version: ${{ needs.config.outputs.version }}
-      # NOTE: workflow_dispatch以外では、 `toJSON(inputs.prerelease) == 'null'` であるため `prerelease: true` となる
-      prerelease: ${{ toJSON(inputs.prerelease) != 'false' }}
       # NOTE: workflow_dispatch以外では、 `inputs.push_dockerhub == null` であるため `push_dockerhub: false` となる
       push_dockerhub: ${{ inputs.push_dockerhub == true }}
+      # NOTE: workflow_dispatch以外では、 `inputs.with_latest == 'null'` であるため `with_latest: false` となる
+      with_latest: ${{ inputs.with_latest == true }}
     secrets:
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/build-latest-dev.yml
+++ b/.github/workflows/build-latest-dev.yml
@@ -36,6 +36,7 @@ jobs:
                 version: dev_version,
                 prerelease: true,
                 push_dockerhub: true,
+                with_latest: false,
               },
             });
             console.log(`Triggered workflow_dispatch for ${dev_version}`);

--- a/test/unit/tools/test_generate_docker_image_names.py
+++ b/test/unit/tools/test_generate_docker_image_names.py
@@ -5,7 +5,7 @@ from tools.generate_docker_image_names import (
 )
 
 
-def test_generate_docker_image_names_for_prerelease() -> None:
+def test_generate_docker_image_names() -> None:
     """プレリリース向けのDockerイメージ名を生成できる。"""
     # Inputs
     repository = "your-org/your-repo"
@@ -30,7 +30,7 @@ def test_generate_docker_image_names_for_prerelease() -> None:
     assert image_names == expected_image_names
 
 
-def test_generate_docker_image_names_for_release() -> None:
+def test_generate_docker_image_names_with_latest() -> None:
     """リリース向けのDockerイメージ名を生成できる。"""
     # Inputs
     repository = "your-org/your-repo"


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->

- #1726

の1番の実装として、Dockerイメージのlatestタグをプッシュする`inputs.with_latest`フラグをエンジンビルドCIに追加します。

DockerイメージビルドCIでは、同じ機能を持っていた`inputs.prerelease`フラグ（ #1708 で追加）を廃止して、`inputs.with_latest`フラグで置き換えました。

このプルリクエストでは、 #1708 と同様に、GitHub Releaseを作成した場合は、プレリリースかどうかによらず、`latest`タグのプッシュは行いません。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

- close #1726 

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
