### PR TITLE
build(ci): バージョンを指定してDockerイメージをlatestタグとしてプッシュするCIを追加

### DIFF
--- a/.github/workflows/build-latest-engine-container.yml
+++ b/.github/workflows/build-latest-engine-container.yml
@@ -87,10 +87,6 @@ jobs:
           # 最初のprefixを取得する
           # NOTE: matrix.prefixes はすべて同じイメージの別名なので、最初のprefixだけをpull対象とする
           FIRST_PREFIX=$(echo "${{ matrix.prefixes }}" | cut -d ',' -f 1)
-          if [[ -z "${FIRST_PREFIX}" ]]; then
-            echo "::error:: matrix.prefixes が空です"
-            exit 1
-          fi
 
           echo "first_prefix=${FIRST_PREFIX}" >> "${GITHUB_OUTPUT}"
 

--- a/.github/workflows/build-latest-engine-container.yml
+++ b/.github/workflows/build-latest-engine-container.yml
@@ -1,5 +1,6 @@
 # latestタグをリリースする
 # NOTE: 指定したバージョンのDockerイメージをプルして、latest タグを付けて再プッシュする
+
 name: Release latest engine container
 on:
   workflow_dispatch:

--- a/.github/workflows/build-latest-engine-container.yml
+++ b/.github/workflows/build-latest-engine-container.yml
@@ -137,10 +137,10 @@ jobs:
 
       - name: <Build> Build and push target Docker images
         run: |
-          while read -r target_tag; do <<< "${{ steps.generate-target-docker-image-names.outputs.tags }}"
+          while read -r target_tag; do
             # Dockerイメージの別名を作成
             docker tag "${{ steps.generate-source-docker-image-name.outputs.tag }}" "${target_tag}"
 
             # Dockerイメージの別名をpush
             docker push "${target_tag}"
-          done
+          done <<< "${{ steps.generate-target-docker-image-names.outputs.tags }}"

--- a/.github/workflows/build-latest-engine-container.yml
+++ b/.github/workflows/build-latest-engine-container.yml
@@ -1,8 +1,5 @@
 name: Build latest engine container
 on:
-  push:
-    branches:
-      - feature/build-latest-engine-container-ci
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/build-latest-engine-container.yml
+++ b/.github/workflows/build-latest-engine-container.yml
@@ -133,7 +133,7 @@ jobs:
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
-      - name: <Build> Build and push target Docker images
+      - name: <Build/Deploy> Build and push target Docker images
         run: |
           # --tag 引数のリストを生成する
           TAG_ARGS=()

--- a/.github/workflows/build-latest-engine-container.yml
+++ b/.github/workflows/build-latest-engine-container.yml
@@ -135,10 +135,14 @@ jobs:
 
       - name: <Build> Build and push target Docker images
         run: |
-          while read -r target_tag; do
-            # Dockerイメージの別名を作成してpushする
-            # NOTE: 複製元のマニフェストリストに含まれるイメージが宛先にコピーされる
-            docker buildx imagetools create \
-              --tag "${target_tag}" \
-              "${{ steps.generate-source-docker-image-name.outputs.tag }}"
+          # --tag 引数のリストを生成する
+          TAG_ARGS=()
+          while IFS= read -r TAG; do
+            TAG_ARGS+=(--tag "$TAG")
           done <<< "${{ steps.generate-target-docker-image-names.outputs.tags }}"
+
+          # Dockerイメージの別名を作成してpushする
+          # NOTE: 複製元のタグに含まれる各プラットフォームのイメージが宛先にコピーされる
+          docker buildx imagetools create \
+            "${TAG_ARGS[@]}" \
+            "${{ steps.generate-source-docker-image-name.outputs.tag }}"

--- a/.github/workflows/build-latest-engine-container.yml
+++ b/.github/workflows/build-latest-engine-container.yml
@@ -36,13 +36,19 @@ jobs:
 
     strategy:
       matrix:
+        # 各変数の説明
+        # prefixes: Docker tagのプレフィックス。カンマ区切り。空文字列の場合、バージョンのみがタグ名になる
         include:
+          # Ubuntu 22.04
+          - prefixes: "cpu-ubuntu22.04"
           # Ubuntu 22.04 / AMD64
           - prefixes: "cpu-amd64-ubuntu22.04"
           # Ubuntu 22.04 / ARM64
           - prefixes: "cpu-arm64-ubuntu22.04"
           # Ubuntu 22.04 / AMD64 / NVIDIA
           - prefixes: "nvidia-ubuntu22.04,nvidia-amd64-ubuntu22.04"
+          # Ubuntu 24.04
+          - prefixes: ",cpu,cpu-ubuntu24.04"
           # Ubuntu 24.04 / AMD64
           - prefixes: "cpu-amd64,cpu-amd64-ubuntu24.04"
           # Ubuntu 24.04 / ARM64
@@ -130,17 +136,12 @@ jobs:
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
-      - name: <Build> Pull source Docker image
-        run: |
-          # 複製元のDockerイメージをpullする
-          docker pull "${{ steps.generate-source-docker-image-name.outputs.tag }}"
-
       - name: <Build> Build and push target Docker images
         run: |
           while read -r target_tag; do
-            # Dockerイメージの別名を作成
-            docker tag "${{ steps.generate-source-docker-image-name.outputs.tag }}" "${target_tag}"
-
-            # Dockerイメージの別名をpush
-            docker push "${target_tag}"
+            # Dockerイメージの別名を作成してpushする
+            # NOTE: 複製元のマニフェストリストに含まれるイメージが宛先にコピーされる
+            docker buildx imagetools create \
+              --tag "${target_tag}" \
+              "${{ steps.generate-source-docker-image-name.outputs.tag }}"
           done <<< "${{ steps.generate-target-docker-image-names.outputs.tags }}"

--- a/.github/workflows/build-latest-engine-container.yml
+++ b/.github/workflows/build-latest-engine-container.yml
@@ -1,5 +1,8 @@
 name: Build latest engine container
 on:
+  push:
+    branches:
+      - feature/build-latest-engine-container-ci
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/build-latest-engine-container.yml
+++ b/.github/workflows/build-latest-engine-container.yml
@@ -1,4 +1,4 @@
-name: Build latest engine container
+name: Release latest engine container
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/build-latest-engine-container.yml
+++ b/.github/workflows/build-latest-engine-container.yml
@@ -36,6 +36,7 @@ jobs:
 
     strategy:
       matrix:
+        # TODO: 1つのランナーで実行したい
         # 各変数の説明
         # prefixes: Docker tagのプレフィックス。カンマ区切り。空文字列の場合、バージョンのみがタグ名になる
         include:

--- a/.github/workflows/build-latest-engine-container.yml
+++ b/.github/workflows/build-latest-engine-container.yml
@@ -1,3 +1,5 @@
+# latestタグをリリースする
+# NOTE: 指定したバージョンのDockerイメージをプルして、latest タグを付けて再プッシュする
 name: Release latest engine container
 on:
   workflow_dispatch:
@@ -99,7 +101,7 @@ jobs:
             echo "tag<<EOF"
 
             # ghcr.io
-            # NOTE: ghcr.io からpullして、 ghcr.io と Docker Hub の両方にpushする
+            # NOTE: Docker Hubのレートリミット回避のためGitHub Container Registryを使う
             uv run tools/generate_docker_image_names.py \
               --repository "${{ needs.config.outputs.ghcr_repository }}" \
               --version "${{ inputs.version }}" \

--- a/.github/workflows/build-latest-engine-container.yml
+++ b/.github/workflows/build-latest-engine-container.yml
@@ -1,0 +1,146 @@
+name: Build latest engine container
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "バージョン情報（A.BB.C / A.BB.C-preview.D）"
+        required: true
+      push_dockerhub:
+        description: "Docker Hubにプッシュする"
+        type: boolean
+        default: false
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  config: # 全 jobs で利用する定数の定義. `env` が利用できないコンテキストでも利用できる.
+    runs-on: ubuntu-latest
+    outputs:
+      ghcr_repository: ${{ steps.vars.outputs.ghcr_repository }}
+      dockerhub_repository: ${{ steps.vars.outputs.dockerhub_repository }}
+    steps:
+      - name: <Setup> Declare variables
+        id: vars
+        run: |
+          : # GitHub Container RegistryのDockerイメージリポジトリ
+          echo "ghcr_repository=ghcr.io/${{ github.repository }}" | tr "[:upper:]" "[:lower:]" >> "$GITHUB_OUTPUT"
+
+          : # Docker HubのDockerイメージリポジトリ
+          echo "dockerhub_repository=${{ vars.DOCKERHUB_USERNAME }}/voicevox_engine" >> "$GITHUB_OUTPUT"
+
+  build-docker-latest:
+    needs: [config]
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        include:
+          # Ubuntu 22.04 / AMD64
+          - prefixes: "cpu-amd64-ubuntu22.04"
+          # Ubuntu 22.04 / ARM64
+          - prefixes: "cpu-arm64-ubuntu22.04"
+          # Ubuntu 22.04 / AMD64 / NVIDIA
+          - prefixes: "nvidia-ubuntu22.04,nvidia-amd64-ubuntu22.04"
+          # Ubuntu 24.04 / AMD64
+          - prefixes: "cpu-amd64,cpu-amd64-ubuntu24.04"
+          # Ubuntu 24.04 / ARM64
+          - prefixes: "cpu-arm64,cpu-arm64-ubuntu24.04"
+          # Ubuntu 24.04 / AMD64 / NVIDIA
+          - prefixes: "nvidia,nvidia-amd64,nvidia-ubuntu24.04,nvidia-amd64-ubuntu24.04"
+
+    steps:
+      - name: <Setup> Check out the repository
+        uses: actions/checkout@v4
+
+      - name: <Setup> Prepare Python
+        uses: ./.github/actions/prepare_python
+
+      - name: <Setup> Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: <Setup> Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: <Setup> Login to Docker Hub
+        if: inputs.push_dockerhub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: <Build> Get first prefix
+        id: get-first-prefix
+        run: |
+          # 最初のprefixを取得する
+          # NOTE: matrix.prefixes はすべて同じイメージの別名なので、最初のprefixだけをpull対象とする
+          FIRST_PREFIX=$(echo "${{ matrix.prefixes }}" | cut -d ',' -f 1)
+          if [[ -z "${FIRST_PREFIX}" ]]; then
+            echo "::error:: matrix.prefixes が空です"
+            exit 1
+          fi
+
+          echo "first_prefix=${FIRST_PREFIX}" >> "${GITHUB_OUTPUT}"
+
+      - name: <Build> Generate source Docker image name
+        id: generate-source-docker-image-name
+        run: |
+          # Dockerイメージ名を outputs.tag に1つだけ格納する
+          {
+            echo "tag<<EOF"
+
+            # ghcr.io
+            # NOTE: ghcr.io からpullして、 ghcr.io と Docker Hub の両方にpushする
+            uv run tools/generate_docker_image_names.py \
+              --repository "${{ needs.config.outputs.ghcr_repository }}" \
+              --version "${{ inputs.version }}" \
+              --prefix "${{ steps.get-first-prefix.outputs.first_prefix }}"
+
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: <Build> Generate target Docker image names
+        id: generate-target-docker-image-names
+        run: |
+          # Dockerイメージ名を outputs.tags に改行区切りで格納する
+          {
+            echo "tags<<EOF"
+
+            # ghcr.io
+            uv run tools/generate_docker_image_names.py \
+              --repository "${{ needs.config.outputs.ghcr_repository }}" \
+              --version "latest" \
+              --prefix "${{ matrix.prefixes }}"
+
+            # Docker Hub
+            # NOTE: workflow_dispatch以外では、 `{{ inputs.push_dockerhub }} == "null"` であるため、 `if [[ false ]]` となる
+            if [[ "${{ inputs.push_dockerhub }}" == "true" ]]; then
+              uv run tools/generate_docker_image_names.py \
+                --repository "${{ needs.config.outputs.dockerhub_repository }}" \
+                --version "latest" \
+                --prefix "${{ matrix.prefixes }}"
+            fi
+
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: <Build> Pull source Docker image
+        run: |
+          # 複製元のDockerイメージをpullする
+          docker pull "${{ steps.generate-source-docker-image-name.outputs.tag }}"
+
+      - name: <Build> Build and push target Docker images
+        run: |
+          while read -r target_tag; do <<< "${{ steps.generate-target-docker-image-names.outputs.tags }}"
+            # Dockerイメージの別名を作成
+            docker tag "${{ steps.generate-source-docker-image-name.outputs.tag }}" "${target_tag}"
+
+            # Dockerイメージの別名をpush
+            docker push "${target_tag}"
+          done


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->

- #1726

の3番の実装として、`workflow_dispatch`でバージョンを指定して、そのバージョンのDockerイメージをlatestタグとしてプッシュするCIを追加します。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

- ref #1727
- ref #1726  

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

マルチプラットフォームイメージにも対応しています。

```shell
gh workflow run --repo aoirint/voicevox_engine build-latest-engine-container.yml --field "version=0.24.0-aoirint.9" --field "push_dockerhub=true"
```

- [CIログ](https://github.com/aoirint/voicevox_engine/actions/runs/15508341847)

<details>
<summary>CIサマリー</summary>

![image](https://github.com/user-attachments/assets/aea7662c-2185-4793-8214-37ef63171f7f)

</details>

<details>
<summary>ghcr.io</summary>

![image](https://github.com/user-attachments/assets/fefadb45-4bbb-4c75-9eca-6c57cd7d91d7)

</details>


## その他
