### PR TITLE
build(ci): DockerイメージビルドCIから `inputs.prerelease` を削除

### DIFF
--- a/.github/workflows/build-engine-container.yml
+++ b/.github/workflows/build-engine-container.yml
@@ -7,9 +7,6 @@ on:
       version:
         type: string
         required: true
-      prerelease:
-        type: boolean
-        default: true
       push_dockerhub:
         type: boolean
         default: false
@@ -21,10 +18,6 @@ on:
       version:
         description: "バージョン情報（A.BB.C / A.BB.C-preview.D）"
         required: true
-      prerelease:
-        description: "プレリリースかどうか"
-        type: boolean
-        default: true
       push_dockerhub:
         description: "Docker Hubにプッシュする"
         type: boolean
@@ -152,12 +145,6 @@ jobs:
       - name: <Build> Generate Docker image names
         id: generate-docker-image-names
         run: |
-          # NOTE: workflow_call・workflow_dispatch以外では、 `{{ inputs.prerelease }} == "null"` であるため、 `if [[ false ]]` となる
-          WITH_LATEST_ARG=""
-          if [[ "${{ inputs.prerelease }}" == "false" ]]; then
-            WITH_LATEST_ARG="--with_latest"
-          fi
-
           # Dockerイメージ名を outputs.tags に改行区切りで格納する
           {
             echo "tags<<EOF"
@@ -166,8 +153,7 @@ jobs:
             uv run tools/generate_docker_image_names.py \
               --repository "${{ needs.config.outputs.ghcr_repository }}" \
               --version "${{ needs.config.outputs.version }}" \
-              --prefix "${{ matrix.prefixes }}" \
-              ${WITH_LATEST_ARG}
+              --prefix "${{ matrix.prefixes }}"
 
             # Docker Hub
             # TODO: レジストリごとにプッシュするプレフィックスを変更したい（ https://github.com/VOICEVOX/voicevox_engine/issues/1663 ）
@@ -176,8 +162,7 @@ jobs:
               uv run tools/generate_docker_image_names.py \
                 --repository "${{ needs.config.outputs.dockerhub_repository }}" \
                 --version "${{ needs.config.outputs.version }}" \
-                --prefix "${{ matrix.prefixes }}" \
-                ${WITH_LATEST_ARG}
+                --prefix "${{ matrix.prefixes }}"
             fi
 
             echo "EOF"

--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -673,8 +673,6 @@ jobs:
     uses: ./.github/workflows/build-engine-container.yml
     with:
       version: ${{ needs.config.outputs.version }}
-      # NOTE: workflow_dispatch以外では、 `toJSON(inputs.prerelease) == 'null'` であるため `prerelease: true` となる
-      prerelease: ${{ toJSON(inputs.prerelease) != 'false' }}
       # NOTE: workflow_dispatch以外では、 `inputs.push_dockerhub == null` であるため `push_dockerhub: false` となる
       push_dockerhub: ${{ inputs.push_dockerhub == true }}
     secrets:

--- a/.github/workflows/build-latest-dev.yml
+++ b/.github/workflows/build-latest-dev.yml
@@ -34,7 +34,6 @@ jobs:
               ref: 'master',
               inputs: {
                 version: dev_version,
-                prerelease: true,
                 push_dockerhub: true,
               },
             });

--- a/.github/workflows/build-latest-dev.yml
+++ b/.github/workflows/build-latest-dev.yml
@@ -34,6 +34,7 @@ jobs:
               ref: 'master',
               inputs: {
                 version: dev_version,
+                prerelease: true,
                 push_dockerhub: true,
               },
             });

--- a/test/unit/tools/test_generate_docker_image_names.py
+++ b/test/unit/tools/test_generate_docker_image_names.py
@@ -5,13 +5,12 @@ from tools.generate_docker_image_names import (
 )
 
 
-def test_generate_docker_image_names_for_prerelease() -> None:
+def test_generate_docker_image_names() -> None:
     """プレリリース向けのDockerイメージ名を生成できる。"""
     # Inputs
     repository = "your-org/your-repo"
     version = "0.22.0-preview.1"
     comma_separated_prefix = ",cpu,cpu-ubuntu22.04"
-    with_latest = False
     # Expects
     expected_image_names = {
         "your-org/your-repo:0.22.0-preview.1",
@@ -23,35 +22,6 @@ def test_generate_docker_image_names_for_prerelease() -> None:
         repository=repository,
         version=version,
         comma_separated_prefix=comma_separated_prefix,
-        with_latest=with_latest,
-    )
-
-    # Test
-    assert image_names == expected_image_names
-
-
-def test_generate_docker_image_names_for_release() -> None:
-    """リリース向けのDockerイメージ名を生成できる。"""
-    # Inputs
-    repository = "your-org/your-repo"
-    version = "0.22.0"
-    comma_separated_prefix = ",cpu,cpu-ubuntu22.04"
-    with_latest = True
-    # Expects
-    expected_image_names = {
-        "your-org/your-repo:0.22.0",
-        "your-org/your-repo:latest",
-        "your-org/your-repo:cpu-0.22.0",
-        "your-org/your-repo:cpu-latest",
-        "your-org/your-repo:cpu-ubuntu22.04-0.22.0",
-        "your-org/your-repo:cpu-ubuntu22.04-latest",
-    }
-    # Outputs
-    image_names = _generate_docker_image_names(
-        repository=repository,
-        version=version,
-        comma_separated_prefix=comma_separated_prefix,
-        with_latest=with_latest,
     )
 
     # Test

--- a/test/unit/tools/test_generate_docker_image_names.py
+++ b/test/unit/tools/test_generate_docker_image_names.py
@@ -6,7 +6,7 @@ from tools.generate_docker_image_names import (
 
 
 def test_generate_docker_image_names() -> None:
-    """プレリリース向けのDockerイメージ名を生成できる。"""
+    """Dockerイメージ名を生成できる。"""
     # Inputs
     repository = "your-org/your-repo"
     version = "0.22.0-preview.1"

--- a/tools/generate_docker_image_names.py
+++ b/tools/generate_docker_image_names.py
@@ -17,26 +17,6 @@ $ uv run ./tools/generate_docker_image_names.py \
   --version "VER" \
   --prefix ""
 REPO:VER
-
-$ uv run ./tools/generate_docker_image_names.py \
-  --repository "REPO" \
-  --version "VER" \
-  --prefix ",A,B" \
-  --with_latest
-REPO:VER
-REPO:latest
-REPO:A-VER
-REPO:A-latest
-REPO:B-VER
-REPO:B-latest
-
-$ uv run ./tools/generate_docker_image_names.py \
-  --repository "REPO" \
-  --version "VER" \
-  --prefix "" \
-  --with_latest
-REPO:VER
-REPO:latest
 """
 
 from argparse import ArgumentParser
@@ -46,7 +26,6 @@ def _generate_docker_image_names(
     repository: str,
     version: str,
     comma_separated_prefix: str,
-    with_latest: bool,
 ) -> set[str]:
     """
     Dockerイメージ名を生成する。
@@ -69,8 +48,6 @@ def _generate_docker_image_names(
         バージョン
     comma_separated_prefix : str
         カンマ区切りのプレフィックス
-    with_latest : bool
-        バージョンをlatestに置き換えたタグを追加する
 
     Returns
     -------
@@ -83,23 +60,10 @@ def _generate_docker_image_names(
     ...     repository="voicevox/voicevox_engine",
     ...     version="0.22.0-preview.1",
     ...     comma_separated_prefix=",cpu,cpu-ubuntu22.04",
-    ...     with_latest=False,
     ... )
     {'voicevox/voicevox_engine:0.22.0-preview.1',
      'voicevox/voicevox_engine:cpu-0.22.0-preview.1',
      'voicevox/voicevox_engine:cpu-ubuntu22.04-0.22.0-preview.1'}
-    >>> _generate_docker_image_names(
-    ...     repository="voicevox/voicevox_engine",
-    ...     version="0.22.0",
-    ...     comma_separated_prefix=",cpu,cpu-ubuntu22.04",
-    ...     with_latest=True,
-    ... )
-    {'voicevox/voicevox_engine:0.22.0',
-     'voicevox/voicevox_engine:latest',
-     'voicevox/voicevox_engine:cpu-0.22.0',
-     'voicevox/voicevox_engine:cpu-latest',
-     'voicevox/voicevox_engine:cpu-ubuntu22.04-0.22.0',
-     'voicevox/voicevox_engine:cpu-ubuntu22.04-latest'}
     """
     # カンマ区切りのタグ名を配列に変換
     prefixes = comma_separated_prefix.split(",")
@@ -112,9 +76,6 @@ def _generate_docker_image_names(
         if prefix:
             prefix = f"{prefix}-"
         docker_image_names.add(f"{repository}:{prefix}{version}")
-
-        if with_latest:
-            docker_image_names.add(f"{repository}:{prefix}latest")
 
     return docker_image_names
 
@@ -140,25 +101,18 @@ def main() -> None:
         default="",
         help='カンマ区切りのプレフィックス（例: ",cpu,cpu-ubuntu22.04", "nvidia,nvidia-ubuntu22.04"）',
     )
-    parser.add_argument(
-        "--with_latest",
-        action="store_true",
-        help="バージョンをlatestに置き換えたタグを追加する",
-    )
 
     args = parser.parse_args()
 
     repository: str = args.repository
     version: str = args.version
     comma_separated_prefix: str = args.prefix
-    with_latest: bool = args.with_latest
 
     # Dockerイメージ名を生成
     docker_image_names = _generate_docker_image_names(
         repository=repository,
         version=version,
         comma_separated_prefix=comma_separated_prefix,
-        with_latest=with_latest,
     )
 
     # 標準出力に出力


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->

DockerイメージビルドCIの `inputs.prerelease` フラグは、安定最新版の`latest`タグをプッシュできるようにするため、

- #1708 

で実装されましたが、VOICEVOX orgでは実際には使われないということが

- #1726 

でわかりました。

#1726 を解決する、

- #1728 

を実装すると、DockerイメージビルドCIの `inputs.prerelease` フラグが`latest`タグのプッシュ方法の代替策（ #1726 の2番 ）としても使われることがなくなるので、削除します。

Dockerイメージ名生成スクリプト`tools/generate_docker_image_names.py`に #1708 で追加した`--with_latest`引数も、
使われることがなくなるので、削除します。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

- ref #1726

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
