### PR TITLE
docs(readme): 英単語の読み方を変更する機能の説明を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,7 +435,7 @@ curl -s \
     -X POST \
     -d @disabled_query.json \
     "127.0.0.1:50021/synthesis?speaker=1" \
-    > audio.wav
+    > disabled_audio.wav
 ```
 
 ### その他の引数


### PR DESCRIPTION
## 内容

カタカナ読みのドキュメントを追加してみました！　これでカタカナ英語機能は多分完成なはず！！

ドキュメントの書き方ちょっと迷いました。
デフォルトでオンになるのと、この機能って結構当たり前の機能なんですよね。
ユーザーはカタカナ読みすることに対して違和感覚えないはず。

ということで、READMEにはdisableのやり方だけ記載しました。

## 関連 Issue

- https://github.com/VOICEVOX/voicevox_engine/issues/1524

（↑のissueはツイートしたらクローズしようかなと思ってます）
