### PR TITLE
refactor: 過剰な関数のネストを削除

### DIFF
--- a/voicevox_engine/tts_pipeline/text_analyzer.py
+++ b/voicevox_engine/tts_pipeline/text_analyzer.py
@@ -367,8 +367,18 @@ def _mora_labels_to_moras(mora_labels: list[MoraLabel]) -> list[Mora]:
     ]
 
 
-def _utterance_to_accent_phrases(utterance: UtteranceLabel) -> list[AccentPhrase]:
-    """UtteranceLabelインスタンスをアクセント句系列へドメイン変換する"""
+def full_context_labels_to_accent_phrases(
+    full_context_labels: list[str],
+) -> list[AccentPhrase]:
+    """フルコンテキストラベルからアクセント句系列を生成する"""
+    if len(full_context_labels) == 0:
+        return []
+
+    utterance = UtteranceLabel.from_labels(
+        list(map(_Label.from_feature, full_context_labels))
+    )
+
+    # UtteranceLabelインスタンスからアクセント句系列を生成する。
     if len(utterance.breath_groups) == 0:
         return []
 
@@ -396,20 +406,3 @@ def _utterance_to_accent_phrases(utterance: UtteranceLabel) -> list[AccentPhrase
         for i_breath_group, breath_group in enumerate(utterance.breath_groups)
         for i_accent_phrase, accent_phrase in enumerate(breath_group.accent_phrases)
     ]
-
-
-def full_context_labels_to_accent_phrases(
-    full_context_labels: list[str],
-) -> list[AccentPhrase]:
-    """フルコンテキストラベルからアクセント句系列を生成する"""
-    if len(full_context_labels) == 0:
-        return []
-
-    utterance = UtteranceLabel.from_labels(
-        list(map(_Label.from_feature, full_context_labels))
-    )
-
-    # ドメインを変換する
-    accent_phrases = _utterance_to_accent_phrases(utterance)
-
-    return accent_phrases


### PR DESCRIPTION
## 内容
過剰な関数のネストを削除するリファクタリングを提案します。  

e2k 導入時に `text_analyzer.py` が整理され、DI などが不要になった。  
その結果、当時は必要だったが現在は不要になったネストが残っている。  
これは可読性を下げているため、削除が妥当である。  

このような背景から、過剰な関数のネストを削除するリファクタリングを提案します。  


## 関連 Issue
ref #1524