### PR TITLE
refactor: `_UtteranceLabel` を削除

### DIFF
--- a/voicevox_engine/tts_pipeline/text_analyzer.py
+++ b/voicevox_engine/tts_pipeline/text_analyzer.py
@@ -243,24 +243,6 @@ class _BreathGroupLabel:
         return cls(accent_phrases=accent_phrases)
 
 
-@dataclass
-class _UtteranceLabel:
-    """発声ラベル"""
-
-    breath_groups: list[_BreathGroupLabel]  # 発声の区切りのリスト
-
-    @classmethod
-    def from_labels(cls, labels: list[_Label]) -> Self:
-        """ラベル系列をポーズで区切りUtteranceLabelインスタンスを生成する"""
-        return cls(
-            breath_groups=[
-                _BreathGroupLabel.from_labels(list(labels))
-                for is_pau, labels in groupby(labels, lambda label: label.is_pause)
-                if not is_pau
-            ]
-        )
-
-
 def mora_to_text(mora_phonemes: str) -> str:
     """モーラ相当の音素文字系列を日本語カタカナ文へ変換する（例: 'hO' -> 'ホ')"""
     if mora_phonemes[-1:] in ["A", "I", "U", "E", "O"]:
@@ -298,12 +280,14 @@ def full_context_labels_to_accent_phrases(
     if len(full_context_labels) == 0:
         return []
 
-    utterance = _UtteranceLabel.from_labels(
-        list(map(_Label.from_feature, full_context_labels))
-    )
+    labels = map(_Label.from_feature, full_context_labels)
+    breath_groups = [
+        _BreathGroupLabel.from_labels(list(labels))
+        for is_pau, labels in groupby(labels, lambda label: label.is_pause)
+        if not is_pau
+    ]
 
-    # _UtteranceLabelインスタンスからアクセント句系列を生成する。
-    if len(utterance.breath_groups) == 0:
+    if len(breath_groups) == 0:
         return []
 
     return [
@@ -321,12 +305,12 @@ def full_context_labels_to_accent_phrases(
                 )
                 if (
                     i_accent_phrase == len(breath_group.accent_phrases) - 1
-                    and i_breath_group != len(utterance.breath_groups) - 1
+                    and i_breath_group != len(breath_groups) - 1
                 )
                 else None
             ),
             is_interrogative=accent_phrase.is_interrogative,
         )
-        for i_breath_group, breath_group in enumerate(utterance.breath_groups)
+        for i_breath_group, breath_group in enumerate(breath_groups)
         for i_accent_phrase, accent_phrase in enumerate(breath_group.accent_phrases)
     ]


### PR DESCRIPTION
## 内容
`_UtteranceLabel` を削除するリファクタリングを提案します。  

`_UtteranceLabel` を整理した結果、処理内容が数行に集約され、インスタンス属性の操作もなくなった。  
すなわちメソッド・関数・クラスとして切り出す必要がなくなった。  

このような背景から、`_UtteranceLabel` を削除するリファクタリングを提案します。  

## 関連 Issue
part of #1686