### PR TITLE
refactor: 空の `breath_groups` を特別扱いしない

### DIFF
--- a/test/unit/tts_pipeline/test_text_analyzer.py
+++ b/test/unit/tts_pipeline/test_text_analyzer.py
@@ -100,19 +100,15 @@ def test_case_hello_hiho() -> list[str]:
 
 
 @pytest.fixture
-def sil_pau_sil() -> list[str]:
+def sil_sil() -> list[str]:
     """無音のみで構成されたフルコンテキストラベル。"""
     return [
         # sil (無音)
-        "xx^xx-sil+pau=sil/A:xx+xx+xx/B:xx-xx_xx/C:xx_xx+xx/D:09+xx_xx/E:xx_xx!xx_xx-xx"
+        "xx^xx-sil+sil=xx/A:xx+xx+xx/B:xx-xx_xx/C:xx_xx+xx/D:09+xx_xx/E:xx_xx!xx_xx-xx"
         + "/F:xx_xx#xx_xx@xx_xx|xx_xx/G:5_5%0_xx_xx/H:xx_xx/I:xx-xx"
         + "@xx+xx&xx-xx|xx+xx/J:1_5/K:2+2-9",
-        # pau (読点)
-        "xx^sil-pau+sil=xx/A:xx+xx+xx/B:09-xx_xx/C:xx_xx+xx/D:09+xx_xx/E:5_5!0_xx-xx"
-        + "/F:xx_xx#xx_xx@xx_xx|xx_xx/G:4_1%0_xx_xx/H:1_5/I:xx-xx"
-        + "@xx+xx&xx-xx|xx+xx/J:1_4/K:2+2-9",
         # sil (無音)
-        "sil^pau-sil+xx=xx/A:xx+xx+xx/B:10-7_2/C:xx_xx+xx/D:xx+xx_xx/E:4_1!0_xx-xx"
+        "xx^sil-sil+xx=xx/A:xx+xx+xx/B:10-7_2/C:xx_xx+xx/D:xx+xx_xx/E:4_1!0_xx-xx"
         + "/F:xx_xx#xx_xx@xx_xx|xx_xx/G:xx_xx%xx_xx_xx/H:1_4/I:xx-xx"
         + "@xx+xx&xx-xx|xx+xx/J:xx_xx/K:2+2-9",
     ]
@@ -190,13 +186,13 @@ def test_full_context_labels_to_accent_phrases_normal(
 
 
 def test_full_context_labels_to_accent_phrases_normal_silence(
-    sil_pau_sil: list[str],
+    sil_sil: list[str],
 ) -> None:
     """`full_context_labels_to_accent_phrases()` は正常な無音のフルコンテキストラベルをパースする。"""
     # Expects
     true_accent_phrases: list[AccentPhrase] = []
     # Outputs
-    accent_phrases = full_context_labels_to_accent_phrases(sil_pau_sil)
+    accent_phrases = full_context_labels_to_accent_phrases(sil_sil)
     # Tests
     assert accent_phrases == true_accent_phrases
 

--- a/test/unit/tts_pipeline/test_text_analyzer.py
+++ b/test/unit/tts_pipeline/test_text_analyzer.py
@@ -101,7 +101,7 @@ def test_case_hello_hiho() -> list[str]:
 
 @pytest.fixture
 def sil_pau_sil() -> list[str]:
-    """無音のみで構成されたのフルコンテキストラベル。"""
+    """無音のみで構成されたフルコンテキストラベル。"""
     return [
         # sil (無音)
         "xx^xx-sil+pau=sil/A:xx+xx+xx/B:xx-xx_xx/C:xx_xx+xx/D:09+xx_xx/E:xx_xx!xx_xx-xx"

--- a/test/unit/tts_pipeline/test_text_analyzer.py
+++ b/test/unit/tts_pipeline/test_text_analyzer.py
@@ -99,6 +99,25 @@ def test_case_hello_hiho() -> list[str]:
     ]
 
 
+@pytest.fixture
+def sil_pau_sil() -> list[str]:
+    """無音のみで構成されたのフルコンテキストラベル。"""
+    return [
+        # sil (無音)
+        "xx^xx-sil+pau=sil/A:xx+xx+xx/B:xx-xx_xx/C:xx_xx+xx/D:09+xx_xx/E:xx_xx!xx_xx-xx"
+        + "/F:xx_xx#xx_xx@xx_xx|xx_xx/G:5_5%0_xx_xx/H:xx_xx/I:xx-xx"
+        + "@xx+xx&xx-xx|xx+xx/J:1_5/K:2+2-9",
+        # pau (読点)
+        "xx^sil-pau+sil=xx/A:xx+xx+xx/B:09-xx_xx/C:xx_xx+xx/D:09+xx_xx/E:5_5!0_xx-xx"
+        + "/F:xx_xx#xx_xx@xx_xx|xx_xx/G:4_1%0_xx_xx/H:1_5/I:xx-xx"
+        + "@xx+xx&xx-xx|xx+xx/J:1_4/K:2+2-9",
+        # sil (無音)
+        "sil^pau-sil+xx=xx/A:xx+xx+xx/B:10-7_2/C:xx_xx+xx/D:xx+xx_xx/E:4_1!0_xx-xx"
+        + "/F:xx_xx#xx_xx@xx_xx|xx_xx/G:xx_xx%xx_xx_xx/H:1_4/I:xx-xx"
+        + "@xx+xx&xx-xx|xx+xx/J:xx_xx/K:2+2-9",
+    ]
+
+
 def test_voice() -> None:
     assert mora_to_text("a") == "ア"
     assert mora_to_text("i") == "イ"
@@ -166,6 +185,18 @@ def test_full_context_labels_to_accent_phrases_normal(
     ]
     # Outputs
     accent_phrases = full_context_labels_to_accent_phrases(test_case_hello_hiho)
+    # Tests
+    assert accent_phrases == true_accent_phrases
+
+
+def test_full_context_labels_to_accent_phrases_normal_silence(
+    sil_pau_sil: list[str],
+) -> None:
+    """`full_context_labels_to_accent_phrases()` は正常な無音のフルコンテキストラベルをパースする。"""
+    # Expects
+    true_accent_phrases: list[AccentPhrase] = []
+    # Outputs
+    accent_phrases = full_context_labels_to_accent_phrases(sil_pau_sil)
     # Tests
     assert accent_phrases == true_accent_phrases
 

--- a/voicevox_engine/tts_pipeline/text_analyzer.py
+++ b/voicevox_engine/tts_pipeline/text_analyzer.py
@@ -303,9 +303,6 @@ def full_context_labels_to_accent_phrases(
     )
 
     # _UtteranceLabelインスタンスからアクセント句系列を生成する。
-    if len(utterance.breath_groups) == 0:
-        return []
-
     return [
         AccentPhrase(
             moras=_mora_labels_to_moras(accent_phrase.moras),


### PR DESCRIPTION
## 内容
空のブレスグループを特別扱いしなくするリファクタリングを提案します。  

現在の `text_analyzer.py` では空の `utterance.breath_groups` を特別扱いして空リストをリターンしている。  
しかし特別扱いのルートを削除しても、通常ルート経由で空リストが正常に処理されることが判明した。  
空リストの処理はバグ源になりやすいため、テストコードを追加したうえで、YAGNI になっている特別扱いのルートを削除するのが望ましい。  

このような背景から、空のブレスグループを特別扱いしなくするリファクタリングを提案します。  

## 関連 Issue
無し

## その他
#1743 と類似していますが、別の機能であるため個別の PR としています（片方だけ NoGo になるケースがありうる）。