### PR TITLE
refactor: 空のフルコンテキストラベル系列を特別扱いしない

### DIFF
--- a/test/unit/tts_pipeline/test_text_analyzer.py
+++ b/test/unit/tts_pipeline/test_text_analyzer.py
@@ -170,6 +170,16 @@ def test_full_context_labels_to_accent_phrases_normal(
     assert accent_phrases == true_accent_phrases
 
 
+def test_full_context_labels_to_accent_phrases_normal_no_label() -> None:
+    """`full_context_labels_to_accent_phrases()` は空のフルコンテキストラベル系列をパースする。"""
+    # Expects
+    true_accent_phrases: list[AccentPhrase] = []
+    # Outputs
+    accent_phrases = full_context_labels_to_accent_phrases([])
+    # Tests
+    assert accent_phrases == true_accent_phrases
+
+
 @pytest.fixture
 def test_case_kog() -> list[str]:
     """OpenJTalk で想定されない音素を含むフルコンテキストラベル。"""

--- a/voicevox_engine/tts_pipeline/text_analyzer.py
+++ b/voicevox_engine/tts_pipeline/text_analyzer.py
@@ -295,9 +295,6 @@ def full_context_labels_to_accent_phrases(
     full_context_labels: list[str],
 ) -> list[AccentPhrase]:
     """フルコンテキストラベルからアクセント句系列を生成する"""
-    if len(full_context_labels) == 0:
-        return []
-
     utterance = _UtteranceLabel.from_labels(
         list(map(_Label.from_feature, full_context_labels))
     )


### PR DESCRIPTION
## 内容
空のフルコンテキストラベル系列を特別扱いしなくするリファクタリングを提案します。  

現在の `text_analyzer.py` では空の `full_context_labels` を特別扱いして空リストをリターンしている。  
しかし特別扱いのルートを削除しても、通常ルート経由で空リストが正常に処理されることが判明した。  
空リストの処理はバグ源になりやすいため、テストコードを追加したうえで、YAGNI になっている特別扱いのルートを削除するのが望ましい。  

このような背景から、空のフルコンテキストラベル系列を特別扱いしなくするリファクタリングを提案します。  

## 関連 Issue
無し

## その他
#1742 と類似していますが、別の機能であるため個別の PR としています（片方だけ NoGo になるケースがありうる）。