### PR TITLE
refactor: `_MoraLabel` を削除

### DIFF
--- a/voicevox_engine/tts_pipeline/text_analyzer.py
+++ b/voicevox_engine/tts_pipeline/text_analyzer.py
@@ -194,8 +194,8 @@ class _AccentPhraseLabel:
     def from_labels(cls, labels: list[_Label]) -> Self:
         """ラベル系列を区切ってアクセント句ラベルを生成する。"""
         moras: list[Mora] = []
-        accent: int = 1
-        is_interrogative: bool = False
+        accent: int | None = None
+        is_interrogative: bool | None = False
 
         for mora_index, _mora_labels in groupby(labels, lambda label: label.mora_index):
             mora_labels = list(_mora_labels)
@@ -224,8 +224,15 @@ class _AccentPhraseLabel:
             # NOTE: 末尾モーラの疑問文フラグがアクセント句の疑問文フラグになる
             is_interrogative = vowel.is_interrogative
 
+        if accent is None:
+            msg = "アクセント位置が指定されていません。"
+            raise RuntimeError(msg)
         # アクセント位置の値がアクセント句内のモーラ数を超える場合はクリップ（ワークアラウンド、VOICEVOX/voicevox_engine#55 を参照）
         accent = accent if accent <= len(moras) else len(moras)
+
+        if is_interrogative is None:
+            msg = "疑問形フラグが指定されていません。"
+            raise RuntimeError(msg)
 
         # アクセント句ラベルを生成する
         accent_phrase = cls(

--- a/voicevox_engine/tts_pipeline/text_analyzer.py
+++ b/voicevox_engine/tts_pipeline/text_analyzer.py
@@ -194,9 +194,7 @@ class _AccentPhraseLabel:
     def from_labels(cls, labels: list[_Label]) -> Self:
         """ラベル系列を区切ってアクセント句ラベルを生成する。"""
         moras: list[Mora] = []
-        accent: int | None = None
-        is_interrogative: bool | None = None
-
+        vowel: _Label | None = None
         for mora_index, _mora_labels in groupby(labels, lambda label: label.mora_index):
             mora_labels = list(_mora_labels)
 
@@ -215,28 +213,19 @@ class _AccentPhraseLabel:
                     raise ValueError(mora_labels)
             moras.append(_generate_mora(consonant=consonant, vowel=vowel))
 
-            if len(moras) == 1:
-                if vowel.accent_position is None:
-                    msg = "アクセント位置が指定されていません。"
-                    raise RuntimeError(msg)
-                accent = vowel.accent_position
+        if vowel is None:
+            msg = "母音が取得できません。"
+            raise RuntimeError(msg)
 
-            # NOTE: 末尾モーラの疑問文フラグがアクセント句の疑問文フラグになる
-            is_interrogative = vowel.is_interrogative
-
-        if accent is None:
+        if vowel.accent_position is None:
             msg = "アクセント位置が指定されていません。"
             raise RuntimeError(msg)
+        accent = vowel.accent_position
         # アクセント位置の値がアクセント句内のモーラ数を超える場合はクリップ（ワークアラウンド、VOICEVOX/voicevox_engine#55 を参照）
         accent = accent if accent <= len(moras) else len(moras)
 
-        if is_interrogative is None:
-            msg = "疑問形フラグが指定されていません。"
-            raise RuntimeError(msg)
-
-        # アクセント句ラベルを生成する
         accent_phrase = cls(
-            moras=moras, accent=accent, is_interrogative=is_interrogative
+            moras=moras, accent=accent, is_interrogative=vowel.is_interrogative
         )
 
         return accent_phrase

--- a/voicevox_engine/tts_pipeline/text_analyzer.py
+++ b/voicevox_engine/tts_pipeline/text_analyzer.py
@@ -157,7 +157,7 @@ class _Label:
         )
 
 
-def _gen_mora(consonant: _Label | None, vowel: _Label) -> Mora:
+def _generate_mora(consonant: _Label | None, vowel: _Label) -> Mora:
     """音素長と音高を0で初期化したモーラを生成する。"""
     phonemes = vowel.phoneme if consonant is None else consonant.phoneme + vowel.phoneme
     return Mora(
@@ -170,7 +170,7 @@ def _gen_mora(consonant: _Label | None, vowel: _Label) -> Mora:
     )
 
 
-def _gen_pau_mora() -> Mora:
+def _generate_pau_mora() -> Mora:
     """音素長と音高を0で初期化したpauモーラを生成する。"""
     return Mora(
         text="、",
@@ -213,7 +213,7 @@ class _AccentPhraseLabel:
                     consonant, vowel = mora_labels[0], mora_labels[1]
                 case _:
                     raise ValueError(mora_labels)
-            moras.append(_gen_mora(consonant=consonant, vowel=vowel))
+            moras.append(_generate_mora(consonant=consonant, vowel=vowel))
 
             if len(moras) == 1:
                 if vowel.accent_position is None:
@@ -310,7 +310,7 @@ def full_context_labels_to_accent_phrases(
             moras=accent_phrase.moras,
             accent=accent_phrase.accent,
             pause_mora=(
-                _gen_pau_mora()
+                _generate_pau_mora()
                 if (
                     i_accent_phrase == len(breath_group.accent_phrases) - 1
                     and i_breath_group != len(utterance.breath_groups) - 1

--- a/voicevox_engine/tts_pipeline/text_analyzer.py
+++ b/voicevox_engine/tts_pipeline/text_analyzer.py
@@ -195,7 +195,7 @@ class _AccentPhraseLabel:
         """ラベル系列を区切ってアクセント句ラベルを生成する。"""
         moras: list[Mora] = []
         accent: int | None = None
-        is_interrogative: bool | None = False
+        is_interrogative: bool | None = None
 
         for mora_index, _mora_labels in groupby(labels, lambda label: label.mora_index):
             mora_labels = list(_mora_labels)

--- a/voicevox_engine/tts_pipeline/text_analyzer.py
+++ b/voicevox_engine/tts_pipeline/text_analyzer.py
@@ -215,7 +215,6 @@ class _AccentPhraseLabel:
                     raise ValueError(mora_labels)
             moras.append(_gen_mora(consonant=consonant, vowel=vowel))
 
-            # NOTE: アクセント位置の情報は先頭モーラに記録されている
             if len(moras) == 1:
                 if vowel.accent_position is None:
                     msg = "アクセント位置が指定されていません。"


### PR DESCRIPTION
## 内容
`_MoraLabel` を削除するリファクタリングを提案します。  

先行リファクタリングにより、`_MoraLabel` への詰替え無しに `Mora` を直接生成できるようになった。  
これにより全体の見通しが改善できる。  

このような背景から、`_MoraLabel` を削除するリファクタリングを提案します。  

変更点と根拠は以下になります：  

- `Mora` 生成は値0のプレイスホルダーなどを要するため、`_gen_mora()` 関数へ切り出す
  - pau モーラが類似したコードのため、同様に切り出す
- アクセントと疑問文フラグを `_Label` から取得する必要があるため、ループ中での取得へ変更する


## 関連 Issue
part of #1686