### PR TITLE
refactor: `_AccentPhraseLabel` を削除

### DIFF
--- a/voicevox_engine/tts_pipeline/text_analyzer.py
+++ b/voicevox_engine/tts_pipeline/text_analyzer.py
@@ -187,7 +187,7 @@ def _generate_accent_phrase(labels: Iterable[_Label]) -> AccentPhrase:
     """
     ラベル系列からアクセント句を生成する。
 
-    ポーズモーラは None で初期化される。
+    pauモーラは None で初期化される。
     """
     moras: list[Mora] = []
     vowel: _Label | None = None

--- a/voicevox_engine/tts_pipeline/text_analyzer.py
+++ b/voicevox_engine/tts_pipeline/text_analyzer.py
@@ -211,7 +211,7 @@ def _generate_accent_phrase(labels: Iterable[_Label]) -> AccentPhrase:
         moras.append(_generate_mora(consonant=consonant, vowel=vowel))
 
     if vowel is None:
-            raise UnreachableError()
+        raise UnreachableError()
 
     if vowel.accent_position is None:
         msg = "アクセント位置が指定されていません。"

--- a/voicevox_engine/tts_pipeline/text_analyzer.py
+++ b/voicevox_engine/tts_pipeline/text_analyzer.py
@@ -1,7 +1,6 @@
 """テキスト解析"""
 
 import re
-from collections.abc import Iterable
 from dataclasses import dataclass
 from itertools import groupby
 from typing import Any, Final, Literal, Self, TypeAlias, TypeGuard
@@ -183,7 +182,7 @@ def _generate_pau_mora() -> Mora:
     )
 
 
-def _generate_accent_phrase(labels: Iterable[_Label]) -> AccentPhrase:
+def _generate_accent_phrase(labels: list[_Label]) -> AccentPhrase:
     """
     ラベル系列からアクセント句を生成する。
 
@@ -256,7 +255,9 @@ def full_context_labels_to_accent_phrases(
             pause_group_labels,
             lambda label: (label.breath_group_index, label.accent_phrase_index),
         )
-        pause_groups.append([_generate_accent_phrase(labels) for _, labels in groups])
+        pause_groups.append(
+            [_generate_accent_phrase(list(labels)) for _, labels in groups]
+        )
 
     accent_phrases: list[AccentPhrase] = []
     for i_pause_group, pause_group in enumerate(pause_groups):

--- a/voicevox_engine/tts_pipeline/text_analyzer.py
+++ b/voicevox_engine/tts_pipeline/text_analyzer.py
@@ -265,20 +265,21 @@ def full_context_labels_to_accent_phrases(
             [_AccentPhraseLabel.from_labels(list(labels)) for _, labels in groups]
         )
 
-    return [
-        AccentPhrase(
-            moras=accent_phrase.moras,
-            accent=accent_phrase.accent,
-            pause_mora=(
-                _generate_pau_mora()
-                if (
-                    i_accent_phrase == len(pause_group) - 1
-                    and i_pause_group != len(pause_groups) - 1
-                )
-                else None
-            ),
-            is_interrogative=accent_phrase.is_interrogative,
-        )
-        for i_pause_group, pause_group in enumerate(pause_groups)
-        for i_accent_phrase, accent_phrase in enumerate(pause_group)
-    ]
+    accent_phrases: list[AccentPhrase] = []
+    for i_pause_group, pause_group in enumerate(pause_groups):
+        is_last_group = i_pause_group == len(pause_groups) - 1
+        for i_accent_phrase, accent_phrase in enumerate(pause_group):
+            is_last_phrase = i_accent_phrase == len(pause_group) - 1
+            _accent_phrase = AccentPhrase(
+                moras=accent_phrase.moras,
+                accent=accent_phrase.accent,
+                pause_mora=(
+                    _generate_pau_mora()
+                    if is_last_phrase and not is_last_group
+                    else None
+                ),
+                is_interrogative=accent_phrase.is_interrogative,
+            )
+            accent_phrases.append(_accent_phrase)
+
+    return accent_phrases

--- a/voicevox_engine/tts_pipeline/text_analyzer.py
+++ b/voicevox_engine/tts_pipeline/text_analyzer.py
@@ -217,6 +217,7 @@ def _generate_accent_phrase(labels: list[_Label]) -> AccentPhrase:
     # アクセント位置の値がアクセント句内のモーラ数を超える場合はクリップ（ワークアラウンド、VOICEVOX/voicevox_engine#55 を参照）
     accent = accent if accent <= len(moras) else len(moras)
 
+    # FIXME: pauモーラは None で初期化されている。必要な更新を忘れる可能性がある。
     return AccentPhrase(
         moras=moras,
         accent=accent,

--- a/voicevox_engine/tts_pipeline/text_analyzer.py
+++ b/voicevox_engine/tts_pipeline/text_analyzer.py
@@ -1,6 +1,7 @@
 """テキスト解析"""
 
 import re
+from collections.abc import Iterable
 from dataclasses import dataclass
 from itertools import groupby
 from typing import Any, Final, Literal, Self, TypeAlias, TypeGuard
@@ -182,53 +183,49 @@ def _generate_pau_mora() -> Mora:
     )
 
 
-@dataclass
-class _AccentPhraseLabel:
-    """アクセント句ラベル"""
+def _generate_accent_phrase(labels: Iterable[_Label]) -> AccentPhrase:
+    """
+    ラベル系列からアクセント句を生成する。
 
-    moras: list[Mora]  # モーラ系列
-    accent: int  # アクセント位置
-    is_interrogative: bool  # 疑問文か否か
+    ポーズモーラは None で初期化される。
+    """
+    moras: list[Mora] = []
+    vowel: _Label | None = None
+    for mora_index, _mora_labels in groupby(labels, lambda label: label.mora_index):
+        mora_labels = list(_mora_labels)
 
-    @classmethod
-    def from_labels(cls, labels: list[_Label]) -> Self:
-        """ラベル系列を区切ってアクセント句ラベルを生成する。"""
-        moras: list[Mora] = []
-        vowel: _Label | None = None
-        for mora_index, _mora_labels in groupby(labels, lambda label: label.mora_index):
-            mora_labels = list(_mora_labels)
+        # モーラ抽出を打ち切る（ワークアラウンド、VOICEVOX/voicevox_engine#57）
+        # mora_index の最大値が 49 であるため、49番目以降のモーラではラベルのモーラ番号を区切りに使えない
+        if mora_index is not None and mora_index >= 49:
+            break
 
-            # モーラ抽出を打ち切る（ワークアラウンド、VOICEVOX/voicevox_engine#57）
-            # mora_index の最大値が 49 であるため、49番目以降のモーラではラベルのモーラ番号を区切りに使えない
-            if mora_index is not None and mora_index >= 49:
-                break
+        # ラベルの数に基づいて子音と母音を分け、モーラを生成する
+        match len(mora_labels):
+            case 1:
+                consonant, vowel = None, mora_labels[0]
+            case 2:
+                consonant, vowel = mora_labels[0], mora_labels[1]
+            case _:
+                raise ValueError(mora_labels)
+        moras.append(_generate_mora(consonant=consonant, vowel=vowel))
 
-            # ラベルの数に基づいて子音と母音を分け、モーラを生成する
-            match len(mora_labels):
-                case 1:
-                    consonant, vowel = None, mora_labels[0]
-                case 2:
-                    consonant, vowel = mora_labels[0], mora_labels[1]
-                case _:
-                    raise ValueError(mora_labels)
-            moras.append(_generate_mora(consonant=consonant, vowel=vowel))
+    if vowel is None:
+        msg = "母音が取得できません。"
+        raise RuntimeError(msg)
 
-        if vowel is None:
-            msg = "母音が取得できません。"
-            raise RuntimeError(msg)
+    if vowel.accent_position is None:
+        msg = "アクセント位置が指定されていません。"
+        raise RuntimeError(msg)
+    accent = vowel.accent_position
+    # アクセント位置の値がアクセント句内のモーラ数を超える場合はクリップ（ワークアラウンド、VOICEVOX/voicevox_engine#55 を参照）
+    accent = accent if accent <= len(moras) else len(moras)
 
-        if vowel.accent_position is None:
-            msg = "アクセント位置が指定されていません。"
-            raise RuntimeError(msg)
-        accent = vowel.accent_position
-        # アクセント位置の値がアクセント句内のモーラ数を超える場合はクリップ（ワークアラウンド、VOICEVOX/voicevox_engine#55 を参照）
-        accent = accent if accent <= len(moras) else len(moras)
-
-        accent_phrase = cls(
-            moras=moras, accent=accent, is_interrogative=vowel.is_interrogative
-        )
-
-        return accent_phrase
+    return AccentPhrase(
+        moras=moras,
+        accent=accent,
+        pause_mora=None,
+        is_interrogative=vowel.is_interrogative,
+    )
 
 
 def mora_to_text(mora_phonemes: str) -> str:
@@ -254,32 +251,22 @@ def full_context_labels_to_accent_phrases(
         if not is_pau
     ]
 
-    PauseGroup: TypeAlias = list[_AccentPhraseLabel]
+    PauseGroup: TypeAlias = list[AccentPhrase]
     pause_groups: list[PauseGroup] = []
     for pause_group_labels in pause_group_labels_list:
         groups = groupby(
             pause_group_labels,
             lambda label: (label.breath_group_index, label.accent_phrase_index),
         )
-        pause_groups.append(
-            [_AccentPhraseLabel.from_labels(list(labels)) for _, labels in groups]
-        )
+        pause_groups.append([_generate_accent_phrase(labels) for _, labels in groups])
 
     accent_phrases: list[AccentPhrase] = []
     for i_pause_group, pause_group in enumerate(pause_groups):
         is_last_group = i_pause_group == len(pause_groups) - 1
         for i_accent_phrase, accent_phrase in enumerate(pause_group):
             is_last_phrase = i_accent_phrase == len(pause_group) - 1
-            _accent_phrase = AccentPhrase(
-                moras=accent_phrase.moras,
-                accent=accent_phrase.accent,
-                pause_mora=(
-                    _generate_pau_mora()
-                    if is_last_phrase and not is_last_group
-                    else None
-                ),
-                is_interrogative=accent_phrase.is_interrogative,
-            )
-            accent_phrases.append(_accent_phrase)
+            if is_last_phrase and not is_last_group:
+                accent_phrase.pause_mora = _generate_pau_mora()
+            accent_phrases.append(accent_phrase)
 
     return accent_phrases


### PR DESCRIPTION
## 内容
`_AccentPhraseLabel` を削除するリファクタリングを提案します。  

`_AccentPhraseLabel` はインスタンス属性を操作しない。  
であれば `_AccentPhraseLabel` でなく `AccentPhrase` を直接生成し、かつ、stateless な関数として実装するのが望ましい。  

このような背景から、`_AccentPhraseLabel` を削除するリファクタリングを提案します。  

## 関連 Issue
close #1686 (final step🎉)