### PR TITLE
refactor: if-elif 構文を match-case 構文で置き換え

### DIFF
--- a/run.py
+++ b/run.py
@@ -40,16 +40,15 @@ def decide_boolean_from_env(env_name: str) -> bool:
     * それ以外はwarningを出してFalseを返す
     """
     env = os.getenv(env_name, default="")
-    if env == "1":
-        return True
-    elif env == "" or env == "0":
-        return False
-    else:
-        warnings.warn(
-            f"Invalid environment variable value: {env_name}={env}",
-            stacklevel=1,
-        )
-        return False
+    match env:
+        case "1":
+            return True
+        case "" | "0":
+            return False
+        case _:
+            msg = f"Invalid environment variable value: {env_name}={env}"
+            warnings.warn(msg, stacklevel=1)
+            return False
 
 
 @dataclass(frozen=True)

--- a/test/e2e/test_disable_api.py
+++ b/test/e2e/test_disable_api.py
@@ -13,16 +13,17 @@ def _assert_request_and_response_403(
     method: Literal["post", "get", "put", "delete"],
     path: str,
 ) -> None:
-    if method == "post":
-        response = client.post(path)
-    elif method == "get":
-        response = client.get(path)
-    elif method == "put":
-        response = client.put(path)
-    elif method == "delete":
-        response = client.delete(path)
-    else:
-        raise ValueError("methodはpost, get, put, deleteのいずれかである必要があります")
+    match method:
+        case "post":
+            response = client.post(path)
+        case "get":
+            response = client.get(path)
+        case "put":
+            response = client.put(path)
+        case "delete":
+            response = client.delete(path)
+        case _:
+            raise ValueError("Never")
 
     assert response.status_code == 403, f"{method} {path} が403を返しませんでした"
 

--- a/test/utility.py
+++ b/test/utility.py
@@ -7,21 +7,21 @@ from typing import Any
 import numpy as np
 import soundfile as sf
 from fastapi.encoders import jsonable_encoder
-from numpy.typing import NDArray
 
 
 def round_floats(value: Any, round_value: int) -> Any:
-    """floatの小数点以下を再帰的に丸める"""
-    if isinstance(value, float):
-        return round(value, round_value)
-    elif isinstance(value, np.ndarray) and np.issubdtype(value.dtype, np.floating):
-        return np.round(value, round_value)
-    elif isinstance(value, list):
-        return [round_floats(v, round_value) for v in value]
-    elif isinstance(value, dict):
-        return {k: round_floats(v, round_value) for k, v in value.items()}
-    else:
-        return value
+    """floatの小数点以下を再帰的に丸める。"""
+    match value:
+        case float():
+            return round(value, round_value)
+        case np.ndarray() if np.issubdtype(value.dtype, np.floating):
+            return np.round(value, round_value)
+        case list():
+            return [round_floats(v, round_value) for v in value]
+        case dict():
+            return {k: round_floats(v, round_value) for k, v in value.items()}
+        case _:
+            return value
 
 
 def pydantic_to_native_type(value: Any) -> Any:
@@ -30,38 +30,36 @@ def pydantic_to_native_type(value: Any) -> Any:
 
 
 def hash_long_string(value: Any) -> Any:
-    """文字数が1000文字を超えるものはハッシュ化する"""
-
-    def to_hash(value: str) -> str:
-        return "MD5:" + hashlib.md5(value.encode()).hexdigest()
-
-    if isinstance(value, str):
-        return value if len(value) <= 1000 else to_hash(value)
-    elif isinstance(value, list):
-        return [hash_long_string(v) for v in value]
-    elif isinstance(value, dict):
-        return {k: hash_long_string(v) for k, v in value.items()}
-    else:
-        return value
+    """文字数が1000文字を超えるものはハッシュ化する。"""
+    match value:
+        case str() if len(value) <= 1000:
+            return value
+        case str():
+            return "MD5:" + hashlib.md5(value.encode()).hexdigest()
+        case list():
+            return [hash_long_string(v) for v in value]
+        case dict():
+            return {k: hash_long_string(v) for k, v in value.items()}
+        case _:
+            return value
 
 
 def summarize_big_ndarray(value: Any) -> Any:
-    """要素数が100を超える NDArray を、ハッシュ値と shape からなる文字列へ要約する"""
-
-    def to_hash(value: NDArray[Any]) -> str:
-        return "MD5:" + hashlib.md5(value.tobytes()).hexdigest()
-
-    if isinstance(value, np.ndarray):
-        if value.size <= 100:
+    """要素数が100を超える NDArray を、ハッシュ値と shape からなる文字列へ要約する。"""
+    match value:
+        case np.ndarray() if value.size <= 100:
             return value
-        else:
-            return {"hash": to_hash(value), "shape": value.shape}
-    elif isinstance(value, list):
-        return [summarize_big_ndarray(v) for v in value]
-    elif isinstance(value, dict):
-        return {k: summarize_big_ndarray(v) for k, v in value.items()}
-    else:
-        return value
+        case np.ndarray():
+            return {
+                "hash": "MD5:" + hashlib.md5(value.tobytes()).hexdigest(),
+                "shape": value.shape,
+            }
+        case list():
+            return [summarize_big_ndarray(v) for v in value]
+        case dict():
+            return {k: summarize_big_ndarray(v) for k, v in value.items()}
+        case _:
+            return value
 
 
 def hash_wave_floats_from_wav_bytes(wav_bytes: bytes) -> str:

--- a/voicevox_engine/core/core_wrapper.py
+++ b/voicevox_engine/core/core_wrapper.py
@@ -39,30 +39,36 @@ def load_runtime_lib(runtime_dirs: list[Path]) -> None:
     """
     # `lib_file_names`は「ENGINE が利用可能な DLL のファイル名一覧」である
     # `lib_names` は「ENGINE が利用可能な DLL のライブラリ名一覧」である（ライブラリ名は `libtorch.so.1.0` の `torch` 部分）
-    if platform.system() == "Windows":
-        # DirectML.dllはonnxruntimeと互換性のないWindows標準搭載のものを優先して読み込むことがあるため、明示的に読み込む
-        # 参考 1. https://github.com/microsoft/onnxruntime/issues/3360
-        # 参考 2. https://tadaoyamaoka.hatenablog.com/entry/2020/06/07/113616
-        lib_file_names = [
-            "torch_cpu.dll",
-            "torch_cuda.dll",
-            "DirectML.dll",
-            "onnxruntime.dll",
-            "voicevox_onnxruntime.dll",
-        ]
-        lib_names = ["torch_cpu", "torch_cuda", "onnxruntime", "voicevox_onnxruntime"]
-    elif platform.system() == "Linux":
-        lib_file_names = [
-            "libtorch.so",
-            "libonnxruntime.so",
-            "libvoicevox_onnxruntime.so",
-        ]
-        lib_names = ["torch", "onnxruntime", "voicevox_onnxruntime"]
-    elif platform.system() == "Darwin":
-        lib_file_names = ["libonnxruntime.dylib", "libvoicevox_onnxruntime.dylib"]
-        lib_names = ["onnxruntime", "voicevox_onnxruntime"]
-    else:
-        raise RuntimeError("不明なOSです")
+    match platform.system():
+        case "Windows":
+            # DirectML.dllはonnxruntimeと互換性のないWindows標準搭載のものを優先して読み込むことがあるため、明示的に読み込む
+            # 参考 1. https://github.com/microsoft/onnxruntime/issues/3360
+            # 参考 2. https://tadaoyamaoka.hatenablog.com/entry/2020/06/07/113616
+            lib_file_names = [
+                "torch_cpu.dll",
+                "torch_cuda.dll",
+                "DirectML.dll",
+                "onnxruntime.dll",
+                "voicevox_onnxruntime.dll",
+            ]
+            lib_names = [
+                "torch_cpu",
+                "torch_cuda",
+                "onnxruntime",
+                "voicevox_onnxruntime",
+            ]
+        case "Linux":
+            lib_file_names = [
+                "libtorch.so",
+                "libonnxruntime.so",
+                "libvoicevox_onnxruntime.so",
+            ]
+            lib_names = ["torch", "onnxruntime", "voicevox_onnxruntime"]
+        case "Darwin":
+            lib_file_names = ["libonnxruntime.dylib", "libvoicevox_onnxruntime.dylib"]
+            lib_names = ["onnxruntime", "voicevox_onnxruntime"]
+        case _:
+            raise RuntimeError("不明なOSです")
 
     # 引数指定ディレクトリ直下の DLL を読み込む
     for runtime_dir in runtime_dirs:
@@ -266,18 +272,18 @@ def _find_version_0_12_core_or_later(core_dir: Path) -> str | None:
 
 def _get_arch_name() -> Literal["x64", "x86", "aarch64", "armv7l"] | None:
     """実行中マシンのアーキテクチャ（None: サポート外アーキテクチャ）。"""
-    machine = platform.machine()
-    # 特定のアーキテクチャ上で複数パターンの文字列を返し得るので一意に変換
-    if machine in ["x86_64", "x64", "AMD64"]:
-        return "x64"
-    elif machine in ["i386", "x86"]:
-        return "x86"
-    elif machine in ["arm64", "aarch64"]:
-        return "aarch64"
-    elif machine == "armv7l":
-        return "armv7l"
-    else:
-        return None
+    # NOTE: 特定のアーキテクチャ上で複数パターンの文字列を返し得るので一意に変換する。
+    match platform.machine():
+        case "x86_64" | "x64" | "AMD64":
+            return "x64"
+        case "i386" | "x86":
+            return "x86"
+        case "arm64" | "aarch64":
+            return "aarch64"
+        case "armv7l":
+            return "armv7l"
+        case _:
+            return None
 
 
 def _get_core_name(


### PR DESCRIPTION
## 内容
if-elif 構文を match-case 構文で置き換えるリファクタリングを提案します。  

変数 `x` が満たす条件によって動作を変える制御には、従来 if-elif 構文が用いられていた。  
この構文には以下の問題点がある：  

- バグ源: `elif` を `if` にタイポするとエラーではなく全く別の動作になる
- 可読性
  - 意図的な `if-elif-if` がありうる状況だと誤読のリスクが上がり、可読性が著しく下がる
  - `if x ..` と `if y ...` が並びうる状況だと誤読のリスクが上がり、可読性が著しく下がる
  - 型チェックのコード量が多い
    - 例: `if isinstance(value, float):`
- 計算量: `x` が関数の場合、チェックの回数分呼び出しがあって無駄
  - 例: `if platform.system() == "Windows":`

これらの問題を解決するために、Python 3.10 にて match-case 構文が導入された。  
稀なケースを除けば match-case の方が優れている（例外: 定数変数（例: `LATEST_VERSION`）との一致チェック）。  

このような背景から、if-elif 構文を match-case 構文で置き換えるリファクタリングを提案します。  

## 関連 Issue
無し