### PR TITLE
refactor: 型レベルで到達不可能なコードを `assert_never()` で表現

### DIFF
--- a/test/benchmark/engine_preparation.py
+++ b/test/benchmark/engine_preparation.py
@@ -2,7 +2,7 @@
 
 import warnings
 from pathlib import Path
-from typing import Literal
+from typing import Literal, assert_never
 
 import httpx
 from fastapi.testclient import TestClient
@@ -71,4 +71,4 @@ def generate_client(
     elif server == "localhost":
         return httpx.Client(base_url="http://localhost:50021")
     else:
-        raise Exception(f"{server} はサポートされていないサーバータイプです")
+        assert_never(server)

--- a/test/e2e/test_disable_api.py
+++ b/test/e2e/test_disable_api.py
@@ -1,6 +1,6 @@
 """APIを無効化するテスト。"""
 
-from typing import Any, Literal
+from typing import Any, Literal, assert_never
 
 from fastapi.testclient import TestClient
 
@@ -22,8 +22,8 @@ def _assert_request_and_response_403(
             response = client.put(path)
         case "delete":
             response = client.delete(path)
-        case _:
-            raise ValueError("Never")
+        case _ as unreachable:
+            assert_never(unreachable)
 
     assert response.status_code == 403, f"{method} {path} が403を返しませんでした"
 

--- a/voicevox_engine/metas/MetasStore.py
+++ b/voicevox_engine/metas/MetasStore.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Final, Literal, TypeAlias
+from typing import Final, Literal, TypeAlias, assert_never
 
 from pydantic import BaseModel, Field
 
@@ -270,4 +270,4 @@ def filter_characters_and_styles(
             sing_character.talk_styles = []
         return sing_characters
     else:
-        raise Exception(f"'{talk_or_sing}' は不正な style_type です")
+        assert_never(talk_or_sing)


### PR DESCRIPTION
## 内容
型レベルで到達不可能なコードを `assert_never()` で表現するリファクタリングを提案します。  

if-elif や match-case では型レベルで到達/実行不可能なコードが出現する。  
これを `typing.assert_never()` で表現すると型チェッカーで不到達の保証ができ、安全性が高まる。  
またコントリビューターがひと目見て到達不可能なコードだと理解でき、可読性が高まる。  

このような背景から、型レベルで到達不可能なコードを `assert_never()` で表現するリファクタリングを提案します。  

## 関連 Issue
https://github.com/VOICEVOX/voicevox_engine/pull/1748#discussion_r2161161262