### PR TITLE
build: [release-0.24] to 0.24.0

### DIFF
--- a/.github/workflows/build-engine-container.yml
+++ b/.github/workflows/build-engine-container.yml
@@ -24,7 +24,7 @@ on:
         default: false
 
 env:
-  VOICEVOX_RESOURCE_VERSION: "0.23.1"
+  VOICEVOX_RESOURCE_VERSION: "0.24.0"
 
 defaults:
   run:

--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -29,7 +29,7 @@ on:
         default: false
 
 env:
-  VOICEVOX_RESOURCE_VERSION: "0.23.1"
+  VOICEVOX_RESOURCE_VERSION: "0.24.0"
   VOICEVOX_CORE_VERSION: "0.15.8"
 
 defaults:

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,7 +78,7 @@ EOF
 COPY --from=download-engine-env /opt/voicevox_engine /opt/voicevox_engine
 
 # Download Resource
-ARG VOICEVOX_RESOURCE_VERSION=0.23.1
+ARG VOICEVOX_RESOURCE_VERSION=0.24.0
 RUN <<EOF
     set -eux
 

--- a/resources/engine_manifest_assets/update_infos.json
+++ b/resources/engine_manifest_assets/update_infos.json
@@ -1,5 +1,15 @@
 [
   {
+    "version": "0.24.0",
+    "descriptions": [
+      "OpenAPIの関数名をわかりやすく変更",
+      "DockerfileでPython実行環境を作成しない形に変更",
+      "Docker Hub上のlatestタグを安定最新版に変更",
+      "辞書に登録されていない英単語の自然なカタカナ読みを可能に"
+    ],
+    "contributors": []
+  },
+  {
     "version": "0.23.1",
     "descriptions": ["キャラクター「離途」「黒沢冴白」を追加"],
     "contributors": []

--- a/test/e2e/single_api/engine_info/__snapshots__/test_engine_manifest/test_get_engine_manifest_200.json
+++ b/test/e2e/single_api/engine_info/__snapshots__/test_engine_manifest/test_get_engine_manifest_200.json
@@ -34,6 +34,16 @@
     {
       "contributors": [],
       "descriptions": [
+        "OpenAPIの関数名をわかりやすく変更",
+        "DockerfileでPython実行環境を作成しない形に変更",
+        "Docker Hub上のlatestタグを安定最新版に変更",
+        "辞書に登録されていない英単語の自然なカタカナ読みを可能に"
+      ],
+      "version": "0.24.0"
+    },
+    {
+      "contributors": [],
+      "descriptions": [
         "キャラクター「離途」「黒沢冴白」を追加"
       ],
       "version": "0.23.1"


### PR DESCRIPTION
## 内容

0.24バージョンへ機能追加アップデートをします。

* OpenAPIの関数名をわかりやすく変更
* DockerfileでPython実行環境を作成しない形に変更
* Docker Hub上のlatestタグを安定最新版に変更
* 辞書に登録されていない英単語の自然なカタカナ読みを可能に

## 関連 Issue

- https://github.com/VOICEVOX/voicevox_project/discussions/64

## その他
