### PR TITLE
speakers/singersとspeaker/singer_infoの型の不一致を修正

### DIFF
--- a/voicevox_engine/metas/Metas.py
+++ b/voicevox_engine/metas/Metas.py
@@ -56,6 +56,7 @@ class StyleInfo(BaseModel):
     """スタイルの追加情報"""
 
     id: StyleId = Field(description="スタイルID")
+    name: str = Field(description="スタイル名")
     icon: str = Field(
         description="このスタイルのアイコンをbase64エンコードしたもの、あるいはURL"
     )
@@ -70,7 +71,8 @@ class StyleInfo(BaseModel):
 
 class SpeakerInfo(BaseModel):
     """キャラクターの追加情報"""
-
+    id: str = Field(description="キャラクターのUUID")
+    name: str = Field(description="キャラクターの名前")
     policy: str = Field(description="policy.md")
     portrait: str = Field(
         description="立ち絵画像をbase64エンコードしたもの、あるいはURL"

--- a/voicevox_engine/metas/Metas.py
+++ b/voicevox_engine/metas/Metas.py
@@ -56,7 +56,7 @@ class StyleInfo(BaseModel):
     """スタイルの追加情報"""
 
     id: StyleId = Field(description="スタイルID")
-    name: str = Field(description="スタイル名")
+    name: str | SkipJsonSchema[None] = Field(description="スタイル名")
     icon: str = Field(
         description="このスタイルのアイコンをbase64エンコードしたもの、あるいはURL"
     )
@@ -72,8 +72,8 @@ class StyleInfo(BaseModel):
 class SpeakerInfo(BaseModel):
     """キャラクターの追加情報"""
 
-    id: str = Field(description="キャラクターのUUID")
-    name: str = Field(description="キャラクターの名前")
+    id: str | SkipJsonSchema[None] = Field(description="キャラクターのUUID")
+    name: str | SkipJsonSchema[None] = Field(description="キャラクターの名前")
     policy: str = Field(description="policy.md")
     portrait: str = Field(
         description="立ち絵画像をbase64エンコードしたもの、あるいはURL"

--- a/voicevox_engine/metas/Metas.py
+++ b/voicevox_engine/metas/Metas.py
@@ -71,6 +71,7 @@ class StyleInfo(BaseModel):
 
 class SpeakerInfo(BaseModel):
     """キャラクターの追加情報"""
+
     id: str = Field(description="キャラクターのUUID")
     name: str = Field(description="キャラクターの名前")
     policy: str = Field(description="policy.md")

--- a/voicevox_engine/metas/MetasStore.py
+++ b/voicevox_engine/metas/MetasStore.py
@@ -174,8 +174,7 @@ class MetasStore:
         characters = self.characters(core_version)
         characters = filter_characters_and_styles(characters, talk_or_sing)
         character = next(
-            filter(lambda character: character.uuid ==
-                   character_uuid, characters), None
+            filter(lambda character: character.uuid == character_uuid, characters), None
         )
         if character is None:
             raise CharacterNotFoundError("該当するキャラクターが見つかりません")
@@ -214,8 +213,7 @@ class MetasStore:
                 icon = _resource_str(style_icon_path)
 
                 # style portrait
-                style_portrait_path = character_path / \
-                    "portraits" / f"{style_id}.png"
+                style_portrait_path = character_path / "portraits" / f"{style_id}.png"
                 style_portrait = None
                 if style_portrait_path.exists():
                     style_portrait = _resource_str(style_portrait_path)
@@ -224,8 +222,9 @@ class MetasStore:
                 voice_samples: list[str] = []
                 for j in range(3):
                     num = str(j + 1).zfill(3)
-                    voice_path = character_path / \
-                        "voice_samples" / f"{style_id}_{num}.wav"
+                    voice_path = (
+                        character_path / "voice_samples" / f"{style_id}_{num}.wav"
+                    )
                     voice_samples.append(_resource_str(voice_path))
 
                 style_infos.append(
@@ -241,7 +240,11 @@ class MetasStore:
             raise CharacterInfoNotFoundError("キャラクター情報が見つかりません") from e
 
         character_info = SpeakerInfo(
-            id=character_id, policy=policy, portrait=portrait, style_infos=style_infos, name=character_name
+            id=character_id,
+            policy=policy,
+            portrait=portrait,
+            style_infos=style_infos,
+            name=character_name,
         )
         return character_info
 

--- a/voicevox_engine/metas/MetasStore.py
+++ b/voicevox_engine/metas/MetasStore.py
@@ -174,7 +174,8 @@ class MetasStore:
         characters = self.characters(core_version)
         characters = filter_characters_and_styles(characters, talk_or_sing)
         character = next(
-            filter(lambda character: character.uuid == character_uuid, characters), None
+            filter(lambda character: character.uuid ==
+                   character_uuid, characters), None
         )
         if character is None:
             raise CharacterNotFoundError("該当するキャラクターが見つかりません")
@@ -182,6 +183,9 @@ class MetasStore:
         # キャラクター情報を取得する
         try:
             character_path = self._characters_path / character_uuid
+
+            character_id = character.uuid
+            character_name = character.name
 
             # character policy
             policy_path = character_path / "policy.md"
@@ -202,14 +206,16 @@ class MetasStore:
             # スタイル情報を取得する
             style_infos = []
             for style in character.talk_styles + character.sing_styles:
-                id = style.id
+                style_id = style.id
+                style_name = style.name
 
                 # style icon
-                style_icon_path = character_path / "icons" / f"{id}.png"
+                style_icon_path = character_path / "icons" / f"{style_id}.png"
                 icon = _resource_str(style_icon_path)
 
                 # style portrait
-                style_portrait_path = character_path / "portraits" / f"{id}.png"
+                style_portrait_path = character_path / \
+                    "portraits" / f"{style_id}.png"
                 style_portrait = None
                 if style_portrait_path.exists():
                     style_portrait = _resource_str(style_portrait_path)
@@ -218,12 +224,14 @@ class MetasStore:
                 voice_samples: list[str] = []
                 for j in range(3):
                     num = str(j + 1).zfill(3)
-                    voice_path = character_path / "voice_samples" / f"{id}_{num}.wav"
+                    voice_path = character_path / \
+                        "voice_samples" / f"{style_id}_{num}.wav"
                     voice_samples.append(_resource_str(voice_path))
 
                 style_infos.append(
                     {
-                        "id": id,
+                        "name": style_name,
+                        "id": style_id,
                         "icon": icon,
                         "portrait": style_portrait,
                         "voice_samples": voice_samples,
@@ -233,7 +241,7 @@ class MetasStore:
             raise CharacterInfoNotFoundError("キャラクター情報が見つかりません") from e
 
         character_info = SpeakerInfo(
-            policy=policy, portrait=portrait, style_infos=style_infos
+            id=character_id, policy=policy, portrait=portrait, style_infos=style_infos, name=character_name
         )
         return character_info
 


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->
`/speakers`と`/speakers_info`で返ってくる情報に差があったため非破壊的に修正。

- `/speaker_info`にidとnameを追加
- `/speaker_info`で返ってくるstyle情報に対して`name`を追加


## 関連 Issue

none