### PR TITLE
docs: メンテナンスガイドラインを追加

### DIFF
--- a/docs/MAINTENANCE.md
+++ b/docs/MAINTENANCE.md
@@ -15,7 +15,7 @@ Docker Hub の `voicevox/voicevox_engine` リポジトリに製品版 VOICEVOX �
 
 1. アップデート情報を`resources/engine_manifest_assets/update_infos.json`に追加
 2. スナップショットテストの更新
-3. Github Workflow の `VOICEVOX_RESOURCE_VERSION`を更新
+3. GitHub Workflow の `VOICEVOX_RESOURCE_VERSION`を更新
 4. デフォルトブランチにプルリクエスト・マージ
 5. パッケージ版・Docker 版を`.github/workflows/build-engine.yml`でビルド
 6. Github Workflow の完了まで待機
@@ -34,6 +34,6 @@ Docker Hub の `voicevox/voicevox_engine` リポジトリに製品版 VOICEVOX �
 1. アップデート情報を`resources/engine_manifest_assets/update_infos.json`に追加
 2. 新しいキャラクターがいる場合は辞書を更新
 3. スナップショットテストの更新
-4. Github Workflow の `VOICEVOX_RESOURCE_VERSION`と`VOICEVOX_CORE_VERSION`を更新
+4. GitHub Workflow の `VOICEVOX_RESOURCE_VERSION`と`VOICEVOX_CORE_VERSION`を更新
 5. `release-0.XX` ブランチにプルリクエスト・マージ
 6. `新しいマイナーバージョン(0.XX.0)のリリース`の手順 5 から手順 10 までを実行


### PR DESCRIPTION
## 内容

メンテナンスガイドラインを追加してみました。

メジャーバージョンアップデート的な感じなのと、マイナーバージョンアップデート的な感じなのでやり方が違うので、２経路用意しています。
大体は[voicevox_projectのdocs](https://github.com/VOICEVOX/voicevox_project/blob/main/docs/%E3%83%AA%E3%83%AA%E3%83%BC%E3%82%B9%E6%88%A6%E7%95%A5.md)に書いているのでそちらを参照する形にもしています。
一応このメンテナンスガイドライン単体でもそこそこ進められるはず。


## その他
