### PR TITLE
refactor: アクセント句の生成とpauseの代入を分けずに一括で生成する

### DIFF
--- a/voicevox_engine/tts_pipeline/text_analyzer.py
+++ b/voicevox_engine/tts_pipeline/text_analyzer.py
@@ -239,7 +239,7 @@ PauseGroup: TypeAlias = list[AccentPhaseLabels]
 def full_context_labels_to_accent_phrases(
     full_context_labels: list[str],
 ) -> list[AccentPhrase]:
-    """フルコンテキストラベルからアクセント句系列を生成する。"""
+    """フルコンテキストラベルからアクセント句系列を生成する"""
     all_labels = map(_Label.from_feature, full_context_labels)
 
     pause_group_labels_list = [


### PR DESCRIPTION
## 内容
アクセント句を一括で生成するリファクタリングを提案します。   

#1746 でのリファクタリングにて、アクセント句の生成と pau の変更に未完成な部分があり、FIXME が付けられていた。  
アクセント句の生成を遅らせることでこれは解消できる。  

このような背景から、アクセント句を一括で生成するリファクタリングを提案します。   

## 関連 Issue
ref #1746