### PR TITLE
fix(build): ビルド時にコアのダウンローダーが見つからなくてエラーになるのを直す

### DIFF
--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -251,11 +251,13 @@ jobs:
             --output-dir "$RUNNER_TEMP" \
             https://github.com/VOICEVOX/voicevox_core/releases/download/"$VOICEVOX_CORE_AND_DOWNLOADER_VERSION"/$downloader_name
 
+          downloader_path=$(cygpath "$RUNNER_TEMP"/$downloader_name)
+
           if [ "$RUNNER_OS" != 'Windows' ]; then
-            chmod +x "$RUNNER_TEMP/$downloader_name"
+            chmod +x "$downloader_path"
           fi
 
-          echo "downloader-path=$RUNNER_TEMP/$downloader_name" >> "$GITHUB_OUTPUT"
+          echo "downloader-path=$downloader_path" >> "$GITHUB_OUTPUT"
 
       # NOTE: ダウンローダー0.15はvoicevox_core.dll、ONNX Runtime、モデル等をまとめてしかダウンロードできないが、0.16になると個別にダウンロードできる
       # TODO: ダウンローダーを0.16にしたら、個別ダウンロードにし、download/core/下に直接配置する

--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -253,8 +253,9 @@ jobs:
 
           downloader_path=$RUNNER_TEMP/$downloader_name
 
-          if [ "$RUNNER_OS" != 'Windows' ]; then
+          if [ "$RUNNER_OS" = 'Windows' ]; then
             downloader_path=$(cygpath "$downloader_path")
+          else
             chmod +x "$downloader_path"
           fi
 

--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -251,9 +251,10 @@ jobs:
             --output-dir "$RUNNER_TEMP" \
             https://github.com/VOICEVOX/voicevox_core/releases/download/"$VOICEVOX_CORE_AND_DOWNLOADER_VERSION"/$downloader_name
 
-          downloader_path=$(cygpath "$RUNNER_TEMP"/$downloader_name)
+          downloader_path=$RUNNER_TEMP/$downloader_name
 
           if [ "$RUNNER_OS" != 'Windows' ]; then
+            downloader_path=$(cygpath "$downloader_path")
             chmod +x "$downloader_path"
           fi
 


### PR DESCRIPTION
## 内容

現在壊れている`build-engine`を復活させる。

経緯: <https://github.com/VOICEVOX/voicevox_engine/pull/1776#issuecomment-3133021255>

## 関連 Issue

fixup #1772 and #1776

## スクリーンショット・動画など

## その他
