### PR TITLE
追加:環境変数の追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,8 +547,7 @@ options:
   --cpu_num_threads CPU_NUM_THREADS
                         音声合成を行うスレッド数です。指定しない場合、代わりに環境変数 VV_CPU_NUM_THREADS の値が使われます。VV_CPU_NUM_THREADS が空文字列でなく数値でもない場合はエラー終了します。
   --output_log_utf8     ログ出力をUTF-8でおこないます。指定しない場合、代わりに環境変数 VV_OUTPUT_LOG_UTF8 の値が使われます。VV_OUTPUT_LOG_UTF8 の値が1の場合はUTF-8で、0または空文字、値がない場合は環境によって自動的に決定されます。
-
-  --cors_policy_mode {CorsPolicyMode.all,CorsPolicyMode.localapps}
+  --cors_policy_mode {all,localapps}
                         CORSの許可モード。allまたはlocalappsが指定できます。allはすべてを許可します。localappsはオリジン間リソース共有ポリシーを、app://.とlocalhost関連、ブラウザ拡張URIに限定します。その他のオリジンはallow_originオプションで追加できます。デフォルトはlocalapps。指定しない場合、代わりに環境変数 VV_CORS_POLICY_MODE の値が使われます。VV_CORS_POLICY_MODE では "all", "localapps" または "ドメイン,ドメイン2" 形式で指定できます。このオプションは--setting_fileで指定される設定ファイルよりも優先されます。
   --allow_origin [ALLOW_ORIGIN ...]
                         許可するオリジンを指定します。スペースで区切ることで複数指定できます。指定しない場合、代わりに環境変数 VV_CORS_POLICY_MODE がカンマ区切りドメイン形式の場合はその値が使われます。このオプションは--setting_fileで指定される設定ファイルよりも優先されます。

--- a/run.py
+++ b/run.py
@@ -51,29 +51,31 @@ def decide_boolean_from_env(env_name: str) -> bool:
             return False
 
 
-def parse_cors_policy_from_env(env_value: str) -> tuple[CorsPolicyMode | None, list[str] | None]:
+def parse_cors_policy_from_env(
+    env_value: str,
+) -> tuple[CorsPolicyMode | None, list[str] | None]:
     """
     環境変数からCORSポリシーモードとallow_originsを解析する。
-    
+
     * "all" または "localapps" の場合は対応するCorsPolicyModeを返す
     * "ドメイン,ドメイン2" 形式の場合は None とドメインリストを返す
     * 空文字列の場合は None, None を返す
     """
     if not env_value:
         return None, None
-    
+
     # 標準のCORSポリシーモードをチェック
     try:
         cors_mode = CorsPolicyMode(env_value)
         return cors_mode, None
     except ValueError:
         pass
-    
+
     # カンマ区切りのドメインリストとして解析
     domains = [domain.strip() for domain in env_value.split(",") if domain.strip()]
     if domains:
         return None, domains
-    
+
     return None, None
 
 
@@ -98,7 +100,7 @@ def read_environment_variables() -> Envs:
     cors_policy_mode, cors_allow_origins = parse_cors_policy_from_env(
         os.getenv("VV_CORS_POLICY_MODE", "")
     )
-    
+
     envs = Envs(
         output_log_utf8=decide_boolean_from_env("VV_OUTPUT_LOG_UTF8"),
         cpu_num_threads=os.getenv("VV_CPU_NUM_THREADS"),
@@ -291,7 +293,7 @@ def read_cli_arguments(envs: Envs) -> _CLIArgs:
             "localappsはオリジン間リソース共有ポリシーを、app://.とlocalhost関連、ブラウザ拡張URIに限定します。"
             "その他のオリジンはallow_originオプションで追加できます。デフォルトはlocalapps。"
             "指定しない場合、代わりに環境変数 VV_CORS_POLICY_MODE の値が使われます。"
-            "VV_CORS_POLICY_MODE では \"all\", \"localapps\" または \"ドメイン,ドメイン2\" 形式で指定できます。"
+            'VV_CORS_POLICY_MODE では "all", "localapps" または "ドメイン,ドメイン2" 形式で指定できます。'
             "このオプションは--setting_fileで指定される設定ファイルよりも優先されます。"
         ),
     )

--- a/run.py
+++ b/run.py
@@ -285,7 +285,7 @@ def read_cli_arguments(envs: Envs) -> _CLIArgs:
         "--cors_policy_mode",
         type=CorsPolicyMode,
         choices=list(CorsPolicyMode),
-        default=envs.cors_policy_mode,
+        default=None,
         help=(
             "CORSの許可モード。allまたはlocalappsが指定できます。allはすべてを許可します。"
             "localappsはオリジン間リソース共有ポリシーを、app://.とlocalhost関連、ブラウザ拡張URIに限定します。"

--- a/run.py
+++ b/run.py
@@ -299,7 +299,6 @@ def read_cli_arguments(envs: Envs) -> _CLIArgs:
     parser.add_argument(
         "--allow_origin",
         nargs="*",
-        default=envs.cors_allow_origins,
         help=(
             "許可するオリジンを指定します。スペースで区切ることで複数指定できます。"
             "指定しない場合、代わりに環境変数 VV_CORS_POLICY_MODE がカンマ区切りドメイン形式の場合はその値が使われます。"


### PR DESCRIPTION
## 内容

- **`VV_CORS_POLICY_MODE`**: CORSポリシーモードの設定
  - `all`: 全てのオリジンを許可
  - `localapps`: ローカルアプリケーションのみ許可
  - `example.com,example2.com`: カンマ区切りで特定ドメインを許可
- **`VV_LOAD_ALL_MODELS`**: 起動時の全モデル読み込み設定
  - `1`: 有効（全モデルを読み込み）
  - `0`または未設定: 無効（必要時に読み込み）
- **`VV_DISABLE_MUTABLE_API`**: 変更可能APIの無効化設定
  - `1`: 無効化
  - `0`または未設定: 有効

## 関連 Issue

ref #1798

## その他

ほぼAIなので間違っていたら申し訳ないです。