### PR TITLE
fix: CORSポリシーモードの選択肢を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,8 +446,8 @@ curl -s \
 $ uv run run.py -h
 
 usage: run.py [-h] [--host HOST] [--port PORT] [--use_gpu] [--voicevox_dir VOICEVOX_DIR] [--voicelib_dir VOICELIB_DIR] [--runtime_dir RUNTIME_DIR] [--enable_mock] [--enable_cancellable_synthesis]
-              [--init_processes INIT_PROCESSES] [--load_all_models] [--cpu_num_threads CPU_NUM_THREADS] [--output_log_utf8] [--cors_policy_mode {CorsPolicyMode.all,CorsPolicyMode.localapps}]
-              [--allow_origin [ALLOW_ORIGIN ...]] [--setting_file SETTING_FILE] [--preset_file PRESET_FILE] [--disable_mutable_api]
+              [--init_processes INIT_PROCESSES] [--load_all_models] [--cpu_num_threads CPU_NUM_THREADS] [--output_log_utf8] [--cors_policy_mode {all,localapps}] [--allow_origin [ALLOW_ORIGIN ...]]
+              [--setting_file SETTING_FILE] [--preset_file PRESET_FILE] [--disable_mutable_api]
 
 VOICEVOX のエンジンです。
 
@@ -471,8 +471,8 @@ options:
   --cpu_num_threads CPU_NUM_THREADS
                         音声合成を行うスレッド数です。指定しない場合、代わりに環境変数 VV_CPU_NUM_THREADS の値が使われます。VV_CPU_NUM_THREADS が空文字列でなく数値でもない場合はエラー終了します。
   --output_log_utf8     ログ出力をUTF-8でおこないます。指定しない場合、代わりに環境変数 VV_OUTPUT_LOG_UTF8 の値が使われます。VV_OUTPUT_LOG_UTF8 の値が1の場合はUTF-8で、0または空文字、値がない場合は環境によって自動的に決定されます。
-  --cors_policy_mode {CorsPolicyMode.all,CorsPolicyMode.localapps}
-                        CORSの許可モード。allまたはlocalappsが指定できます。allはすべてを許可します。localappsはオリジン間リソース共有ポリシーを、app://.とlocalhost関連に限定します。その他のオリジンはallow_originオプションで追加できます。デフォルトはlocalapps。このオプションは--
+  --cors_policy_mode {all,localapps}
+                        CORSの許可モード。allまたはlocalappsが指定できます。allはすべてを許可します。localappsはオリジン間リソース共有ポリシーを、app://.とlocalhost関連、ブラウザ拡張URIに限定します。その他のオリジンはallow_originオプションで追加できます。デフォルトはlocalapps。このオプションは--
                         setting_fileで指定される設定ファイルよりも優先されます。
   --allow_origin [ALLOW_ORIGIN ...]
                         許可するオリジンを指定します。スペースで区切ることで複数指定できます。このオプションは--setting_fileで指定される設定ファイルよりも優先されます。

--- a/run.py
+++ b/run.py
@@ -243,7 +243,7 @@ def read_cli_arguments(envs: Envs) -> _CLIArgs:
     parser.add_argument(
         "--cors_policy_mode",
         type=CorsPolicyMode,
-        choices=list(CorsPolicyMode),
+        choices=[i.value for i in CorsPolicyMode],
         default=None,
         help=(
             "CORSの許可モード。allまたはlocalappsが指定できます。allはすべてを許可します。"


### PR DESCRIPTION
## 内容

ヘルプの文字列`--cors_policy_mode`の表示が`{CorsPolicyMode.all,CorsPolicyMode.localapps}`と壊れていたので修正します。

## その他

`argpars`の`choices`に`enum`を渡すのは非推奨だそうです。
https://docs.python.org/ja/3/library/argparse.html#choices