### PR TITLE
chore: メンテナンスが止まっている`pip-licenses`を`pip-licenses-cli`に置き換え

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dev = [
   "httpx>=0.28.1", # NOTE: required by fastapi.testclient.TestClient (fastapi-slim's unmanaged dependency)
   "mypy>=1.10.0",
   "pip-audit>=2.7.3",
-  "pip-licenses==5.0.0", # NOTE: must be specified exactly (ref: https://github.com/VOICEVOX/voicevox_engine/issues/1281)
+  "pip-licenses-cli==2.0.0", # NOTE: must be specified exactly (ref: https://github.com/VOICEVOX/voicevox_engine/issues/1281)
   "pre-commit>=4.0.1",
   "pytest>=8.2.0",
   "ruff>=0.11.1",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -38,7 +38,8 @@ packaging==24.2
 pip==25.0.1
 pip-api==0.0.34
 pip-audit==2.9.0
-pip-licenses==5.0.0
+pip-licenses-cli==2.0.0
+pip-licenses-lib==0.6.0
 pip-requirements-parser==32.0.1
 platformdirs==4.3.7
 pluggy==1.5.0
@@ -67,7 +68,6 @@ soxr==0.5.0.post1
 starlette==0.45.3
 syrupy==4.9.1
 toml==0.10.2
-tomli==2.2.1
 tqdm==4.67.1
 types-pyyaml==6.0.12.20250402
 typing-extensions==4.13.2

--- a/tools/create_venv_and_generate_licenses.bash
+++ b/tools/create_venv_and_generate_licenses.bash
@@ -11,7 +11,9 @@ uv venv "licenses_venv"
 export VIRTUAL_ENV="licenses_venv"
 uv sync --active
 # requirements-dev.txt でバージョン指定されている pip-licenses-cli をインストールする
-uv pip install "$(grep pip-licenses-cli requirements-dev.txt | cut -f 1 -d ';')"
+uv pip install \
+  "$(grep pip-licenses-cli requirements-dev.txt | cut -f 1 -d ';')" \
+  "$(grep pip-licenses-lib requirements-dev.txt | cut -f 1 -d ';')"
 uv run --active tools/generate_licenses.py > "${OUTPUT_LICENSE_JSON_PATH}"
 
 rm -rf $VIRTUAL_ENV

--- a/tools/create_venv_and_generate_licenses.bash
+++ b/tools/create_venv_and_generate_licenses.bash
@@ -10,8 +10,8 @@ fi
 uv venv "licenses_venv"
 export VIRTUAL_ENV="licenses_venv"
 uv sync --active
-# requirements-dev.txt でバージョン指定されている pip-licenses をインストールする
-uv pip install "$(grep pip-licenses requirements-dev.txt | cut -f 1 -d ';')"
+# requirements-dev.txt でバージョン指定されている pip-licenses-cli をインストールする
+uv pip install "$(grep pip-licenses-cli requirements-dev.txt | cut -f 1 -d ';')"
 uv run --active tools/generate_licenses.py > "${OUTPUT_LICENSE_JSON_PATH}"
 
 rm -rf $VIRTUAL_ENV

--- a/uv.lock
+++ b/uv.lock
@@ -537,16 +537,25 @@ wheels = [
 ]
 
 [[package]]
-name = "pip-licenses"
-version = "5.0.0"
+name = "pip-licenses-cli"
+version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "pip-licenses-lib" },
     { name = "prettytable" },
-    { name = "tomli" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a0/49/d36a3ddb73d22970a35afa3e9fd53c8318150f8122e4257ca9875f1d4e38/pip_licenses-5.0.0.tar.gz", hash = "sha256:0633a1f9aab58e5a6216931b0e1d5cdded8bcc2709ff563674eb0e2ff9e77e8e", size = 41542, upload-time = "2024-07-23T10:48:29.785Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/9f/d0edd6b5e246c46cd949758cd5f1a42603124f3d43240aa56a9712a5a2de/pip_licenses_cli-2.0.0.tar.gz", hash = "sha256:ddbd4d5fff2270b66d515d5737f0145bc35ed42b9179f684c0f5f020d33e4320", size = 20890, upload-time = "2025-07-30T09:35:29.549Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/0a/bfaf1479d09d19f503a669d9c8e433ac59ae687fb8da1d8207eb85c5a9f4/pip_licenses-5.0.0-py3-none-any.whl", hash = "sha256:82c83666753efb86d1af1c405c8ab273413eb10d6689c218df2f09acf40e477d", size = 20497, upload-time = "2024-07-23T10:48:27.59Z" },
+    { url = "https://files.pythonhosted.org/packages/75/ca/b4f03ec0a5678343de70746552e507440f60ae33fbf641f2a6ace2ba1d7e/pip_licenses_cli-2.0.0-py3-none-any.whl", hash = "sha256:9e49a34bd9613bd3c2133e8edb5726338134ad0e748df502fe9881cd3a140456", size = 15870, upload-time = "2025-07-30T09:35:28.216Z" },
+]
+
+[[package]]
+name = "pip-licenses-lib"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/64/299e014671bec7b1c136d374d583a6e60d0179d578f67a1bd7c08c28f23c/pip_licenses_lib-0.6.0.tar.gz", hash = "sha256:ee0e9d2e58d776e1ceaaf23d5f0c99205620079b1cdc6bb77ceb9ef3fbc3aaad", size = 13090, upload-time = "2025-06-26T14:55:43.834Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/b1/2a01e6230d6800d77b3bd1cf952b743ce320681915db5e66182f8d4c3c8a/pip_licenses_lib-0.6.0-py3-none-any.whl", hash = "sha256:057fc3167e49fe207237dce646b1460a31d92c96a605cf8a09aff9c3cc1b164c", size = 8916, upload-time = "2025-06-26T14:55:42.436Z" },
 ]
 
 [[package]]
@@ -971,25 +980,6 @@ wheels = [
 ]
 
 [[package]]
-name = "tomli"
-version = "2.2.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/18/87/302344fed471e44a87289cf4967697d07e532f2421fdaf868a303cbae4ff/tomli-2.2.1.tar.gz", hash = "sha256:cd45e1dc79c835ce60f7404ec8119f2eb06d38b1deba146f07ced3bbc44505ff", size = 17175, upload-time = "2024-11-27T22:38:36.873Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/43/ca/75707e6efa2b37c77dadb324ae7d9571cb424e61ea73fad7c56c2d14527f/tomli-2.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678e4fa69e4575eb77d103de3df8a895e1591b48e740211bd1067378c69e8249", size = 131077, upload-time = "2024-11-27T22:37:54.956Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/16/51ae563a8615d472fdbffc43a3f3d46588c264ac4f024f63f01283becfbb/tomli-2.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:023aa114dd824ade0100497eb2318602af309e5a55595f76b626d6d9f3b7b0a6", size = 123429, upload-time = "2024-11-27T22:37:56.698Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/dd/4f6cd1e7b160041db83c694abc78e100473c15d54620083dbd5aae7b990e/tomli-2.2.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ece47d672db52ac607a3d9599a9d48dcb2f2f735c6c2d1f34130085bb12b112a", size = 226067, upload-time = "2024-11-27T22:37:57.63Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/6b/c54ede5dc70d648cc6361eaf429304b02f2871a345bbdd51e993d6cdf550/tomli-2.2.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6972ca9c9cc9f0acaa56a8ca1ff51e7af152a9f87fb64623e31d5c83700080ee", size = 236030, upload-time = "2024-11-27T22:37:59.344Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/47/999514fa49cfaf7a92c805a86c3c43f4215621855d151b61c602abb38091/tomli-2.2.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c954d2250168d28797dd4e3ac5cf812a406cd5a92674ee4c8f123c889786aa8e", size = 240898, upload-time = "2024-11-27T22:38:00.429Z" },
-    { url = "https://files.pythonhosted.org/packages/73/41/0a01279a7ae09ee1573b423318e7934674ce06eb33f50936655071d81a24/tomli-2.2.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8dd28b3e155b80f4d54beb40a441d366adcfe740969820caf156c019fb5c7ec4", size = 229894, upload-time = "2024-11-27T22:38:02.094Z" },
-    { url = "https://files.pythonhosted.org/packages/55/18/5d8bc5b0a0362311ce4d18830a5d28943667599a60d20118074ea1b01bb7/tomli-2.2.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:e59e304978767a54663af13c07b3d1af22ddee3bb2fb0618ca1593e4f593a106", size = 245319, upload-time = "2024-11-27T22:38:03.206Z" },
-    { url = "https://files.pythonhosted.org/packages/92/a3/7ade0576d17f3cdf5ff44d61390d4b3febb8a9fc2b480c75c47ea048c646/tomli-2.2.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:33580bccab0338d00994d7f16f4c4ec25b776af3ffaac1ed74e0b3fc95e885a8", size = 238273, upload-time = "2024-11-27T22:38:04.217Z" },
-    { url = "https://files.pythonhosted.org/packages/72/6f/fa64ef058ac1446a1e51110c375339b3ec6be245af9d14c87c4a6412dd32/tomli-2.2.1-cp311-cp311-win32.whl", hash = "sha256:465af0e0875402f1d226519c9904f37254b3045fc5084697cefb9bdde1ff99ff", size = 98310, upload-time = "2024-11-27T22:38:05.908Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/1c/4a2dcde4a51b81be3530565e92eda625d94dafb46dbeb15069df4caffc34/tomli-2.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:2d0f2fdd22b02c6d81637a3c95f8cd77f995846af7414c5c4b8d0545afa1bc4b", size = 108309, upload-time = "2024-11-27T22:38:06.812Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/c2/61d3e0f47e2b74ef40a68b9e6ad5984f6241a942f7cd3bbfbdbd03861ea9/tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc", size = 14257, upload-time = "2024-11-27T22:38:35.385Z" },
-]
-
-[[package]]
 name = "tqdm"
 version = "4.67.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1116,7 +1106,7 @@ dev = [
     { name = "httpx" },
     { name = "mypy" },
     { name = "pip-audit" },
-    { name = "pip-licenses" },
+    { name = "pip-licenses-cli" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "ruff" },
@@ -1146,13 +1136,13 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-build = [{ name = "pyinstaller", specifier = ">=6.0.0" }]
+build = [{ name = "pyinstaller", specifier = ">=6" }]
 dev = [
     { name = "coveralls", specifier = ">=4.0.1" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "mypy", specifier = ">=1.10.0" },
     { name = "pip-audit", specifier = ">=2.7.3" },
-    { name = "pip-licenses", specifier = "==5.0.0" },
+    { name = "pip-licenses-cli", specifier = "==2.0.0" },
     { name = "pre-commit", specifier = ">=4.0.1" },
     { name = "pytest", specifier = ">=8.2.0" },
     { name = "ruff", specifier = ">=0.11.1" },


### PR DESCRIPTION
## 内容

ライセンス生成に使用している`pip-licenses`のメンテナンスが停止しているためそのフォークの`pip-licenses-cli`に置き換えます。

選定の理由は[`pip-licenses`のissue](https://github.com/raimon49/pip-licenses/issues/227)で移行先に上げられているからです。

## 関連 Issue

close #1639

## その他

masterで生成されるライセンスとの違いは`typing_extensions`のライセンスが`UNKNOWN`から`PSF-2.0`になるだけです。

ライセンス生成時にインストールするのは`pip-licenses-cli`だけですがその依存もインストールするべきなのかもしれない。(いい方法が思いつかない)