### PR TITLE
feat!: `ENTRYPOINT`と`CMD`を変更して引数の変更を簡単にする

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,10 +94,10 @@ set -eux
 # Display README for engine
 cat /opt/voicevox_engine/README.md > /dev/stderr
 
-exec "\$@"
+exec gosu user /opt/voicevox_engine/run "\$@"
 EOF
 
-ENTRYPOINT [ "/entrypoint.sh", "gosu", "user", "/opt/voicevox_engine/run" ]
+ENTRYPOINT [ "/entrypoint.sh" ]
 CMD [ "--host", "0.0.0.0" ]
 
 # Enable use_gpu


### PR DESCRIPTION
## 内容

`CMD`の方に書かれていたエンジン起動用のコマンドを`ENTRYPOINT`に移動します。

現在、エンジンの引数を設定するには以下のようにする必要があります。
```bash
docker run --publish=127.0.0.1:50021:50021 voicevox_engine gosu user /opt/voicevox_engine/run --host 0.0.0.0 [その他の引数]
```
これはドキュメント化されていない上に分かりにくいです。

この変更により引数の変更が以下のように簡単になります。
```bash
docker run --publish=127.0.0.1:50021:50021 voicevox_engine --host 0.0.0.0 [その他の引数]
```

## 関連 Issue

resolve #1800

## その他

これは破壊的変更です。

`--host 0.0.0.0`や`--use_gpu`は`CMD`にあるため引数を変更する場合はほぼ必ず入れる必要があります。
これは今後のPRで改善する予定です。
ref https://github.com/VOICEVOX/voicevox_engine/issues/1800#issuecomment-3460797902