### PR TITLE
fix: カスタマイズしたPyInstallerのインストールコマンドを修正

### DIFF
--- a/tools/modify_pyinstaller.bash
+++ b/tools/modify_pyinstaller.bash
@@ -24,4 +24,4 @@ __declspec(dllexport) DWORD AmdPowerXpressRequestHighPerformance = 0x00000001;
 #endif
 EOF
 (cd "$tempdir/bootloader" && python ./waf all --msvc_targets="x64")
-uv pip install "$tempdir" # TODO: 可能であればuv addでやる
+uv pip install --reinstall-package pyinstaller "$tempdir" # TODO: 可能であればuv addでやる


### PR DESCRIPTION
## 内容

WindowsビルドではPyInstallerをカスタマイズしています。
しかしインストール時に`-U`フラグを指定しているためPyInstallerの依存パッケージも更新されています。
`-U`フラグを削除することで更新するパッケージをPyInstallerのみにしてそれ以外のパッケージはlockされたバージョンを使うようにします。

## スクリーンショット・動画など

PyInstaller以外も更新されている
<img width="1077" height="538" alt="PyInstaller以外のパッケージも更新されているWorkflowのログ" src="https://github.com/user-attachments/assets/6dc48720-20ec-44a3-93b8-aecfb3f4ade1" />

## その他

多分`-U`フラグがなくてもPyInstaller自体はカスタマイズしたものがインストールされるはず。