### PR TITLE
chore(ci): `if: true`を削除してactionlintエラーを解消

### DIFF
--- a/.github/workflows/build-engine-container.yml
+++ b/.github/workflows/build-engine-container.yml
@@ -277,9 +277,6 @@ jobs:
           bash ./tools/build_and_push_multi_platform_docker_images.bash
 
   run-release-test-workflow:
-    # NOTE: デフォルトブランチでのビルドを一時的にやめているので、常にtrueになっている
-    # FIXME: Docker Hubにpushしない場合はfalseになるようにする
-    if: true
     needs: [config, build-docker, build-docker-multi-platform]
     uses: ./.github/workflows/test-engine-container.yml
     with:


### PR DESCRIPTION
## 内容

`build-engine-container.yml`で発生していたactionlintエラーを解消しました。

## 変更内容

`run-release-test-workflow`ジョブの不要な`if: true`条件とそのコメントを削除しました。

この条件は過去の経緯で追加されたものでしたが、技術的な制約は見当たらず、常に真となる条件はactionlintでエラーとなるため削除しました。

## 関連 Issue

close #1824