### PR TITLE
feat: uvのキャッシュを有効化

### DIFF
--- a/.github/actions/prepare_python/action.yml
+++ b/.github/actions/prepare_python/action.yml
@@ -9,7 +9,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    # NOTE: アンドキュメントな変数を使用するので存在チェックをする
+    # NOTE: アンドキュメントな環境変数を使用するので存在を確認をする
     - name: <Setup> Get ImageOS environment variable
       id: image-os
       run: |


### PR DESCRIPTION
## 内容

#1616 で無効にしていたCI/DI環境でのuvのキャッシュを有効化します。

[`cache-suffix`](https://github.com/astral-sh/setup-uv/blob/v7/docs/caching.md#enable-caching)を使用することでキャッシュのキーを設定します。
キャッシュのキーにはGCCが参照するglibcのバージョンを使用します。(例: `glibc-2.35.`)

glibcのバージョンは`libc.so.6`を直接実行することで取得できるようです。
https://sourceware.org/glibc/wiki/FAQ#How_can_I_find_out_which_version_of_glibc_I_am_using_in_the_moment.3F

## 関連 Issue

resolve #1657

## その他

Windowsは原則新しいコンパイラでビルドしても原則的に以前のバージョンでも動作すると思います。
macOSは元々ビルドされたwheelにビルドしたOSバージョンのタグが付くため問題は起こらなそうです。
そのためWindowsとmacOSは何も対策をしていません。

glibcのバージョンの文字列の最後に`.`が付いていますが面倒なのでそのままにしています。(コード増やしてバグ増やす方が怖い)