### PR TITLE
chore(build): VOICEVOX Nemo を除外してモデルをダウンロードするように

### DIFF
--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -340,10 +340,13 @@ jobs:
       - name: <Setup> Download models
         if: steps.models-cache-restore.outputs.cache-hit != 'true'
         run: |
+          # NOTE: VOICEVOX Nemo を除外
+          MODELS_PATTERN='[!n]*'
           # NOTE: `"y"`を流し込んで利用規約に同意している
           ${{ steps.download-downloader.outputs.downloader-path }} \
             --only models \
             --models-version "$VOICEVOX_VVM_VERSION" \
+            --models-pattern "$MODELS_PATTERN" \
             -o download/core \
             <<< y
         env:


### PR DESCRIPTION
## 内容

将来Nemo用のVVMがダウンロードされうるので、ダウンロードされないようにしました。

エンジンのビルド時、VOICEVOX COREのダウンローダーを使って、VOICEVOX VVMで配布されているVVMを組み込んでます。
VVMはバージョン0.16.2からデフォルトでNemo用のVVMも配布します。 [参考](https://github.com/VOICEVOX/voicevox_vvm/issues/40)
現状のCOREのダウンローダーはデフォルトで全VVMをダウンロードします。
このままだとVVMのバージョンを0.16.2に上げたときにNemoのも入ってしまうので、覚えてるうちにダウンロード対象を絞るようにしてみました。

Nemo用のVVMは`n`から始まるファイル名にすると約束しています。 [参考](https://github.com/VOICEVOX/voicevox_vvm/blob/64debf93d2725a33cf16104f7c8f974111768470/README.md#%E5%82%99%E8%80%83)
なので`n`以外から始まるものをダウンロードするようにしています。

## 関連 Issue

- https://github.com/VOICEVOX/voicevox_vvm/issues/40

## その他
