### PR TITLE
chore(build): [release-0.25] VOICEVOX Nemo を除外してモデルをダウンロードするように (#1830)

### DIFF
--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -339,10 +339,13 @@ jobs:
       - name: <Setup> Download models
         if: steps.models-cache-restore.outputs.cache-hit != 'true'
         run: |
+          # NOTE: VOICEVOX Nemo を除外
+          MODELS_PATTERN='[!n]*'
           # NOTE: `"y"`を流し込んで利用規約に同意している
           ${{ steps.download-downloader.outputs.downloader-path }} \
             --only models \
             --models-version "$VOICEVOX_VVM_VERSION" \
+            --models-pattern "$MODELS_PATTERN" \
             -o download/core \
             <<< y
         env:


### PR DESCRIPTION
## 内容

e60ee0d0d8e7d757e4ca1edf22c94c9ccf0345ca
をcherry-pickします。

## 関連 Issue

- https://github.com/VOICEVOX/voicevox_engine/pull/1830

## その他
