### PR TITLE
ci: 書き込みが必要な job に permissions: を明示する

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -19,6 +19,8 @@ defaults:
 jobs:
   upload-doc:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write
     steps:
       - name: <Setup> Check out the repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1

--- a/.github/workflows/build-engine-container.yml
+++ b/.github/workflows/build-engine-container.yml
@@ -55,7 +55,6 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     permissions:
-      contents: read
       packages: write
 
     strategy:
@@ -215,7 +214,6 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: read
       packages: write
 
     strategy:

--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -57,6 +57,8 @@ jobs:
   build-and-upload:
     needs: [config]
     environment: ${{ github.event.inputs.code_signing == 'true' && 'code_signing' || '' }} # コード署名用のenvironment
+    permissions:
+      contents: write
     strategy:
       matrix:
         include:
@@ -556,6 +558,8 @@ jobs:
     if: needs.config.outputs.version != ''
     needs: [config, build-and-upload]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: <Setup> Check out the repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -576,6 +580,8 @@ jobs:
   run-build-engine-container-workflow:
     if: needs.config.outputs.version != ''
     needs: [config, run-release-test-workflow]
+    permissions:
+      packages: write
     uses: ./.github/workflows/build-engine-container.yml
     with:
       version: ${{ needs.config.outputs.version }}

--- a/.github/workflows/build-latest-dev.yml
+++ b/.github/workflows/build-latest-dev.yml
@@ -15,6 +15,8 @@ jobs:
   latest-dev-build:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'VOICEVOX'
+    permissions:
+      actions: write
     steps:
       - name: Trigger workflow_dispatch
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0

--- a/.github/workflows/build-latest-engine-container.yml
+++ b/.github/workflows/build-latest-engine-container.yml
@@ -36,6 +36,8 @@ jobs:
   build-docker-latest:
     needs: [config]
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
 
     strategy:
       matrix:

--- a/.github/workflows/test-issue-freshness.yml
+++ b/.github/workflows/test-issue-freshness.yml
@@ -13,6 +13,8 @@ on:
 jobs:
   stale:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - name: <Test> Notify inactive 必要性議論 issues
         uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0


### PR DESCRIPTION
## 内容

`GITHUB_TOKEN` のデフォルト権限を read-only に切り替えるにあたり、書き込みが必要な job に `permissions:` を明示しました。

- `build-latest-dev.yml` の `latest-dev-build` job: `actions/github-script` が `createWorkflowDispatch` を呼び出すため `actions: write` を追加
- `build-docs.yml` の `upload-doc` job: `peaceiris/actions-gh-pages` が `gh-pages` ブランチへ push するため `contents: write` を追加
- `build-latest-engine-container.yml` の `build-docker-latest` job: GitHub Container Registry へ Docker イメージを push するため `packages: write` を追加
- `build-engine.yml` の `build-and-upload` job: `ncipollo/release-action` がリリースアセットをアップロードするため `contents: write` を追加
- `build-engine.yml` の `update-tag-to-current-commit` job: tag を force push するため `contents: write` を追加
- `build-engine.yml` の `run-build-engine-container-workflow` job: reusable workflow 呼び出し側から GitHub Container Registry への push 権限を渡すため `packages: write` を追加
- `build-engine-container.yml` の `build-docker` job と `build-docker-multi-platform` job: 既存の `contents: read` は public resource の read なので削除し、GitHub Container Registry への push に必要な `packages: write` だけを残しました
- `test-issue-freshness.yml` の `stale` job: `actions/stale` が issue にラベル付けとコメントを行うため `issues: write` を追加

`test-engine-container.yml` の GitHub Container Registry へのログインは pull 用なので対応不要です。

## 関連 Issue

ref VOICEVOX/voicevox_project#93
