### PR TITLE
ci: ワークフロー起動からon: release.createdを削除

### DIFF
--- a/.github/workflows/build-engine-container.yml
+++ b/.github/workflows/build-engine-container.yml
@@ -41,8 +41,8 @@ jobs:
       - name: <Setup> Declare variables
         id: vars
         run: |
-          : # releaseタグ名か、workflow_dispatchでのバージョン名が入る
-          echo "version=${{ github.event.release.tag_name || github.event.inputs.version }}" >> "$GITHUB_OUTPUT"
+          : # workflow_call か workflow_dispatch でのバージョン名が入る
+          echo "version=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
 
           : # GitHub Container RegistryのDockerイメージリポジトリ
           echo "ghcr_repository=ghcr.io/${{ github.repository }}" | tr "[:upper:]" "[:lower:]" >> "$GITHUB_OUTPUT"
@@ -157,7 +157,6 @@ jobs:
 
             # Docker Hub
             # TODO: レジストリごとにプッシュするプレフィックスを変更したい（ https://github.com/VOICEVOX/voicevox_engine/issues/1663 ）
-            # NOTE: workflow_call・workflow_dispatch以外では、 `{{ inputs.push_dockerhub }} == "null"` であるため、 `if [[ false ]]` となる
             if [[ "${{ inputs.push_dockerhub }}" == "true" ]]; then
               uv run tools/generate_docker_image_names.py \
                 --repository "${{ needs.config.outputs.dockerhub_repository }}" \

--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -3,9 +3,6 @@ on:
   push:
     branches:
       - master
-  release:
-    types:
-      - created
   workflow_dispatch:
     inputs:
       version:
@@ -49,14 +46,14 @@ jobs:
       - name: <Setup> Declare variables
         id: vars
         run: |
-          : # release タグ名, または workflow_dispatch でのバージョン名. リリースでない (push event) 場合は空文字列
-          echo "version=${{ github.event.release.tag_name || github.event.inputs.version }}" >> "$GITHUB_OUTPUT"
-          : # release タグ名, または workflow_dispatch でのバージョン名, または 'latest'
-          echo "version_or_latest=${{ github.event.release.tag_name || github.event.inputs.version || 'latest' }}" >> "$GITHUB_OUTPUT"
+          : # workflow_dispatch でのバージョン名. リリースでない push イベントの場合は空文字列
+          echo "version=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+          : # workflow_dispatch でのバージョン名, または 'latest'
+          echo "version_or_latest=${{ inputs.version || 'latest' }}" >> "$GITHUB_OUTPUT"
 
   build-and-upload:
     needs: [config]
-    environment: ${{ github.event.inputs.code_signing == 'true' && 'code_signing' || '' }} # コード署名用のenvironment
+    environment: ${{ inputs.code_signing == true && 'code_signing' || '' }} # コード署名用のenvironment
     strategy:
       matrix:
         include:
@@ -455,7 +452,7 @@ jobs:
           mv download/core/additional_libraries/*.so* dist/run/
 
       - name: <Build> Code signing
-        if: github.event.inputs.code_signing == 'true' && runner.os == 'Windows'
+        if: inputs.code_signing == true && runner.os == 'Windows'
         run: bash tools/codesign.bash "dist/run/run.exe"
         env:
           ESIGNERCKA_USERNAME: ${{ secrets.ESIGNERCKA_USERNAME }}
@@ -476,7 +473,7 @@ jobs:
           mv archives_7z.txt "${{ steps.vars.outputs.package_name }}.7z.txt"
 
       - name: <Deploy> Upload 7z archives to artifact
-        if: github.event.inputs.upload_artifact == 'true'
+        if: inputs.upload_artifact == true
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ steps.vars.outputs.package_name }}-7z
@@ -488,7 +485,7 @@ jobs:
         uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         with:
           allowUpdates: true
-          prerelease: ${{ github.event.inputs.prerelease }}
+          prerelease: ${{ inputs.prerelease }}
           token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ needs.config.outputs.version }}
           artifacts: >
@@ -521,7 +518,7 @@ jobs:
           mv archives_vvpp.txt "${{ steps.vars.outputs.package_name }}.vvpp.txt"
 
       - name: <Deploy> Upload VVPP archives to artifact
-        if: github.event.inputs.upload_artifact == 'true'
+        if: inputs.upload_artifact == true
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ steps.vars.outputs.package_name }}-vvpp
@@ -535,7 +532,7 @@ jobs:
         uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         with:
           allowUpdates: true
-          prerelease: ${{ github.event.inputs.prerelease }}
+          prerelease: ${{ inputs.prerelease }}
           token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ needs.config.outputs.version }}
           artifacts: >
@@ -545,7 +542,7 @@ jobs:
           commit: ${{ github.sha }}
 
       - name: <Deploy> Merge artifacts
-        if: github.event.inputs.upload_artifact == 'true'
+        if: inputs.upload_artifact == true
         uses: actions/upload-artifact/merge@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ steps.vars.outputs.package_name }}
@@ -579,7 +576,7 @@ jobs:
     uses: ./.github/workflows/build-engine-container.yml
     with:
       version: ${{ needs.config.outputs.version }}
-      # NOTE: workflow_dispatch以外では、 `inputs.push_dockerhub == null` であるため `push_dockerhub: false` となる
+      # NOTE: push イベントでは `inputs.push_dockerhub == null` であるため `push_dockerhub: false` となる
       push_dockerhub: ${{ inputs.push_dockerhub == true }}
     secrets:
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
## 内容

build workflowをrelease作成から起動してを作れる経路を削除します。

デバッグのために便利かなと思っていたのと、昔の名残で残していましたが、コードが煩雑化してしまったり、セキュリティ的にリスクになり得ると思ったので削除しようと思います。
代わりに、Githubの`Actions`でbuildを`workflow_dispatch`すればリリースできます。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## その他

Copilotへ：
on: release経路でreleaseを作れる、というドキュメントが存在しないことを確かめてコメントください。
