### PR TITLE
ci: actionlint ダウンロード時に SHA256 チェックサムを検証する

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,10 @@ jobs:
 
       - name: <Test> Check workflow files
         run: |
-          bash <(curl -f --retry 3 --retry-delay 5 https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+          curl -fLO --retry 3 --retry-delay 5 \
+              "https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_linux_amd64.tar.gz"
+          echo "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8  actionlint_1.7.12_linux_amd64.tar.gz" | sha256sum --check
+          tar -xzf actionlint_1.7.12_linux_amd64.tar.gz actionlint
           ./actionlint
 
       - name: <Test> Check pinact


### PR DESCRIPTION
## 内容

`download-actionlint.bash` を `main` ブランチから取得して実行していた箇所を、リリースアセット `actionlint_1.7.12_linux_amd64.tar.gz` を直接 `curl` で取得して `sha256sum --check` で検証する形に変更しました。

## 関連 Issue

ref VOICEVOX/voicevox_project#94

## スクリーンショット・動画など

## その他

VOICEVOX/voicevox#2999 と同じ方針で対応しています。バージョンアップ時はチェックサムを `sha256sum` で確認して更新してください。リリースから 7 日以上経過後が望ましいです。