### PR TITLE
ci: [release-0.25] 書き込みが必要な job に permissions: を明示する

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -19,6 +19,8 @@ defaults:
 jobs:
   upload-doc:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write
     steps:
       - name: <Setup> Check out the repository
         uses: actions/checkout@v4

--- a/.github/workflows/build-engine-container.yml
+++ b/.github/workflows/build-engine-container.yml
@@ -55,7 +55,6 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     permissions:
-      contents: read
       packages: write
 
     strategy:
@@ -215,7 +214,6 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: read
       packages: write
 
     strategy:

--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -57,6 +57,8 @@ jobs:
   build-and-upload:
     needs: [config]
     environment: ${{ github.event.inputs.code_signing == 'true' && 'code_signing' || '' }} # コード署名用のenvironment
+    permissions:
+      contents: write
     strategy:
       matrix:
         include:
@@ -553,6 +555,8 @@ jobs:
     if: needs.config.outputs.version != ''
     needs: [config, build-and-upload]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: <Setup> Check out the repository
         uses: actions/checkout@v4
@@ -573,6 +577,8 @@ jobs:
   run-build-engine-container-workflow:
     if: needs.config.outputs.version != ''
     needs: [config, run-release-test-workflow]
+    permissions:
+      packages: write
     uses: ./.github/workflows/build-engine-container.yml
     with:
       version: ${{ needs.config.outputs.version }}

--- a/.github/workflows/build-latest-dev.yml
+++ b/.github/workflows/build-latest-dev.yml
@@ -15,6 +15,8 @@ jobs:
   latest-dev-build:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'VOICEVOX'
+    permissions:
+      actions: write
     steps:
       - name: Trigger workflow_dispatch
         uses: actions/github-script@v7

--- a/.github/workflows/build-latest-engine-container.yml
+++ b/.github/workflows/build-latest-engine-container.yml
@@ -36,6 +36,8 @@ jobs:
   build-docker-latest:
     needs: [config]
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
 
     strategy:
       matrix:

--- a/.github/workflows/test-issue-freshness.yml
+++ b/.github/workflows/test-issue-freshness.yml
@@ -13,6 +13,8 @@ on:
 jobs:
   stale:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - name: <Test> Notify inactive 必要性議論 issues
         uses: actions/stale@v9


### PR DESCRIPTION
## 内容

https://github.com/VOICEVOX/voicevox_engine/pull/1853

をrelease-0.25に適用します。

`GITHUB_TOKEN` のデフォルト権限を read-only に切り替えた影響で、0.25向けビルドに必要な書き込み権限が不足していたため、書き込みが必要な job に `permissions:` を明示します。

## 関連 Issue

ref VOICEVOX/voicevox_project#93

## その他

- 元の修正: #1853