### PR TITLE
ci: zlib ダウンロード時に SHA256 チェックサムを検証する

### DIFF
--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -150,6 +150,7 @@ jobs:
         if: steps.zlib-cache-restore.outputs.cache-hit != 'true' && matrix.zlib_url != ''
         run: |
           curl -fL --retry 3 --retry-delay 5 "${{ matrix.zlib_url }}" -o download/zlib.zip
+          echo "fd324c6923aa4f45a60413665e0b68bb34a7779d0861849e02d2711ff8efb9a4  download/zlib.zip" | sha256sum --check
           mkdir -p download/zlib
 
           # extract only dlls


### PR DESCRIPTION
## 内容

`build-engine.yml` の zlib ダウンロード処理で `zlib123dllx64.zip` を取得した後、`sha256sum --check` を追加しました。

## 関連 Issue

ref VOICEVOX/voicevox_project#94

## スクリーンショット・動画など

## その他

VOICEVOX/voicevox#2999 と同じ方針で対応しています。
この DLL の配布元 ZIP が更新される際は、チェックサムを `sha256sum` で確認して更新してください。
