### PR TITLE
<ご参考まで>ストリーミング音声合成の参考実装を追加

### DIFF
--- a/test/e2e/__snapshots__/test_openapi/test_OpenAPIの形が変わっていないことを確認.json
+++ b/test/e2e/__snapshots__/test_openapi/test_OpenAPIの形が変わっていないことを確認.json
@@ -3032,7 +3032,7 @@
             "content": {
               "multipart/mixed": {
                 "schema": {
-                  "description": "Each part body is complete WAV bytes. Part headers include X-Sequence and X-Is-Last.",
+                  "description": "Each part body is complete WAV bytes. Part headers include X-Sequence.",
                   "format": "binary",
                   "type": "string"
                 }

--- a/test/e2e/__snapshots__/test_openapi/test_OpenAPIの形が変わっていないことを確認.json
+++ b/test/e2e/__snapshots__/test_openapi/test_OpenAPIの形が変わっていないことを確認.json
@@ -2969,6 +2969,94 @@
         ]
       }
     },
+    "/streaming_synthesis": {
+      "post": {
+        "operationId": "streaming_synthesis",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "speaker",
+            "required": true,
+            "schema": {
+              "title": "Speaker",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "疑問系のテキストが与えられたら語尾を自動調整する",
+            "in": "query",
+            "name": "enable_interrogative_upspeak",
+            "required": false,
+            "schema": {
+              "default": true,
+              "description": "疑問系のテキストが与えられたら語尾を自動調整する",
+              "title": "Enable Interrogative Upspeak",
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "ストリーミング音声合成で 1 チャンクにまとめる最小アクセント句数。大きいほど初回応答は遅くなるが、チャンク境界の音質劣化を抑えやすい。",
+            "in": "query",
+            "name": "chunk_min_accent_phrases",
+            "required": false,
+            "schema": {
+              "default": 4,
+              "description": "ストリーミング音声合成で 1 チャンクにまとめる最小アクセント句数。大きいほど初回応答は遅くなるが、チャンク境界の音質劣化を抑えやすい。",
+              "minimum": 1,
+              "title": "Chunk Min Accent Phrases",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "core_version",
+            "required": false,
+            "schema": {
+              "title": "Core Version",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AudioQuery"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "multipart/mixed": {
+                "schema": {
+                  "description": "Each part body is complete WAV bytes. Part headers include X-Sequence and X-Is-Last.",
+                  "format": "binary",
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "音声合成する（ストリーミング）",
+        "tags": [
+          "音声合成"
+        ]
+      }
+    },
     "/supported_devices": {
       "get": {
         "description": "対応デバイスの一覧を取得します。",

--- a/test/e2e/single_api/tts_pipeline/__snapshots__/test_streaming_synthesis.ambr
+++ b/test/e2e/single_api/tts_pipeline/__snapshots__/test_streaming_synthesis.ambr
@@ -1,4 +1,4 @@
 # serializer version: 1
 # name: test_post_streaming_synthesis_200
-  'MD5:65ee783b124f0794ce7754e46aac1bf0'
+  'MD5:05247babe72d82b92fc649bb065ea54c'
 # ---

--- a/test/e2e/single_api/tts_pipeline/__snapshots__/test_streaming_synthesis.ambr
+++ b/test/e2e/single_api/tts_pipeline/__snapshots__/test_streaming_synthesis.ambr
@@ -1,0 +1,4 @@
+# serializer version: 1
+# name: test_post_streaming_synthesis_200
+  'MD5:f7d42ce5787856549abc3d2d7561c06f'
+# ---

--- a/test/e2e/single_api/tts_pipeline/__snapshots__/test_streaming_synthesis.ambr
+++ b/test/e2e/single_api/tts_pipeline/__snapshots__/test_streaming_synthesis.ambr
@@ -1,4 +1,4 @@
 # serializer version: 1
 # name: test_post_streaming_synthesis_200
-  'MD5:f7d42ce5787856549abc3d2d7561c06f'
+  'MD5:65ee783b124f0794ce7754e46aac1bf0'
 # ---

--- a/test/e2e/single_api/tts_pipeline/test_streaming_synthesis.py
+++ b/test/e2e/single_api/tts_pipeline/test_streaming_synthesis.py
@@ -78,7 +78,6 @@ def test_post_streaming_synthesis_200(
 
     headers, wav_bytes = parts[0]
     assert headers["x-sequence"] == "0"
-    assert headers["x-is-last"] == "true"
     assert headers["content-type"] == "audio/wav"
     assert wav_bytes.startswith(b"RIFF")
     assert snapshot == hash_wave_floats_from_wav_bytes(wav_bytes)
@@ -128,7 +127,6 @@ def test_post_streaming_synthesis_splits_by_accent_phrase(
 
     parts = _parse_multipart_response(response.headers["content-type"], response.read())
     assert [headers["x-sequence"] for headers, _wav_bytes in parts] == ["0", "1"]
-    assert [headers["x-is-last"] for headers, _wav_bytes in parts] == ["false", "true"]
 
     for _headers, wav_bytes in parts:
         assert wav_bytes.startswith(b"RIFF")
@@ -157,6 +155,18 @@ def test_post_streaming_synthesis_groups_by_chunk_min_accent_phrases(
                 "pause_mora": None,
                 "is_interrogative": False,
             },
+            {
+                "moras": [gen_mora("テ", "t", 2.3, "e", 0.8, 3.3)],
+                "accent": 1,
+                "pause_mora": None,
+                "is_interrogative": False,
+            },
+            {
+                "moras": [gen_mora("ス", "s", 2.1, "U", 0.3, 0.0)],
+                "accent": 1,
+                "pause_mora": None,
+                "is_interrogative": False,
+            },
         ],
         "speedScale": 1.0,
         "pitchScale": 1.0,
@@ -179,7 +189,6 @@ def test_post_streaming_synthesis_groups_by_chunk_min_accent_phrases(
 
     parts = _parse_multipart_response(response.headers["content-type"], response.read())
     assert [headers["x-sequence"] for headers, _wav_bytes in parts] == ["0", "1"]
-    assert [headers["x-is-last"] for headers, _wav_bytes in parts] == ["false", "true"]
 
     for _headers, wav_bytes in parts:
         assert wav_bytes.startswith(b"RIFF")
@@ -214,6 +223,5 @@ def test_post_streaming_synthesis_empty_accent_phrases(
 
     headers, wav_bytes = parts[0]
     assert headers["x-sequence"] == "0"
-    assert headers["x-is-last"] == "true"
     assert headers["content-type"] == "audio/wav"
     assert wav_bytes.startswith(b"RIFF")

--- a/test/e2e/single_api/tts_pipeline/test_streaming_synthesis.py
+++ b/test/e2e/single_api/tts_pipeline/test_streaming_synthesis.py
@@ -1,0 +1,134 @@
+"""/streaming_synthesis API のテスト。"""
+
+from fastapi.testclient import TestClient
+from syrupy.assertion import SnapshotAssertion
+
+from test.e2e.single_api.utils import gen_mora
+from test.utility import hash_wave_floats_from_wav_bytes
+
+
+def _parse_multipart_response(
+    content_type: str, body: bytes
+) -> list[tuple[dict[str, str], bytes]]:
+    boundary = content_type.split("boundary=", maxsplit=1)[1].strip('"')
+    boundary_line = f"--{boundary}\r\n".encode("ascii")
+    closing_boundary_line = f"--{boundary}--\r\n".encode("ascii")
+    parts: list[tuple[dict[str, str], bytes]] = []
+    cursor = 0
+
+    while True:
+        if body[cursor:].startswith(closing_boundary_line):
+            return parts
+
+        assert body[cursor:].startswith(boundary_line)
+        cursor += len(boundary_line)
+
+        header_end = body.index(b"\r\n\r\n", cursor)
+        header_lines = body[cursor:header_end].decode("ascii").split("\r\n")
+        headers: dict[str, str] = {}
+        for line in header_lines:
+            key, value = line.split(":", maxsplit=1)
+            headers[key.lower()] = value.strip()
+
+        content_length = int(headers["content-length"])
+        body_start = header_end + len(b"\r\n\r\n")
+        body_end = body_start + content_length
+        parts.append((headers, body[body_start:body_end]))
+        cursor = body_end + len(b"\r\n")
+
+
+def test_post_streaming_synthesis_200(
+    client: TestClient, snapshot: SnapshotAssertion
+) -> None:
+    query = {
+        "accent_phrases": [
+            {
+                "moras": [
+                    gen_mora("テ", "t", 2.3, "e", 0.8, 3.3),
+                    gen_mora("ス", "s", 2.1, "U", 0.3, 0.0),
+                    gen_mora("ト", "t", 2.3, "o", 1.8, 4.1),
+                ],
+                "accent": 1,
+                "pause_mora": None,
+                "is_interrogative": False,
+            }
+        ],
+        "speedScale": 1.0,
+        "pitchScale": 1.0,
+        "intonationScale": 1.0,
+        "volumeScale": 1.0,
+        "prePhonemeLength": 0.1,
+        "postPhonemeLength": 0.1,
+        "pauseLength": None,
+        "pauseLengthScale": 1.0,
+        "outputSamplingRate": 24000,
+        "outputStereo": False,
+        "kana": "テ'_スト",
+    }
+    response = client.post(
+        "/streaming_synthesis",
+        params={"speaker": 0, "chunk_min_accent_phrases": 1},
+        json=query,
+    )
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("multipart/mixed")
+
+    parts = _parse_multipart_response(response.headers["content-type"], response.read())
+    assert len(parts) == 1
+
+    headers, wav_bytes = parts[0]
+    assert headers["x-sequence"] == "0"
+    assert headers["x-is-last"] == "true"
+    assert headers["content-type"] == "audio/wav"
+    assert wav_bytes.startswith(b"RIFF")
+    assert snapshot == hash_wave_floats_from_wav_bytes(wav_bytes)
+
+
+def test_post_streaming_synthesis_splits_by_accent_phrase(
+    client: TestClient,
+) -> None:
+    query = {
+        "accent_phrases": [
+            {
+                "moras": [
+                    gen_mora("テ", "t", 2.3, "e", 0.8, 3.3),
+                ],
+                "accent": 1,
+                "pause_mora": gen_mora("、", None, None, "pau", 0.3, 0.0),
+                "is_interrogative": False,
+            },
+            {
+                "moras": [
+                    gen_mora("ス", "s", 2.1, "U", 0.3, 0.0),
+                    gen_mora("ト", "t", 2.3, "o", 1.8, 4.1),
+                ],
+                "accent": 1,
+                "pause_mora": None,
+                "is_interrogative": False,
+            },
+        ],
+        "speedScale": 1.0,
+        "pitchScale": 1.0,
+        "intonationScale": 1.0,
+        "volumeScale": 1.0,
+        "prePhonemeLength": 0.1,
+        "postPhonemeLength": 0.1,
+        "pauseLength": None,
+        "pauseLengthScale": 1.0,
+        "outputSamplingRate": 24000,
+        "outputStereo": False,
+        "kana": "テ'、ス'_ト",
+    }
+    response = client.post(
+        "/streaming_synthesis",
+        params={"speaker": 0, "chunk_min_accent_phrases": 1},
+        json=query,
+    )
+    assert response.status_code == 200
+
+    parts = _parse_multipart_response(response.headers["content-type"], response.read())
+    assert [headers["x-sequence"] for headers, _wav_bytes in parts] == ["0", "1"]
+    assert [headers["x-is-last"] for headers, _wav_bytes in parts] == ["false", "true"]
+
+    for _headers, wav_bytes in parts:
+        assert wav_bytes.startswith(b"RIFF")

--- a/test/e2e/single_api/tts_pipeline/test_streaming_synthesis.py
+++ b/test/e2e/single_api/tts_pipeline/test_streaming_synthesis.py
@@ -132,3 +132,37 @@ def test_post_streaming_synthesis_splits_by_accent_phrase(
 
     for _headers, wav_bytes in parts:
         assert wav_bytes.startswith(b"RIFF")
+
+
+def test_post_streaming_synthesis_empty_accent_phrases(
+    client: TestClient,
+) -> None:
+    query = {
+        "accent_phrases": [],
+        "speedScale": 1.0,
+        "pitchScale": 1.0,
+        "intonationScale": 1.0,
+        "volumeScale": 1.0,
+        "prePhonemeLength": 0.1,
+        "postPhonemeLength": 0.1,
+        "pauseLength": None,
+        "pauseLengthScale": 1.0,
+        "outputSamplingRate": 24000,
+        "outputStereo": False,
+        "kana": "",
+    }
+    response = client.post(
+        "/streaming_synthesis",
+        params={"speaker": 0, "chunk_min_accent_phrases": 1},
+        json=query,
+    )
+    assert response.status_code == 200
+
+    parts = _parse_multipart_response(response.headers["content-type"], response.read())
+    assert len(parts) == 1
+
+    headers, wav_bytes = parts[0]
+    assert headers["x-sequence"] == "0"
+    assert headers["x-is-last"] == "true"
+    assert headers["content-type"] == "audio/wav"
+    assert wav_bytes.startswith(b"RIFF")

--- a/test/e2e/single_api/tts_pipeline/test_streaming_synthesis.py
+++ b/test/e2e/single_api/tts_pipeline/test_streaming_synthesis.py
@@ -134,6 +134,57 @@ def test_post_streaming_synthesis_splits_by_accent_phrase(
         assert wav_bytes.startswith(b"RIFF")
 
 
+def test_post_streaming_synthesis_groups_by_chunk_min_accent_phrases(
+    client: TestClient,
+) -> None:
+    query = {
+        "accent_phrases": [
+            {
+                "moras": [gen_mora("テ", "t", 2.3, "e", 0.8, 3.3)],
+                "accent": 1,
+                "pause_mora": None,
+                "is_interrogative": False,
+            },
+            {
+                "moras": [gen_mora("ス", "s", 2.1, "U", 0.3, 0.0)],
+                "accent": 1,
+                "pause_mora": None,
+                "is_interrogative": False,
+            },
+            {
+                "moras": [gen_mora("ト", "t", 2.3, "o", 1.8, 4.1)],
+                "accent": 1,
+                "pause_mora": None,
+                "is_interrogative": False,
+            },
+        ],
+        "speedScale": 1.0,
+        "pitchScale": 1.0,
+        "intonationScale": 1.0,
+        "volumeScale": 1.0,
+        "prePhonemeLength": 0.1,
+        "postPhonemeLength": 0.1,
+        "pauseLength": None,
+        "pauseLengthScale": 1.0,
+        "outputSamplingRate": 24000,
+        "outputStereo": False,
+        "kana": "テ'/ス'_ト",
+    }
+    response = client.post(
+        "/streaming_synthesis",
+        params={"speaker": 0, "chunk_min_accent_phrases": 2},
+        json=query,
+    )
+    assert response.status_code == 200
+
+    parts = _parse_multipart_response(response.headers["content-type"], response.read())
+    assert [headers["x-sequence"] for headers, _wav_bytes in parts] == ["0", "1"]
+    assert [headers["x-is-last"] for headers, _wav_bytes in parts] == ["false", "true"]
+
+    for _headers, wav_bytes in parts:
+        assert wav_bytes.startswith(b"RIFF")
+
+
 def test_post_streaming_synthesis_empty_accent_phrases(
     client: TestClient,
 ) -> None:

--- a/test/unit/tts_pipeline/test_tts_engine.py
+++ b/test/unit/tts_pipeline/test_tts_engine.py
@@ -242,6 +242,52 @@ def test_synthesize_wave_chunks_decodes_lazily() -> None:
     assert core.decode_forward.call_count == 2
 
 
+def test_synthesize_wave_chunks_skips_empty_accent_phrase_chunks() -> None:
+    core = MockCoreWrapper()
+    core.decode_forward = MagicMock(wraps=core.decode_forward)  # type: ignore[method-assign]
+    tts_engine = TTSEngine(core=core)
+    query = _gen_hello_hiho_query()
+    query.accent_phrases = [
+        query.accent_phrases[0],
+        AccentPhrase(moras=[], accent=1),
+        query.accent_phrases[1],
+    ]
+
+    chunks = list(
+        tts_engine.synthesize_wave_chunks(
+            query,
+            StyleId(1),
+            enable_interrogative_upspeak=True,
+            min_accent_phrases=1,
+        )
+    )
+
+    assert len(chunks) == 2
+    assert all(chunk.size > 0 for chunk in chunks)
+    assert core.decode_forward.call_count == 2
+
+
+def test_synthesize_wave_chunks_handles_all_empty_accent_phrases() -> None:
+    core = MockCoreWrapper()
+    core.decode_forward = MagicMock(wraps=core.decode_forward)  # type: ignore[method-assign]
+    tts_engine = TTSEngine(core=core)
+    query = _gen_hello_hiho_query()
+    query.accent_phrases = [AccentPhrase(moras=[], accent=1)]
+
+    chunks = list(
+        tts_engine.synthesize_wave_chunks(
+            query,
+            StyleId(1),
+            enable_interrogative_upspeak=True,
+            min_accent_phrases=1,
+        )
+    )
+
+    assert len(chunks) == 1
+    assert chunks[0].size > 0
+    assert core.decode_forward.call_count == 1
+
+
 def test_mocked_update_length_and_pitch_output(
     snapshot_json: SnapshotAssertion,
 ) -> None:

--- a/test/unit/tts_pipeline/test_tts_engine.py
+++ b/test/unit/tts_pipeline/test_tts_engine.py
@@ -221,6 +221,27 @@ def test_mocked_update_pitch_output(snapshot_json: SnapshotAssertion) -> None:
     assert snapshot_json == round_floats(pydantic_to_native_type(result), round_value=2)
 
 
+def test_synthesize_wave_chunks_decodes_lazily() -> None:
+    core = MockCoreWrapper()
+    core.decode_forward = MagicMock(wraps=core.decode_forward)  # type: ignore[method-assign]
+    tts_engine = TTSEngine(core=core)
+
+    chunks = tts_engine.synthesize_wave_chunks(
+        _gen_hello_hiho_query(),
+        StyleId(1),
+        enable_interrogative_upspeak=True,
+        min_accent_phrases=1,
+    )
+
+    first_chunk = next(chunks)
+    assert first_chunk.size > 0
+    assert core.decode_forward.call_count == 1
+
+    second_chunk = next(chunks)
+    assert second_chunk.size > 0
+    assert core.decode_forward.call_count == 2
+
+
 def test_mocked_update_length_and_pitch_output(
     snapshot_json: SnapshotAssertion,
 ) -> None:

--- a/voicevox_engine/app/routers/tts_pipeline.py
+++ b/voicevox_engine/app/routers/tts_pipeline.py
@@ -2,10 +2,11 @@
 
 import zipfile
 from collections.abc import Iterator
+from io import BytesIO
 from secrets import token_hex
 from tempfile import NamedTemporaryFile, TemporaryFile
 from traceback import print_exception
-from typing import Annotated, BinaryIO, Self
+from typing import Annotated, Self
 
 import numpy as np
 import soundfile
@@ -96,79 +97,44 @@ def generate_tts_pipeline_router(
     router = APIRouter()
     streaming_wav_file_read_size = 64 * 1024
 
-    def wave_to_wav_file(
+    def wave_to_wav_buffer(
         wave: NDArray[np.float32], sampling_rate: int
-    ) -> tuple[BinaryIO, int]:
-        """波形を complete WAV file に変換する。"""
-        wav_file = TemporaryFile()
+    ) -> tuple[BytesIO, int]:
+        """波形を complete WAV buffer に変換する。"""
+        wav_buffer = BytesIO()
         try:
             soundfile.write(
-                file=wav_file,
+                file=wav_buffer,
                 data=wave,
                 samplerate=sampling_rate,
                 format="WAV",
             )
-            wav_file.flush()
-            content_length = wav_file.tell()
-            wav_file.seek(0)
-            return wav_file, content_length
+            wav_buffer.flush()
+            content_length = wav_buffer.tell()
+            wav_buffer.seek(0)
+            return wav_buffer, content_length
         except Exception:
-            wav_file.close()
+            wav_buffer.close()
             raise
 
     def make_streaming_audio_chunk_parts(
-        wav_files_iter: Iterator[tuple[BinaryIO, int]], boundary: str
+        wav_buffers_iter: Iterator[tuple[BytesIO, int]], boundary: str
     ) -> Iterator[bytes]:
-        """complete WAV file の列を multipart/mixed として返す。"""
-        wav_files_iterator = iter(wav_files_iter)
-        try:
-            current_wav_file, content_length = next(wav_files_iterator)
-        except StopIteration:
-            yield f"--{boundary}--\r\n".encode("ascii")
-            return
-
-        sequence = 0
-        next_wav_file: BinaryIO | None = None
-        try:
-            while True:
-                if current_wav_file is None:
-                    raise RuntimeError("Current WAV file is unexpectedly closed.")
-                try:
-                    next_wav_file, next_content_length = next(wav_files_iterator)
-                    is_last = "false"
-                except StopIteration:
-                    next_wav_file = None
-                    next_content_length = 0
-                    is_last = "true"
-
-                yield (
-                    f"--{boundary}\r\n"
-                    "Content-Type: audio/wav\r\n"
-                    f"X-Sequence: {sequence}\r\n"
-                    f"X-Is-Last: {is_last}\r\n"
-                    f"Content-Length: {content_length}\r\n"
-                    "\r\n"
-                ).encode("ascii")
-                try:
-                    while chunk := current_wav_file.read(streaming_wav_file_read_size):
-                        yield chunk
-                finally:
-                    current_wav_file.close()
-                    current_wav_file = None
-                yield b"\r\n"
-
-                if next_wav_file is None:
-                    break
-
-                current_wav_file = next_wav_file
-                content_length = next_content_length
-                next_wav_file = None
-                sequence += 1
-        finally:
-            if current_wav_file is not None:
-                current_wav_file.close()
-            if next_wav_file is not None:
-                next_wav_file.close()
+        """complete WAV buffer の列を multipart/mixed として返す。"""
+        for sequence, (wav_buffer, content_length) in enumerate(wav_buffers_iter):
+            yield (
+                f"--{boundary}\r\n"
+                "Content-Type: audio/wav\r\n"
+                f"X-Sequence: {sequence}\r\n"
+                f"Content-Length: {content_length}\r\n"
+                "\r\n"
+            ).encode("ascii")
+            try:
+                while chunk := wav_buffer.read(streaming_wav_file_read_size):
+                    yield chunk
+            finally:
+                wav_buffer.close()
+            yield b"\r\n"
 
         yield f"--{boundary}--\r\n".encode("ascii")
 
@@ -387,7 +353,7 @@ def generate_tts_pipeline_router(
                         "schema": {
                             "type": "string",
                             "format": "binary",
-                            "description": "Each part body is complete WAV bytes. Part headers include X-Sequence and X-Is-Last.",
+                            "description": "Each part body is complete WAV bytes. Part headers include X-Sequence.",
                         }
                     }
                 },
@@ -418,8 +384,8 @@ def generate_tts_pipeline_router(
         engine = tts_engines.get_tts_engine(version)
         boundary = f"voicevox-{token_hex(16)}"
 
-        wav_files_iter = (
-            wave_to_wav_file(wave, query.outputSamplingRate)
+        wav_buffers_iter = (
+            wave_to_wav_buffer(wave, query.outputSamplingRate)
             for wave in engine.synthesize_wave_chunks(
                 query,
                 style_id,
@@ -430,7 +396,7 @@ def generate_tts_pipeline_router(
 
         return StreamingResponse(
             make_streaming_audio_chunk_parts(
-                wav_files_iter,
+                wav_buffers_iter,
                 boundary=boundary,
             ),
             media_type=f"multipart/mixed; boundary={boundary}",

--- a/voicevox_engine/app/routers/tts_pipeline.py
+++ b/voicevox_engine/app/routers/tts_pipeline.py
@@ -1,6 +1,9 @@
 """音声合成機能を提供する API Router"""
 
 import zipfile
+from collections.abc import Iterator
+from io import BytesIO
+from math import ceil
 from tempfile import NamedTemporaryFile, TemporaryFile
 from traceback import print_exception
 from typing import Annotated, Self
@@ -10,7 +13,7 @@ from fastapi import APIRouter, HTTPException, Query, Request
 from pydantic import BaseModel, Field
 from pydantic.json_schema import SkipJsonSchema
 from starlette.background import BackgroundTask
-from starlette.responses import FileResponse
+from starlette.responses import FileResponse, StreamingResponse
 
 from voicevox_engine.cancellable_engine import (
     CancellableEngine,
@@ -90,6 +93,32 @@ def generate_tts_pipeline_router(
 ) -> APIRouter:
     """音声合成 API Router を生成する"""
     router = APIRouter()
+    streaming_synthesis_boundary = "voicevox-stream-boundary"
+
+    def wave_to_wav_bytes(wave: object, sampling_rate: int) -> bytes:
+        """波形を complete WAV bytes に変換する。"""
+        wav_file = BytesIO()
+        soundfile.write(file=wav_file, data=wave, samplerate=sampling_rate, format="WAV")
+        return wav_file.getvalue()
+
+    def make_streaming_audio_chunk_parts(
+        wav_bytes_iter: Iterator[bytes], total_chunks: int
+    ) -> Iterator[bytes]:
+        """complete WAV bytes の列を multipart/mixed として返す。"""
+        for sequence, wav_bytes in enumerate(wav_bytes_iter):
+            is_last = "true" if sequence == total_chunks - 1 else "false"
+            yield (
+                f"--{streaming_synthesis_boundary}\r\n"
+                "Content-Type: audio/wav\r\n"
+                f"X-Sequence: {sequence}\r\n"
+                f"X-Is-Last: {is_last}\r\n"
+                f"Content-Length: {len(wav_bytes)}\r\n"
+                "\r\n"
+            ).encode("ascii")
+            yield wav_bytes
+            yield b"\r\n"
+
+        yield f"--{streaming_synthesis_boundary}--\r\n".encode("ascii")
 
     @router.post(
         "/audio_query",
@@ -294,6 +323,68 @@ def generate_tts_pipeline_router(
             f.name,
             media_type="audio/wav",
             background=BackgroundTask(try_delete_file, f.name),
+        )
+
+    @router.post(
+        "/streaming_synthesis",
+        response_class=StreamingResponse,
+        responses={
+            200: {
+                "content": {
+                    "multipart/mixed": {
+                        "schema": {
+                            "type": "string",
+                            "format": "binary",
+                            "description": "Each part body is complete WAV bytes. Part headers include X-Sequence and X-Is-Last.",
+                        }
+                    }
+                },
+            }
+        },
+        tags=["音声合成"],
+        summary="音声合成する（ストリーミング）",
+    )
+    def streaming_synthesis(
+        query: AudioQuery,
+        style_id: Annotated[StyleId, Query(alias="speaker")],
+        enable_interrogative_upspeak: Annotated[
+            bool,
+            Query(
+                description="疑問系のテキストが与えられたら語尾を自動調整する",
+            ),
+        ] = True,
+        chunk_min_accent_phrases: Annotated[
+            int,
+            Query(
+                ge=1,
+                description="ストリーミング音声合成で 1 チャンクにまとめる最小アクセント句数。大きいほど初回応答は遅くなるが、チャンク境界の音質劣化を抑えやすい。",
+            ),
+        ] = 4,
+        core_version: str | SkipJsonSchema[None] = None,
+    ) -> StreamingResponse:
+        version = core_version or LATEST_VERSION
+        engine = tts_engines.get_tts_engine(version)
+        total_chunks = max(
+            1,
+            ceil(len(query.accent_phrases) / chunk_min_accent_phrases),
+        )
+
+        wav_bytes_iter = (
+            wave_to_wav_bytes(wave, query.outputSamplingRate)
+            for wave in engine.synthesize_wave_chunks(
+                query,
+                style_id,
+                enable_interrogative_upspeak=enable_interrogative_upspeak,
+                min_accent_phrases=chunk_min_accent_phrases,
+            )
+        )
+
+        return StreamingResponse(
+            make_streaming_audio_chunk_parts(
+                wav_bytes_iter,
+                total_chunks=total_chunks,
+            ),
+            media_type=f"multipart/mixed; boundary={streaming_synthesis_boundary}",
         )
 
     @router.post(

--- a/voicevox_engine/app/routers/tts_pipeline.py
+++ b/voicevox_engine/app/routers/tts_pipeline.py
@@ -2,11 +2,10 @@
 
 import zipfile
 from collections.abc import Iterator
-from io import BytesIO
 from secrets import token_hex
 from tempfile import NamedTemporaryFile, TemporaryFile
 from traceback import print_exception
-from typing import Annotated, Self
+from typing import Annotated, BinaryIO, Self
 
 import soundfile
 from fastapi import APIRouter, HTTPException, Query, Request
@@ -93,20 +92,23 @@ def generate_tts_pipeline_router(
 ) -> APIRouter:
     """音声合成 API Router を生成する"""
     router = APIRouter()
+    streaming_wav_file_read_size = 64 * 1024
 
-    def wave_to_wav_bytes(wave: object, sampling_rate: int) -> bytes:
-        """波形を complete WAV bytes に変換する。"""
-        wav_file = BytesIO()
+    def wave_to_wav_file(wave: object, sampling_rate: int) -> tuple[BinaryIO, int]:
+        """波形を complete WAV file に変換する。"""
+        wav_file = TemporaryFile()
         soundfile.write(file=wav_file, data=wave, samplerate=sampling_rate, format="WAV")
-        return wav_file.getvalue()
+        content_length = wav_file.tell()
+        wav_file.seek(0)
+        return wav_file, content_length
 
     def make_streaming_audio_chunk_parts(
-        wav_bytes_iter: Iterator[bytes], boundary: str
+        wav_files_iter: Iterator[tuple[BinaryIO, int]], boundary: str
     ) -> Iterator[bytes]:
-        """complete WAV bytes の列を multipart/mixed として返す。"""
-        wav_bytes_iterator = iter(wav_bytes_iter)
+        """complete WAV file の列を multipart/mixed として返す。"""
+        wav_files_iterator = iter(wav_files_iter)
         try:
-            wav_bytes = next(wav_bytes_iterator)
+            wav_file, content_length = next(wav_files_iterator)
         except StopIteration:
             yield f"--{boundary}--\r\n".encode("ascii")
             return
@@ -114,10 +116,11 @@ def generate_tts_pipeline_router(
         sequence = 0
         while True:
             try:
-                next_wav_bytes = next(wav_bytes_iterator)
+                next_wav_file, next_content_length = next(wav_files_iterator)
                 is_last = "false"
             except StopIteration:
-                next_wav_bytes = None
+                next_wav_file = None
+                next_content_length = 0
                 is_last = "true"
 
             yield (
@@ -125,16 +128,21 @@ def generate_tts_pipeline_router(
                 "Content-Type: audio/wav\r\n"
                 f"X-Sequence: {sequence}\r\n"
                 f"X-Is-Last: {is_last}\r\n"
-                f"Content-Length: {len(wav_bytes)}\r\n"
+                f"Content-Length: {content_length}\r\n"
                 "\r\n"
             ).encode("ascii")
-            yield wav_bytes
+            try:
+                while chunk := wav_file.read(streaming_wav_file_read_size):
+                    yield chunk
+            finally:
+                wav_file.close()
             yield b"\r\n"
 
-            if next_wav_bytes is None:
+            if next_wav_file is None:
                 break
 
-            wav_bytes = next_wav_bytes
+            wav_file = next_wav_file
+            content_length = next_content_length
             sequence += 1
 
         yield f"--{boundary}--\r\n".encode("ascii")
@@ -385,8 +393,8 @@ def generate_tts_pipeline_router(
         engine = tts_engines.get_tts_engine(version)
         boundary = f"voicevox-{token_hex(16)}"
 
-        wav_bytes_iter = (
-            wave_to_wav_bytes(wave, query.outputSamplingRate)
+        wav_files_iter = (
+            wave_to_wav_file(wave, query.outputSamplingRate)
             for wave in engine.synthesize_wave_chunks(
                 query,
                 style_id,
@@ -397,7 +405,7 @@ def generate_tts_pipeline_router(
 
         return StreamingResponse(
             make_streaming_audio_chunk_parts(
-                wav_bytes_iter,
+                wav_files_iter,
                 boundary=boundary,
             ),
             media_type=f"multipart/mixed; boundary={boundary}",

--- a/voicevox_engine/app/routers/tts_pipeline.py
+++ b/voicevox_engine/app/routers/tts_pipeline.py
@@ -114,36 +114,43 @@ def generate_tts_pipeline_router(
             return
 
         sequence = 0
-        while True:
-            try:
-                next_wav_file, next_content_length = next(wav_files_iterator)
-                is_last = "false"
-            except StopIteration:
+        next_wav_file: BinaryIO | None = None
+        try:
+            while True:
+                try:
+                    next_wav_file, next_content_length = next(wav_files_iterator)
+                    is_last = "false"
+                except StopIteration:
+                    next_wav_file = None
+                    next_content_length = 0
+                    is_last = "true"
+
+                yield (
+                    f"--{boundary}\r\n"
+                    "Content-Type: audio/wav\r\n"
+                    f"X-Sequence: {sequence}\r\n"
+                    f"X-Is-Last: {is_last}\r\n"
+                    f"Content-Length: {content_length}\r\n"
+                    "\r\n"
+                ).encode("ascii")
+                try:
+                    while chunk := wav_file.read(streaming_wav_file_read_size):
+                        yield chunk
+                finally:
+                    wav_file.close()
+                yield b"\r\n"
+
+                if next_wav_file is None:
+                    break
+
+                wav_file = next_wav_file
+                content_length = next_content_length
                 next_wav_file = None
-                next_content_length = 0
-                is_last = "true"
-
-            yield (
-                f"--{boundary}\r\n"
-                "Content-Type: audio/wav\r\n"
-                f"X-Sequence: {sequence}\r\n"
-                f"X-Is-Last: {is_last}\r\n"
-                f"Content-Length: {content_length}\r\n"
-                "\r\n"
-            ).encode("ascii")
-            try:
-                while chunk := wav_file.read(streaming_wav_file_read_size):
-                    yield chunk
-            finally:
-                wav_file.close()
-            yield b"\r\n"
-
-            if next_wav_file is None:
-                break
-
-            wav_file = next_wav_file
-            content_length = next_content_length
-            sequence += 1
+                sequence += 1
+        finally:
+            wav_file.close()
+            if next_wav_file is not None:
+                next_wav_file.close()
 
         yield f"--{boundary}--\r\n".encode("ascii")
 

--- a/voicevox_engine/app/routers/tts_pipeline.py
+++ b/voicevox_engine/app/routers/tts_pipeline.py
@@ -7,8 +7,10 @@ from tempfile import NamedTemporaryFile, TemporaryFile
 from traceback import print_exception
 from typing import Annotated, BinaryIO, Self
 
+import numpy as np
 import soundfile
 from fastapi import APIRouter, HTTPException, Query, Request
+from numpy.typing import NDArray
 from pydantic import BaseModel, Field
 from pydantic.json_schema import SkipJsonSchema
 from starlette.background import BackgroundTask
@@ -94,10 +96,13 @@ def generate_tts_pipeline_router(
     router = APIRouter()
     streaming_wav_file_read_size = 64 * 1024
 
-    def wave_to_wav_file(wave: object, sampling_rate: int) -> tuple[BinaryIO, int]:
+    def wave_to_wav_file(
+        wave: NDArray[np.float32], sampling_rate: int
+    ) -> tuple[BinaryIO, int]:
         """波形を complete WAV file に変換する。"""
         wav_file = TemporaryFile()
         soundfile.write(file=wav_file, data=wave, samplerate=sampling_rate, format="WAV")
+        wav_file.flush()
         content_length = wav_file.tell()
         wav_file.seek(0)
         return wav_file, content_length
@@ -108,7 +113,7 @@ def generate_tts_pipeline_router(
         """complete WAV file の列を multipart/mixed として返す。"""
         wav_files_iterator = iter(wav_files_iter)
         try:
-            wav_file, content_length = next(wav_files_iterator)
+            current_wav_file, content_length = next(wav_files_iterator)
         except StopIteration:
             yield f"--{boundary}--\r\n".encode("ascii")
             return
@@ -117,6 +122,7 @@ def generate_tts_pipeline_router(
         next_wav_file: BinaryIO | None = None
         try:
             while True:
+                assert current_wav_file is not None
                 try:
                     next_wav_file, next_content_length = next(wav_files_iterator)
                     is_last = "false"
@@ -134,21 +140,23 @@ def generate_tts_pipeline_router(
                     "\r\n"
                 ).encode("ascii")
                 try:
-                    while chunk := wav_file.read(streaming_wav_file_read_size):
+                    while chunk := current_wav_file.read(streaming_wav_file_read_size):
                         yield chunk
                 finally:
-                    wav_file.close()
+                    current_wav_file.close()
+                    current_wav_file = None
                 yield b"\r\n"
 
                 if next_wav_file is None:
                     break
 
-                wav_file = next_wav_file
+                current_wav_file = next_wav_file
                 content_length = next_content_length
                 next_wav_file = None
                 sequence += 1
         finally:
-            wav_file.close()
+            if current_wav_file is not None:
+                current_wav_file.close()
             if next_wav_file is not None:
                 next_wav_file.close()
 

--- a/voicevox_engine/app/routers/tts_pipeline.py
+++ b/voicevox_engine/app/routers/tts_pipeline.py
@@ -3,7 +3,7 @@
 import zipfile
 from collections.abc import Iterator
 from io import BytesIO
-from math import ceil
+from secrets import token_hex
 from tempfile import NamedTemporaryFile, TemporaryFile
 from traceback import print_exception
 from typing import Annotated, Self
@@ -93,7 +93,6 @@ def generate_tts_pipeline_router(
 ) -> APIRouter:
     """音声合成 API Router を生成する"""
     router = APIRouter()
-    streaming_synthesis_boundary = "voicevox-stream-boundary"
 
     def wave_to_wav_bytes(wave: object, sampling_rate: int) -> bytes:
         """波形を complete WAV bytes に変換する。"""
@@ -102,13 +101,27 @@ def generate_tts_pipeline_router(
         return wav_file.getvalue()
 
     def make_streaming_audio_chunk_parts(
-        wav_bytes_iter: Iterator[bytes], total_chunks: int
+        wav_bytes_iter: Iterator[bytes], boundary: str
     ) -> Iterator[bytes]:
         """complete WAV bytes の列を multipart/mixed として返す。"""
-        for sequence, wav_bytes in enumerate(wav_bytes_iter):
-            is_last = "true" if sequence == total_chunks - 1 else "false"
+        wav_bytes_iterator = iter(wav_bytes_iter)
+        try:
+            wav_bytes = next(wav_bytes_iterator)
+        except StopIteration:
+            yield f"--{boundary}--\r\n".encode("ascii")
+            return
+
+        sequence = 0
+        while True:
+            try:
+                next_wav_bytes = next(wav_bytes_iterator)
+                is_last = "false"
+            except StopIteration:
+                next_wav_bytes = None
+                is_last = "true"
+
             yield (
-                f"--{streaming_synthesis_boundary}\r\n"
+                f"--{boundary}\r\n"
                 "Content-Type: audio/wav\r\n"
                 f"X-Sequence: {sequence}\r\n"
                 f"X-Is-Last: {is_last}\r\n"
@@ -118,7 +131,13 @@ def generate_tts_pipeline_router(
             yield wav_bytes
             yield b"\r\n"
 
-        yield f"--{streaming_synthesis_boundary}--\r\n".encode("ascii")
+            if next_wav_bytes is None:
+                break
+
+            wav_bytes = next_wav_bytes
+            sequence += 1
+
+        yield f"--{boundary}--\r\n".encode("ascii")
 
     @router.post(
         "/audio_query",
@@ -364,10 +383,7 @@ def generate_tts_pipeline_router(
     ) -> StreamingResponse:
         version = core_version or LATEST_VERSION
         engine = tts_engines.get_tts_engine(version)
-        total_chunks = max(
-            1,
-            ceil(len(query.accent_phrases) / chunk_min_accent_phrases),
-        )
+        boundary = f"voicevox-{token_hex(16)}"
 
         wav_bytes_iter = (
             wave_to_wav_bytes(wave, query.outputSamplingRate)
@@ -382,9 +398,9 @@ def generate_tts_pipeline_router(
         return StreamingResponse(
             make_streaming_audio_chunk_parts(
                 wav_bytes_iter,
-                total_chunks=total_chunks,
+                boundary=boundary,
             ),
-            media_type=f"multipart/mixed; boundary={streaming_synthesis_boundary}",
+            media_type=f"multipart/mixed; boundary={boundary}",
         )
 
     @router.post(

--- a/voicevox_engine/app/routers/tts_pipeline.py
+++ b/voicevox_engine/app/routers/tts_pipeline.py
@@ -101,11 +101,20 @@ def generate_tts_pipeline_router(
     ) -> tuple[BinaryIO, int]:
         """波形を complete WAV file に変換する。"""
         wav_file = TemporaryFile()
-        soundfile.write(file=wav_file, data=wave, samplerate=sampling_rate, format="WAV")
-        wav_file.flush()
-        content_length = wav_file.tell()
-        wav_file.seek(0)
-        return wav_file, content_length
+        try:
+            soundfile.write(
+                file=wav_file,
+                data=wave,
+                samplerate=sampling_rate,
+                format="WAV",
+            )
+            wav_file.flush()
+            content_length = wav_file.tell()
+            wav_file.seek(0)
+            return wav_file, content_length
+        except Exception:
+            wav_file.close()
+            raise
 
     def make_streaming_audio_chunk_parts(
         wav_files_iter: Iterator[tuple[BinaryIO, int]], boundary: str
@@ -122,7 +131,8 @@ def generate_tts_pipeline_router(
         next_wav_file: BinaryIO | None = None
         try:
             while True:
-                assert current_wav_file is not None
+                if current_wav_file is None:
+                    raise RuntimeError("Current WAV file is unexpectedly closed.")
                 try:
                     next_wav_file, next_content_length = next(wav_files_iterator)
                     is_last = "false"

--- a/voicevox_engine/dev/tts_engine/mock.py
+++ b/voicevox_engine/dev/tts_engine/mock.py
@@ -1,6 +1,7 @@
 """TTSEngine のモック"""
 
 import copy
+from collections.abc import Iterator
 from typing import Final
 
 import numpy as np
@@ -43,6 +44,25 @@ class MockTTSEngine(TTSEngine):
         raw_wave, sr_raw_wave = self.forward(kana_text)
         wave = raw_wave_to_output_wave(query, raw_wave, sr_raw_wave)
         return wave
+
+    def synthesize_wave_chunks(
+        self,
+        query: AudioQuery,
+        style_id: StyleId,
+        enable_interrogative_upspeak: bool,
+        min_accent_phrases: int = 4,
+    ) -> Iterator[NDArray[np.float32]]:
+        """音声合成用のクエリに含まれる読み仮名を複数アクセント句ごとに音声波形へ変換する。"""
+        self._core._assert_style_supports_feature(style_id, "talk")
+        query = copy.deepcopy(query)
+
+        min_accent_phrases = max(1, min_accent_phrases)
+        for start in range(0, len(query.accent_phrases), min_accent_phrases):
+            accent_phrases = query.accent_phrases[start : start + min_accent_phrases]
+            flatten_moras = to_flatten_moras(accent_phrases)
+            kana_text = "".join([mora.text for mora in flatten_moras])
+            raw_wave, sr_raw_wave = self.forward(kana_text)
+            yield raw_wave_to_output_wave(query, raw_wave, sr_raw_wave)
 
     def forward(self, text: str) -> tuple[NDArray[np.float32], int]:
         """文字列から pyopenjtalk を用いて音声を合成する。"""

--- a/voicevox_engine/dev/tts_engine/mock.py
+++ b/voicevox_engine/dev/tts_engine/mock.py
@@ -69,19 +69,28 @@ class MockTTSEngine(TTSEngine):
             return
 
         min_accent_phrases = max(1, min_accent_phrases)
-        chunk_starts = list(range(0, len(query.accent_phrases), min_accent_phrases))
-        for start in chunk_starts:
-            accent_phrases = query.accent_phrases[start : start + min_accent_phrases]
+        chunk_accent_phrases_list = [
+            query.accent_phrases[start : start + min_accent_phrases]
+            for start in range(0, len(query.accent_phrases), min_accent_phrases)
+        ]
+        if (
+            len(chunk_accent_phrases_list) >= 2
+            and len(chunk_accent_phrases_list[-1]) < min_accent_phrases
+        ):
+            chunk_accent_phrases_list[-2].extend(chunk_accent_phrases_list[-1])
+            chunk_accent_phrases_list.pop()
+
+        for i, accent_phrases in enumerate(chunk_accent_phrases_list):
             kana_text = create_kana(accent_phrases)
             raw_wave, sr_raw_wave = self.forward(kana_text)
-            if start == chunk_starts[0]:
+            if i == 0:
                 pre_silence_length = int(
                     query.prePhonemeLength / query.speedScale * sr_raw_wave
                 )
                 raw_wave = np.concatenate(
                     [np.zeros(pre_silence_length, dtype=np.float32), raw_wave]
                 )
-            if start == chunk_starts[-1]:
+            if i == len(chunk_accent_phrases_list) - 1:
                 post_silence_length = int(
                     query.postPhonemeLength / query.speedScale * sr_raw_wave
                 )

--- a/voicevox_engine/dev/tts_engine/mock.py
+++ b/voicevox_engine/dev/tts_engine/mock.py
@@ -13,6 +13,7 @@ from ...model import AudioQuery
 from ...tts_pipeline.audio_postprocessing import raw_wave_to_output_wave
 from ...tts_pipeline.tts_engine import (
     TTSEngine,
+    _apply_interrogative_upspeak,
     to_flatten_moras,
 )
 from ..core.mock import MockCoreWrapper
@@ -55,6 +56,9 @@ class MockTTSEngine(TTSEngine):
         """音声合成用のクエリに含まれる読み仮名を複数アクセント句ごとに音声波形へ変換する。"""
         self._core._assert_style_supports_feature(style_id, "talk")
         query = copy.deepcopy(query)
+        query.accent_phrases = _apply_interrogative_upspeak(
+            query.accent_phrases, enable_interrogative_upspeak
+        )
 
         min_accent_phrases = max(1, min_accent_phrases)
         for start in range(0, len(query.accent_phrases), min_accent_phrases):

--- a/voicevox_engine/dev/tts_engine/mock.py
+++ b/voicevox_engine/dev/tts_engine/mock.py
@@ -14,7 +14,7 @@ from ...tts_pipeline.audio_postprocessing import raw_wave_to_output_wave
 from ...tts_pipeline.kana_converter import create_kana
 from ...tts_pipeline.tts_engine import (
     TTSEngine,
-    _apply_interrogative_upspeak,
+    apply_interrogative_upspeak,
     to_flatten_moras,
 )
 from ..core.mock import MockCoreWrapper
@@ -57,13 +57,13 @@ class MockTTSEngine(TTSEngine):
         """音声合成用のクエリに含まれる読み仮名を複数アクセント句ごとに音声波形へ変換する。"""
         self._core._assert_style_supports_feature(style_id, "talk")
         query = copy.deepcopy(query)
-        query.accent_phrases = _apply_interrogative_upspeak(
+        query.accent_phrases = apply_interrogative_upspeak(
             query.accent_phrases, enable_interrogative_upspeak
         )
 
         if len(query.accent_phrases) == 0:
             sampling_rate = 48000
-            duration = query.prePhonemeLength + query.postPhonemeLength
+            duration = (query.prePhonemeLength + query.postPhonemeLength) / query.speedScale
             raw_wave = np.zeros(max(1, int(duration * sampling_rate)), dtype=np.float32)
             yield raw_wave_to_output_wave(query, raw_wave, sampling_rate)
             return

--- a/voicevox_engine/dev/tts_engine/mock.py
+++ b/voicevox_engine/dev/tts_engine/mock.py
@@ -11,6 +11,7 @@ from pyopenjtalk import tts
 from ...metas.metas import StyleId
 from ...model import AudioQuery
 from ...tts_pipeline.audio_postprocessing import raw_wave_to_output_wave
+from ...tts_pipeline.kana_converter import create_kana
 from ...tts_pipeline.tts_engine import (
     TTSEngine,
     _apply_interrogative_upspeak,
@@ -60,11 +61,17 @@ class MockTTSEngine(TTSEngine):
             query.accent_phrases, enable_interrogative_upspeak
         )
 
+        if len(query.accent_phrases) == 0:
+            sampling_rate = 48000
+            duration = query.prePhonemeLength + query.postPhonemeLength
+            raw_wave = np.zeros(max(1, int(duration * sampling_rate)), dtype=np.float32)
+            yield raw_wave_to_output_wave(query, raw_wave, sampling_rate)
+            return
+
         min_accent_phrases = max(1, min_accent_phrases)
         for start in range(0, len(query.accent_phrases), min_accent_phrases):
             accent_phrases = query.accent_phrases[start : start + min_accent_phrases]
-            flatten_moras = to_flatten_moras(accent_phrases)
-            kana_text = "".join([mora.text for mora in flatten_moras])
+            kana_text = create_kana(accent_phrases)
             raw_wave, sr_raw_wave = self.forward(kana_text)
             yield raw_wave_to_output_wave(query, raw_wave, sr_raw_wave)
 

--- a/voicevox_engine/dev/tts_engine/mock.py
+++ b/voicevox_engine/dev/tts_engine/mock.py
@@ -61,18 +61,33 @@ class MockTTSEngine(TTSEngine):
             query.accent_phrases, enable_interrogative_upspeak
         )
 
+        sampling_rate = 48000
         if len(query.accent_phrases) == 0:
-            sampling_rate = 48000
             duration = (query.prePhonemeLength + query.postPhonemeLength) / query.speedScale
             raw_wave = np.zeros(max(1, int(duration * sampling_rate)), dtype=np.float32)
             yield raw_wave_to_output_wave(query, raw_wave, sampling_rate)
             return
 
         min_accent_phrases = max(1, min_accent_phrases)
-        for start in range(0, len(query.accent_phrases), min_accent_phrases):
+        chunk_starts = list(range(0, len(query.accent_phrases), min_accent_phrases))
+        for start in chunk_starts:
             accent_phrases = query.accent_phrases[start : start + min_accent_phrases]
             kana_text = create_kana(accent_phrases)
             raw_wave, sr_raw_wave = self.forward(kana_text)
+            if start == chunk_starts[0]:
+                pre_silence_length = int(
+                    query.prePhonemeLength / query.speedScale * sr_raw_wave
+                )
+                raw_wave = np.concatenate(
+                    [np.zeros(pre_silence_length, dtype=np.float32), raw_wave]
+                )
+            if start == chunk_starts[-1]:
+                post_silence_length = int(
+                    query.postPhonemeLength / query.speedScale * sr_raw_wave
+                )
+                raw_wave = np.concatenate(
+                    [raw_wave, np.zeros(post_silence_length, dtype=np.float32)]
+                )
             yield raw_wave_to_output_wave(query, raw_wave, sr_raw_wave)
 
     def forward(self, text: str) -> tuple[NDArray[np.float32], int]:

--- a/voicevox_engine/tts_pipeline/tts_engine.py
+++ b/voicevox_engine/tts_pipeline/tts_engine.py
@@ -101,6 +101,16 @@ def _apply_interrogative_upspeak(
     return accent_phrases
 
 
+def apply_interrogative_upspeak(
+    accent_phrases: list[AccentPhrase], enable_interrogative_upspeak: bool
+) -> list[AccentPhrase]:
+    """必要に応じて各アクセント句の末尾へ疑問形モーラを付与する。"""
+    return _apply_interrogative_upspeak(
+        accent_phrases,
+        enable_interrogative_upspeak,
+    )
+
+
 def _apply_prepost_silence(moras: list[Mora], query: AudioQuery) -> list[Mora]:
     """モーラ系列へ音声合成用のクエリがもつ前後無音（`prePhonemeLength` & `postPhonemeLength`）を付加する"""
     pre_silence_moras = [_generate_silence_mora(query.prePhonemeLength)]
@@ -439,7 +449,7 @@ class TTSEngine:
         """音声合成用のクエリ・スタイルID・疑問文語尾自動調整フラグに基づいて音声波形を生成する"""
         # モーフィング時などに同一参照のqueryで複数回呼ばれる可能性があるので、元の引数のqueryに破壊的変更を行わない
         query = copy.deepcopy(query)
-        query.accent_phrases = _apply_interrogative_upspeak(
+        query.accent_phrases = apply_interrogative_upspeak(
             query.accent_phrases, enable_interrogative_upspeak
         )
 
@@ -457,7 +467,7 @@ class TTSEngine:
     ) -> Iterator[NDArray[np.float32]]:
         """複数アクセント句をまとめた単位で音声波形を生成する。"""
         query = copy.deepcopy(query)
-        query.accent_phrases = _apply_interrogative_upspeak(
+        query.accent_phrases = apply_interrogative_upspeak(
             query.accent_phrases, enable_interrogative_upspeak
         )
 

--- a/voicevox_engine/tts_pipeline/tts_engine.py
+++ b/voicevox_engine/tts_pipeline/tts_engine.py
@@ -2,6 +2,7 @@
 
 import copy
 import math
+from collections.abc import Iterator
 from typing import Any, Final, Literal, TypeAlias
 
 import numpy as np
@@ -199,20 +200,20 @@ def _apply_intonation_scale(moras: list[Mora], query: AudioQuery) -> list[Mora]:
     return moras
 
 
-def _query_to_decoder_feature(
-    query: AudioQuery,
-) -> tuple[NDArray[np.float32], NDArray[np.float32]]:
-    """音声合成用のクエリからフレームごとの音素 (shape=(フレーム長, 音素数)) と音高 (shape=(フレーム長,)) を得る"""
-    moras = to_flatten_moras(query.accent_phrases)
-
-    # 設定を適用する
-    moras = _apply_prepost_silence(moras, query)
+def _apply_query_scales(moras: list[Mora], query: AudioQuery) -> list[Mora]:
+    """モーラ系列へ音声合成用のクエリがもつ各種スケールを適用する。"""
     moras = _apply_pause_length(moras, query)
     moras = _apply_pause_length_scale(moras, query)
     moras = _apply_speed_scale(moras, query)
     moras = _apply_pitch_scale(moras, query)
     moras = _apply_intonation_scale(moras, query)
+    return moras
 
+
+def _moras_to_decoder_feature(
+    moras: list[Mora],
+) -> tuple[NDArray[np.float32], NDArray[np.float32]]:
+    """モーラ系列からフレームごとの音素 (shape=(フレーム長, 音素数)) と音高 (shape=(フレーム長,)) を得る。"""
     # 表現を変更する（音素クラス → 音素 onehot ベクトル、モーラクラス → 音高スカラ）
     phoneme = np.stack([p.onehot for p in _to_flatten_phonemes(moras)])
     f0 = np.array([mora.pitch for mora in moras], dtype=np.float32)
@@ -223,6 +224,64 @@ def _query_to_decoder_feature(
     f0 = np.repeat(f0, frame_per_mora)
 
     return phoneme, f0
+
+
+def _query_to_decoder_feature(
+    query: AudioQuery,
+) -> tuple[NDArray[np.float32], NDArray[np.float32]]:
+    """音声合成用のクエリからフレームごとの音素 (shape=(フレーム長, 音素数)) と音高 (shape=(フレーム長,)) を得る"""
+    moras = to_flatten_moras(query.accent_phrases)
+    moras = _apply_prepost_silence(moras, query)
+    moras = _apply_query_scales(moras, query)
+    return _moras_to_decoder_feature(moras)
+
+
+def _group_moras_by_accent_phrase_count(
+    accent_phrase_moras: list[list[Mora]], min_accent_phrases: int
+) -> list[list[Mora]]:
+    """アクセント句ごとのモーラ系列を指定数以上になるよう結合する。"""
+    grouped: list[list[Mora]] = []
+    for start in range(0, len(accent_phrase_moras), min_accent_phrases):
+        moras: list[Mora] = []
+        for phrase_moras in accent_phrase_moras[start : start + min_accent_phrases]:
+            moras += phrase_moras
+        grouped.append(moras)
+    return grouped
+
+
+def _query_to_decoder_feature_chunks(
+    query: AudioQuery, min_accent_phrases: int
+) -> Iterator[tuple[NDArray[np.float32], NDArray[np.float32]]]:
+    """音声合成用のクエリからアクセント句ごとのデコーダー入力を得る。"""
+    if len(query.accent_phrases) == 0:
+        moras = _apply_prepost_silence([], query)
+        moras = _apply_query_scales(moras, query)
+        yield _moras_to_decoder_feature(moras)
+        return
+
+    accent_phrase_moras = [
+        to_flatten_moras([accent_phrase]) for accent_phrase in query.accent_phrases
+    ]
+    chunk_moras_list = _group_moras_by_accent_phrase_count(
+        accent_phrase_moras,
+        min_accent_phrases=max(1, min_accent_phrases),
+    )
+    chunk_moras_list[0] = [
+        _generate_silence_mora(query.prePhonemeLength),
+        *chunk_moras_list[0],
+    ]
+    chunk_moras_list[-1] = [
+        *chunk_moras_list[-1],
+        _generate_silence_mora(query.postPhonemeLength),
+    ]
+
+    # 抑揚スケールなどは文全体を基準にするため、全チャンクの Mora オブジェクトを
+    # 共有したリストに一度まとめてから適用する。
+    all_moras = [mora for chunk_moras in chunk_moras_list for mora in chunk_moras]
+    _apply_query_scales(all_moras, query)
+
+    for chunk_moras in chunk_moras_list:
+        yield _moras_to_decoder_feature(chunk_moras)
 
 
 class TTSEngine:
@@ -383,6 +442,23 @@ class TTSEngine:
         raw_wave, sr_raw_wave = self._core.safe_decode_forward(phoneme, f0, style_id)
         wave = raw_wave_to_output_wave(query, raw_wave, sr_raw_wave)
         return wave
+
+    def synthesize_wave_chunks(
+        self,
+        query: AudioQuery,
+        style_id: StyleId,
+        enable_interrogative_upspeak: bool,
+        min_accent_phrases: int = 4,
+    ) -> Iterator[NDArray[np.float32]]:
+        """複数アクセント句をまとめた単位で音声波形を生成する。"""
+        query = copy.deepcopy(query)
+        query.accent_phrases = _apply_interrogative_upspeak(
+            query.accent_phrases, enable_interrogative_upspeak
+        )
+
+        for phoneme, f0 in _query_to_decoder_feature_chunks(query, min_accent_phrases):
+            raw_wave, sr_raw_wave = self._core.safe_decode_forward(phoneme, f0, style_id)
+            yield raw_wave_to_output_wave(query, raw_wave, sr_raw_wave)
 
     def initialize_synthesis(self, style_id: StyleId, skip_reinit: bool) -> None:
         """指定されたスタイル ID に関する合成機能を初期化する。既に初期化されていた場合は引数に応じて再初期化する。"""

--- a/voicevox_engine/tts_pipeline/tts_engine.py
+++ b/voicevox_engine/tts_pipeline/tts_engine.py
@@ -244,7 +244,7 @@ def _group_moras_by_accent_phrase_count(
     for start in range(0, len(accent_phrase_moras), min_accent_phrases):
         moras: list[Mora] = []
         for phrase_moras in accent_phrase_moras[start : start + min_accent_phrases]:
-            moras += phrase_moras
+            moras.extend(phrase_moras)
         grouped.append(moras)
     return grouped
 
@@ -278,7 +278,12 @@ def _query_to_decoder_feature_chunks(
     # 抑揚スケールなどは文全体を基準にするため、全チャンクの Mora オブジェクトを
     # 共有したリストに一度まとめてから適用する。
     all_moras = [mora for chunk_moras in chunk_moras_list for mora in chunk_moras]
-    _apply_query_scales(all_moras, query)
+    scaled_moras = _apply_query_scales(all_moras, query)
+    current = 0
+    for i, chunk_moras in enumerate(chunk_moras_list):
+        next_current = current + len(chunk_moras)
+        chunk_moras_list[i] = scaled_moras[current:next_current]
+        current = next_current
 
     for chunk_moras in chunk_moras_list:
         yield _moras_to_decoder_feature(chunk_moras)

--- a/voicevox_engine/tts_pipeline/tts_engine.py
+++ b/voicevox_engine/tts_pipeline/tts_engine.py
@@ -250,12 +250,19 @@ def _query_to_decoder_feature(
 def _group_moras_by_accent_phrase_count(
     accent_phrase_moras: list[list[Mora]], min_accent_phrases: int
 ) -> list[list[Mora]]:
-    """アクセント句ごとのモーラ系列を指定数ごとに結合する。末尾は端数になり得る。"""
+    """アクセント句ごとのモーラ系列を指定数以上になるよう結合する。"""
     grouped: list[list[Mora]] = []
     for start in range(0, len(accent_phrase_moras), min_accent_phrases):
         moras: list[Mora] = []
         for phrase_moras in accent_phrase_moras[start : start + min_accent_phrases]:
             moras.extend(phrase_moras)
+        if (
+            len(accent_phrase_moras[start : start + min_accent_phrases])
+            < min_accent_phrases
+            and len(grouped) > 0
+        ):
+            grouped[-1].extend(moras)
+            continue
         grouped.append(moras)
     return grouped
 

--- a/voicevox_engine/tts_pipeline/tts_engine.py
+++ b/voicevox_engine/tts_pipeline/tts_engine.py
@@ -1,7 +1,6 @@
 """テキスト音声合成エンジン"""
 
 import copy
-import math
 from collections.abc import Iterator
 from typing import Any, Final, Literal, TypeAlias
 
@@ -203,10 +202,12 @@ def _apply_intonation_scale(moras: list[Mora], query: AudioQuery) -> list[Mora]:
     """モーラ系列へ音声合成用のクエリがもつ抑揚スケール（`intonationScale`）を適用する"""
     # 有声音素 (f0>0) の平均値に対する乖離度をスケール
     voiced = list(filter(lambda mora: mora.pitch > 0, moras))
+    if len(voiced) == 0:
+        return moras
+
     mean_f0 = np.mean(list(map(lambda mora: mora.pitch, voiced))).item()
-    if mean_f0 != math.nan:  # 空リスト -> NaN
-        for mora in voiced:
-            mora.pitch = (mora.pitch - mean_f0) * query.intonationScale + mean_f0
+    for mora in voiced:
+        mora.pitch = (mora.pitch - mean_f0) * query.intonationScale + mean_f0
     return moras
 
 
@@ -270,8 +271,16 @@ def _query_to_decoder_feature_chunks(
         return
 
     accent_phrase_moras = [
-        to_flatten_moras([accent_phrase]) for accent_phrase in query.accent_phrases
+        moras
+        for accent_phrase in query.accent_phrases
+        if len(moras := to_flatten_moras([accent_phrase])) > 0
     ]
+    if len(accent_phrase_moras) == 0:
+        moras = _apply_prepost_silence([], query)
+        moras = _apply_query_scales(moras, query)
+        yield _moras_to_decoder_feature(moras)
+        return
+
     chunk_moras_list = _group_moras_by_accent_phrase_count(
         accent_phrase_moras,
         min_accent_phrases=max(1, min_accent_phrases),

--- a/voicevox_engine/tts_pipeline/tts_engine.py
+++ b/voicevox_engine/tts_pipeline/tts_engine.py
@@ -239,7 +239,7 @@ def _query_to_decoder_feature(
 def _group_moras_by_accent_phrase_count(
     accent_phrase_moras: list[list[Mora]], min_accent_phrases: int
 ) -> list[list[Mora]]:
-    """アクセント句ごとのモーラ系列を指定数以上になるよう結合する。"""
+    """アクセント句ごとのモーラ系列を指定数ごとに結合する。末尾は端数になり得る。"""
     grouped: list[list[Mora]] = []
     for start in range(0, len(accent_phrase_moras), min_accent_phrases):
         moras: list[Mora] = []


### PR DESCRIPTION
## 内容

ストリーミング音声合成 API の参考実装です。

関連 Issue / PR:

- Related: VOICEVOX/voicevox_core#853
- Related: VOICEVOX/voicevox_engine#1492
- Reference: VOICEVOX/voicevox_engine#1823

既に `#1492` / `#1823` でより本筋の実装・議論が進んでいることは認識しています。
この PR は、そちらの議論と完全に同じ方向を狙ったものというより、外部クライアントから Kokoro-MLX のように「生成された音声チャンクを順に受け取り、できるだけ早く再生を始める」用途で VOICEVOX を使いたかったため、その実験結果を参考として共有するものです。

特に、LLM 音声対話などで「最初の音が出るまでの時間」を短くしたい、という動機があります。

## やったこと

- `TTSEngine.synthesize_wave_chunks()` を追加
  - `AudioQuery` の `accent_phrases` をチャンク単位に分割
  - 全文の合成完了を待たず、チャンクごとに decode して波形を yield
  - 空のアクセント句だけでチャンクが作られないようにし、全て空の場合は前後無音のみを 1 チャンク合成
- FastAPI にストリーミング合成エンドポイントを追加
  - 現状の実装名は `/streaming_synthesis`
  - upstream の既存案に合わせるなら `/stream_synthesis` へリネーム可能です
- レスポンス形式は `multipart/mixed`
  - 各 part の body は complete WAV bytes
  - 各 part に `Content-Type: audio/wav`, `X-Sequence`, `Content-Length` を付与
  - ストリーム終了は multipart の closing boundary で判断します
  - 低遅延性を保つため、次チャンクを先読みして `X-Is-Last` を付ける方式は採用していません
- `chunk_min_accent_phrases` を追加
  - 1 チャンクあたりの最小アクセント句数を指定
  - 末尾の端数チャンクは前チャンクへ結合
  - 小さいほど first audio latency は短くなりやすい
  - 大きいほどチャンク境界の品質劣化や総処理時間の増加を抑えやすい
- 既存の `/synthesis` は変更せず、追加 API として実装
- mock engine / unit test / e2e test / OpenAPI snapshot を更新

## なぜ multipart/mixed + WAV にしたか

当初は base64/NDJSON も検討しましたが、クライアント側・サーバー側の双方で余計な encode/decode が必要になるため避けました。

PCM 16bit LE も低レイヤーでは扱いやすい一方、sampling rate などのメタデータを別途扱う必要があります。
今回は、既存の `/synthesis` に近く、クライアント側でも 1 part = 1 WAV として扱いやすいことを優先して、`multipart/mixed` で complete WAV を複数返す形にしています。

また、低遅延性を優先するため、各 part の終端判定用に次チャンクを先読みする設計は避けています。
利用側は multipart の closing boundary をストリーム終端として扱います。

## 利用側の扱い

`POST /streaming_synthesis?speaker=<speaker_id>&chunk_min_accent_phrases=<n>` に `AudioQuery` を渡すと、`multipart/mixed` が返ります。

各 part の body は complete WAV bytes です。
各 part の主なヘッダは以下です。

- `Content-Type: audio/wav`
- `X-Sequence`: 0 origin の連番
- `Content-Length`

`X-Is-Last` はありません。
ストリーム終了は multipart の closing boundary で判断します。

## 計測

ローカル環境で、春日部つむぎ `speaker=8`、186 文字、49 accent phrases の文章を使って比較しました。
事前に warm-up 済みです。

### 通常 `/synthesis`

- first byte: 約 2796 ms
- complete: 約 2799 ms
- audio duration: 約 28.36 sec

### streaming, `chunk_min_accent_phrases=4`

- first response byte: 約 372 ms
- first complete WAV chunk: 約 373 ms
- complete: 約 3562 ms
- chunks: 12
- first chunk duration: 約 3.24 sec

### streaming, `chunk_min_accent_phrases=2`

- first response byte: 約 333 ms
- first complete WAV chunk: 約 333 ms
- complete: 約 4754 ms
- chunks: 24
- first chunk duration: 約 2.18 sec

### streaming, `chunk_min_accent_phrases=1`

- first response byte: 約 131 ms
- first complete WAV chunk: 約 132 ms
- complete: 約 7195 ms
- chunks: 49
- first chunk duration: 約 0.47 sec

`X-Is-Last` のための次チャンク先読みをなくしているため、first response byte と first complete WAV chunk はほぼ同じタイミングになっています。

`chunk_min_accent_phrases=1` は総処理時間は伸びますが、最初の音声チャンクが非常に早く返るため、低遅延再生用途ではかなり有効でした。
一方で、チャンク境界の品質や最適なチャンク幅は環境・話者・用途に依存するため、固定値ではなくクライアント側から調整できる形にしています。

## 注意点 / 相談したいこと

- 既存の `#1823` では `/stream_synthesis` として実装が進んでいますが、この PR は参考に、という気持ちなのでエンドポイントは意図的に変えています。
- この実装は「アクセント句単位で既存合成処理を分割する」方向のため、core 側の本格的な streaming intermediate / segment rendering とは設計思想が異なります
- 品質とレイテンシのトレードオフがあるため、デフォルトの chunk size は議論したいです
- complete WAV を multipart で返す形が最も扱いやすいか、PCM / Opus / 単一 WAV stream などと比較して検討したいです

## テスト

- `uv run --group dev ruff check ...`
- `uv run --group dev pytest test/e2e/single_api/tts_pipeline/test_streaming_synthesis.py test/e2e/test_openapi.py test/unit/tts_pipeline/test_tts_engine.py::test_synthesize_wave_chunks_decodes_lazily test/unit/tts_pipeline/test_tts_engine.py::test_synthesize_wave_chunks_skips_empty_accent_phrase_chunks test/unit/tts_pipeline/test_tts_engine.py::test_synthesize_wave_chunks_handles_all_empty_accent_phrases -q`
- `uv run pytest --snapshot-warn-unused`
  - `290 passed, 1 skipped`

## 音声サンプル

サンプルを添付します。

- [normal.wav](https://github.com/user-attachments/files/28618003/normal.wav)
- [tsumugi_normal_chunk1.wav](https://github.com/user-attachments/files/28618016/tsumugi_normal_chunk1.wav)
- [tsumugi_normal_chunk2.wav](https://github.com/user-attachments/files/28618020/tsumugi_normal_chunk2.wav)
- [tsumugi_stream_chunk1.wav](https://github.com/user-attachments/files/28618029/tsumugi_stream_chunk1.wav)
- [tsumugi_stream_chunk2.wav](https://github.com/user-attachments/files/28618037/tsumugi_stream_chunk2.wav)