### PR TITLE
refactor: get_openapi()の直接呼び出しをapp.openapi()経由に変更する

### DIFF
--- a/voicevox_engine/app/openapi_schema.py
+++ b/voicevox_engine/app/openapi_schema.py
@@ -3,7 +3,6 @@
 from typing import Any
 
 from fastapi import FastAPI
-from fastapi.openapi.utils import get_openapi
 from fastapi.routing import APIRoute
 from pydantic import BaseModel
 
@@ -21,27 +20,16 @@ def simplify_operation_ids(app: FastAPI) -> FastAPI:
 
 def configure_openapi_schema(app: FastAPI, manage_library: bool | None) -> FastAPI:
     """自動生成された OpenAPI schema へカスタム属性を追加する。"""
+    original_openapi = app.openapi
 
     # BaseLibraryInfo/VvlibManifestモデルはAPIとして表には出ないが、エディタ側で利用したいので、手動で追加する
     # ref: https://fastapi.tiangolo.com/advanced/extending-openapi/#modify-the-openapi-schema
     def custom_openapi() -> Any:
-        if app.openapi_schema:
+        if app.openapi_schema is not None:
             return app.openapi_schema
-        openapi_schema = get_openapi(
-            title=app.title,
-            version=app.version,
-            openapi_version=app.openapi_version,
-            summary=app.summary,
-            description=app.description,
-            terms_of_service=app.terms_of_service,
-            contact=app.contact,
-            license_info=app.license_info,
-            routes=app.routes,
-            webhooks=app.webhooks.routes,
-            tags=app.openapi_tags,
-            servers=app.servers,
-            separate_input_output_schemas=app.separate_input_output_schemas,
-        )
+
+        openapi_schema = original_openapi()
+
         if manage_library:
             additional_models: list[type[BaseModel]] = [
                 BaseLibraryInfo,


### PR DESCRIPTION
## 内容
OpenAPIスキーマを手動で変更するところの元のスキーマを取得する関数をget_openapi()からapp.openapi()に変更しました。
<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue
ref #1783 
<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
