### PR TITLE
追加:cors_policy_mode・load_all_models・allow_originでの環境変数の追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,8 +446,8 @@ curl -s \
 $ uv run run.py -h
 
 usage: run.py [-h] [--host HOST] [--port PORT] [--use_gpu | --no-use_gpu] [--voicevox_dir VOICEVOX_DIR] [--voicelib_dir VOICELIB_DIR] [--runtime_dir RUNTIME_DIR] [--enable_mock]
-              [--enable_cancellable_synthesis] [--init_processes INIT_PROCESSES] [--load_all_models | --no-load_all_models] [--cpu_num_threads CPU_NUM_THREADS] [--output_log_utf8]
-              [--cors_policy_mode {all,localapps}] [--allow_origin [ALLOW_ORIGIN ...]] [--setting_file SETTING_FILE] [--preset_file PRESET_FILE] [--disable_mutable_api | --no-disable_mutable_api]
+              [--enable_cancellable_synthesis] [--init_processes INIT_PROCESSES] [--load_all_models] [--cpu_num_threads CPU_NUM_THREADS] [--output_log_utf8] [--cors_policy_mode {all,localapps}]
+              [--allow_origin [ALLOW_ORIGIN ...]] [--setting_file SETTING_FILE] [--preset_file PRESET_FILE] [--disable_mutable_api]
 
 VOICEVOX のエンジンです。
 
@@ -468,8 +468,7 @@ options:
                         音声合成を途中でキャンセルできるようになります。
   --init_processes INIT_PROCESSES
                         cancellable_synthesis機能の初期化時に生成するプロセス数です。
-  --load_all_models, --no-load_all_models
-                        起動時に全ての音声合成モデルを読み込みます。指定しない場合、代わりに環境変数 VV_LOAD_ALL_MODELS、設定ファイルの値が順に使われます。VV_LOAD_ALL_MODELS の値が1の場合は読み込み、0の場合は読み込みません。いずれにも指定がない場合は読み込みません。
+  --load_all_models     起動時に全ての音声合成モデルを読み込みます。指定しない場合、代わりに環境変数 VV_LOAD_ALL_MODELS、設定ファイルの値が順に使われます。
   --cpu_num_threads CPU_NUM_THREADS
                         音声合成を行うスレッド数です。指定しない場合、代わりに環境変数 VV_CPU_NUM_THREADS の値が使われます。VV_CPU_NUM_THREADS が空文字列でなく数値でもない場合はエラー終了します。
   --output_log_utf8     ログ出力をUTF-8でおこないます。指定しない場合、代わりに環境変数 VV_OUTPUT_LOG_UTF8 の値が使われます。VV_OUTPUT_LOG_UTF8 の値が1の場合はUTF-8で、0または空文字、値がない場合は環境によって自動的に決定されます。
@@ -482,8 +481,8 @@ options:
                         設定ファイルを指定できます。
   --preset_file PRESET_FILE
                         プリセットファイルを指定できます。指定がない場合、環境変数 VV_PRESET_FILE、ユーザーディレクトリのpresets.yamlを順に探します。
-  --disable_mutable_api, --no-disable_mutable_api
-                        辞書登録や設定変更など、エンジンの静的なデータを変更するAPIを無効化します。指定しない場合、代わりに環境変数 VV_DISABLE_MUTABLE_API、設定ファイルの値が順に使われます。VV_DISABLE_MUTABLE_API の値が1の場合は無効化で、0の場合は無効化しません。いずれにも指定がない場合は無効化しません。
+  --disable_mutable_api
+                        辞書登録や設定変更など、エンジンの静的なデータを変更するAPIを無効化します。指定しない場合、代わりに環境変数 VV_DISABLE_MUTABLE_API、設定ファイルの値が順に使われます。
 ```
 
 #### プロキシ環境での利用

--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ VOICEVOX ではセキュリティ保護のため`localhost`・`127.0.0.1`・`app
 
 ### データを変更する API を無効化する
 
-実行時引数`--disable_mutable_api`か環境変数`VV_DISABLE_MUTABLE_API=1`を指定することで、エンジンの設定や辞書などを変更する API を無効にできます。
+実行時引数`--disable_mutable_api`か環境変数`VV_DISABLE_MUTABLE_API=1`、または設定ファイルの`disable_mutable_api: true`を指定することで、エンジンの設定や辞書などを変更する API を無効にできます。
 
 ### 文字コード
 
@@ -446,8 +446,8 @@ curl -s \
 $ uv run run.py -h
 
 usage: run.py [-h] [--host HOST] [--port PORT] [--use_gpu | --no-use_gpu] [--voicevox_dir VOICEVOX_DIR] [--voicelib_dir VOICELIB_DIR] [--runtime_dir RUNTIME_DIR] [--enable_mock]
-              [--enable_cancellable_synthesis] [--init_processes INIT_PROCESSES] [--load_all_models] [--cpu_num_threads CPU_NUM_THREADS] [--output_log_utf8] [--cors_policy_mode {all,localapps}]
-              [--allow_origin [ALLOW_ORIGIN ...]] [--setting_file SETTING_FILE] [--preset_file PRESET_FILE] [--disable_mutable_api]
+              [--enable_cancellable_synthesis] [--init_processes INIT_PROCESSES] [--load_all_models | --no-load_all_models] [--cpu_num_threads CPU_NUM_THREADS] [--output_log_utf8]
+              [--cors_policy_mode {all,localapps}] [--allow_origin [ALLOW_ORIGIN ...]] [--setting_file SETTING_FILE] [--preset_file PRESET_FILE] [--disable_mutable_api | --no-disable_mutable_api]
 
 VOICEVOX のエンジンです。
 
@@ -468,21 +468,22 @@ options:
                         音声合成を途中でキャンセルできるようになります。
   --init_processes INIT_PROCESSES
                         cancellable_synthesis機能の初期化時に生成するプロセス数です。
-  --load_all_models     起動時に全ての音声合成モデルを読み込みます。
+  --load_all_models, --no-load_all_models
+                        起動時に全ての音声合成モデルを読み込みます。指定しない場合、代わりに環境変数 VV_LOAD_ALL_MODELS、設定ファイルの値が順に使われます。VV_LOAD_ALL_MODELS の値が1の場合は読み込み、0の場合は読み込みません。いずれにも指定がない場合は読み込みません。
   --cpu_num_threads CPU_NUM_THREADS
                         音声合成を行うスレッド数です。指定しない場合、代わりに環境変数 VV_CPU_NUM_THREADS の値が使われます。VV_CPU_NUM_THREADS が空文字列でなく数値でもない場合はエラー終了します。
   --output_log_utf8     ログ出力をUTF-8でおこないます。指定しない場合、代わりに環境変数 VV_OUTPUT_LOG_UTF8 の値が使われます。VV_OUTPUT_LOG_UTF8 の値が1の場合はUTF-8で、0または空文字、値がない場合は環境によって自動的に決定されます。
   --cors_policy_mode {all,localapps}
-                        CORSの許可モード。allまたはlocalappsが指定できます。allはすべてを許可します。localappsはオリジン間リソース共有ポリシーを、app://.とlocalhost関連、ブラウザ拡張URIに限定します。その他のオリジンはallow_originオプションで追加できます。デフォルトはlocalapps。このオプションは--
-                        setting_fileで指定される設定ファイルよりも優先されます。
+                        CORSの許可モード。allまたはlocalappsが指定できます。allはすべてを許可します。localappsはオリジン間リソース共有ポリシーを、app://.とlocalhost関連、ブラウザ拡張URIに限定します。その他のオリジンはallow_originオプションで追加できます。デフォルトはlocalapps。指定しない場合、代わりに環境変数
+                        VV_CORS_POLICY_MODE、--setting_fileで指定される設定ファイルの値が順に使われます。
   --allow_origin [ALLOW_ORIGIN ...]
-                        許可するオリジンを指定します。スペースで区切ることで複数指定できます。このオプションは--setting_fileで指定される設定ファイルよりも優先されます。
+                        許可するオリジンを指定します。スペースで区切ることで複数指定できます。指定しない場合、代わりに環境変数 VV_ALLOW_ORIGIN（カンマ区切り）、--setting_fileで指定される設定ファイルの値が順に使われます。
   --setting_file SETTING_FILE
                         設定ファイルを指定できます。
   --preset_file PRESET_FILE
                         プリセットファイルを指定できます。指定がない場合、環境変数 VV_PRESET_FILE、ユーザーディレクトリのpresets.yamlを順に探します。
-  --disable_mutable_api
-                        辞書登録や設定変更など、エンジンの静的なデータを変更するAPIを無効化します。指定しない場合、代わりに環境変数 VV_DISABLE_MUTABLE_API の値が使われます。VV_DISABLE_MUTABLE_API の値が1の場合は無効化で、0または空文字、値がない場合は無視されます。
+  --disable_mutable_api, --no-disable_mutable_api
+                        辞書登録や設定変更など、エンジンの静的なデータを変更するAPIを無効化します。指定しない場合、代わりに環境変数 VV_DISABLE_MUTABLE_API、設定ファイルの値が順に使われます。VV_DISABLE_MUTABLE_API の値が1の場合は無効化で、0の場合は無効化しません。いずれにも指定がない場合は無効化しません。
 ```
 
 #### プロキシ環境での利用

--- a/run.py
+++ b/run.py
@@ -311,15 +311,14 @@ def read_cli_arguments(envs: Envs) -> _CLIArgs:
         default=2,
         help="cancellable_synthesis機能の初期化時に生成するプロセス数です。",
     )
+    # NOTE: default=None により「未指定」を表現し、環境変数・設定ファイルへのフォールバックを可能にする
     parser.add_argument(
         "--load_all_models",
-        action=argparse.BooleanOptionalAction,
+        action="store_true",
         default=None,
         help=(
             "起動時に全ての音声合成モデルを読み込みます。"
             "指定しない場合、代わりに環境変数 VV_LOAD_ALL_MODELS、設定ファイルの値が順に使われます。"
-            "VV_LOAD_ALL_MODELS の値が1の場合は読み込み、0の場合は読み込みません。"
-            "いずれにも指定がない場合は読み込みません。"
         ),
     )
 
@@ -385,15 +384,14 @@ def read_cli_arguments(envs: Envs) -> _CLIArgs:
         ),
     )
 
+    # NOTE: default=None により「未指定」を表現し、環境変数・設定ファイルへのフォールバックを可能にする
     parser.add_argument(
         "--disable_mutable_api",
-        action=argparse.BooleanOptionalAction,
+        action="store_true",
         default=None,
         help=(
             "辞書登録や設定変更など、エンジンの静的なデータを変更するAPIを無効化します。"
             "指定しない場合、代わりに環境変数 VV_DISABLE_MUTABLE_API、設定ファイルの値が順に使われます。"
-            "VV_DISABLE_MUTABLE_API の値が1の場合は無効化で、0の場合は無効化しません。"
-            "いずれにも指定がない場合は無効化しません。"
         ),
     )
 

--- a/run.py
+++ b/run.py
@@ -57,6 +57,29 @@ def decide_boolean_from_env(env_name: str) -> bool:
             return False
 
 
+def decide_boolean_from_env_or_none(env_name: str) -> bool | None:
+    """
+    環境変数からbool値を返す。設定の優先順位付けのため、未指定なら None を返す。
+
+    * 環境変数が"1"ならTrueを返す
+    * 環境変数が"0"ならFalseを返す
+    * 環境変数が空白か存在しないならNoneを返す
+    * それ以外はwarningを出してNoneを返す
+    """
+    env = os.getenv(env_name, default="")
+    match env:
+        case "1":
+            return True
+        case "0":
+            return False
+        case "":
+            return None
+        case _:
+            msg = f"Invalid environment variable value: {env_name}={env}"
+            warnings.warn(msg, stacklevel=1)
+            return None
+
+
 def decide_port_from_env(env_name: str) -> int | None:
     """
     環境変数からポート番号を返す。
@@ -79,6 +102,39 @@ def decide_port_from_env(env_name: str) -> int | None:
     return None
 
 
+def decide_cors_policy_mode_from_env(env_name: str) -> CorsPolicyMode | None:
+    """
+    環境変数からCORSの許可モードを返す。
+
+    * 環境変数が "all" か "localapps" なら対応する `CorsPolicyMode` を返す
+    * 環境変数が空白か存在しないならNoneを返す
+    * それ以外はwarningを出してNoneを返す
+    """
+    env = os.getenv(env_name, default="")
+    if env == "":
+        return None
+    try:
+        return CorsPolicyMode(env)
+    except ValueError:
+        msg = f"Invalid environment variable value: {env_name}={env}"
+        warnings.warn(msg, stacklevel=1)
+        return None
+
+
+def decide_allow_origin_from_env(env_name: str) -> list[str] | None:
+    """
+    環境変数から許可するオリジンのリストを返す。
+
+    * 環境変数が存在するなら、カンマ区切りでリスト化して返す（各要素の前後の空白は除く）
+    * 環境変数が空白か存在しないか、有効なオリジンが無いならNoneを返す
+    """
+    env = os.getenv(env_name, default="")
+    if env == "":
+        return None
+    origins = [origin.strip() for origin in env.split(",") if origin.strip()]
+    return origins or None
+
+
 @dataclass(frozen=True)
 class Envs:
     """環境変数の集合"""
@@ -86,7 +142,10 @@ class Envs:
     output_log_utf8: bool
     cpu_num_threads: str | None
     env_preset_path: str | None
-    disable_mutable_api: bool
+    disable_mutable_api: bool | None
+    load_all_models: bool | None
+    cors_policy_mode: CorsPolicyMode | None
+    allow_origins: list[str] | None
     host: str | None
     port: int | None
     use_gpu: bool
@@ -101,7 +160,10 @@ def read_environment_variables() -> Envs:
         output_log_utf8=decide_boolean_from_env("VV_OUTPUT_LOG_UTF8"),
         cpu_num_threads=os.getenv("VV_CPU_NUM_THREADS"),
         env_preset_path=os.getenv("VV_PRESET_FILE"),
-        disable_mutable_api=decide_boolean_from_env("VV_DISABLE_MUTABLE_API"),
+        disable_mutable_api=decide_boolean_from_env_or_none("VV_DISABLE_MUTABLE_API"),
+        load_all_models=decide_boolean_from_env_or_none("VV_LOAD_ALL_MODELS"),
+        cors_policy_mode=decide_cors_policy_mode_from_env("VV_CORS_POLICY_MODE"),
+        allow_origins=decide_allow_origin_from_env("VV_ALLOW_ORIGIN"),
         host=os.getenv("VV_HOST"),
         port=decide_port_from_env("VV_PORT"),
         use_gpu=decide_boolean_from_env("VV_USE_GPU"),
@@ -179,14 +241,14 @@ class _CLIArgs:
     enable_mock: bool
     enable_cancellable_synthesis: bool
     init_processes: int
-    load_all_models: bool
+    load_all_models: bool | None
     cpu_num_threads: int | None
     output_log_utf8: bool
     cors_policy_mode: CorsPolicyMode | None
     allow_origins: list[str] | None
     setting_file: Path
     preset_file: Path | None
-    disable_mutable_api: bool
+    disable_mutable_api: bool | None
 
 
 _cli_args_adapter = TypeAdapter(_CLIArgs)
@@ -251,8 +313,14 @@ def read_cli_arguments(envs: Envs) -> _CLIArgs:
     )
     parser.add_argument(
         "--load_all_models",
-        action="store_true",
-        help="起動時に全ての音声合成モデルを読み込みます。",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help=(
+            "起動時に全ての音声合成モデルを読み込みます。"
+            "指定しない場合、代わりに環境変数 VV_LOAD_ALL_MODELS、設定ファイルの値が順に使われます。"
+            "VV_LOAD_ALL_MODELS の値が1の場合は読み込み、0の場合は読み込みません。"
+            "いずれにも指定がない場合は読み込みません。"
+        ),
     )
 
     # 引数へcpu_num_threadsの指定がなければ、環境変数をロールします。
@@ -286,7 +354,7 @@ def read_cli_arguments(envs: Envs) -> _CLIArgs:
             "CORSの許可モード。allまたはlocalappsが指定できます。allはすべてを許可します。"
             "localappsはオリジン間リソース共有ポリシーを、app://.とlocalhost関連、ブラウザ拡張URIに限定します。"
             "その他のオリジンはallow_originオプションで追加できます。デフォルトはlocalapps。"
-            "このオプションは--setting_fileで指定される設定ファイルよりも優先されます。"
+            "指定しない場合、代わりに環境変数 VV_CORS_POLICY_MODE、--setting_fileで指定される設定ファイルの値が順に使われます。"
         ),
     )
 
@@ -295,7 +363,8 @@ def read_cli_arguments(envs: Envs) -> _CLIArgs:
         nargs="*",
         help=(
             "許可するオリジンを指定します。スペースで区切ることで複数指定できます。"
-            "このオプションは--setting_fileで指定される設定ファイルよりも優先されます。"
+            "指定しない場合、代わりに環境変数 VV_ALLOW_ORIGIN（カンマ区切り）、"
+            "--setting_fileで指定される設定ファイルの値が順に使われます。"
         ),
     )
 
@@ -318,11 +387,13 @@ def read_cli_arguments(envs: Envs) -> _CLIArgs:
 
     parser.add_argument(
         "--disable_mutable_api",
-        action="store_true",
+        action=argparse.BooleanOptionalAction,
+        default=None,
         help=(
             "辞書登録や設定変更など、エンジンの静的なデータを変更するAPIを無効化します。"
-            "指定しない場合、代わりに環境変数 VV_DISABLE_MUTABLE_API の値が使われます。"
-            "VV_DISABLE_MUTABLE_API の値が1の場合は無効化で、0または空文字、値がない場合は無視されます。"
+            "指定しない場合、代わりに環境変数 VV_DISABLE_MUTABLE_API、設定ファイルの値が順に使われます。"
+            "VV_DISABLE_MUTABLE_API の値が1の場合は無効化で、0の場合は無効化しません。"
+            "いずれにも指定がない場合は無効化しません。"
         ),
     )
 
@@ -352,7 +423,15 @@ def main() -> None:
     if args.output_log_utf8:
         set_output_log_utf8()
 
+    setting_loader = SettingHandler(args.setting_file)
+    settings = setting_loader.load()
+
+    # 複数方式で指定可能な場合、優先度は上から「引数」「環境変数」「設定ファイル」「デフォルト値」
+
     use_gpu = select_first_not_none([args.use_gpu, envs.use_gpu])
+    load_all_models = select_first_not_none(
+        [args.load_all_models, envs.load_all_models, settings.load_all_models]
+    )
 
     core_manager = initialize_cores(
         use_gpu=use_gpu,
@@ -361,7 +440,7 @@ def main() -> None:
         runtime_dirs=args.runtime_dirs,
         cpu_num_threads=args.cpu_num_threads,
         enable_mock=args.enable_mock,
-        load_all_models=args.load_all_models,
+        load_all_models=load_all_models,
     )
     tts_engines = make_tts_engines_from_cores(core_manager)
     song_engines = make_song_engines_from_cores(core_manager)
@@ -380,23 +459,18 @@ def main() -> None:
             enable_mock=args.enable_mock,
         )
 
-    setting_loader = SettingHandler(args.setting_file)
-    settings = setting_loader.load()
-
-    # 複数方式で指定可能な場合、優先度は上から「引数」「環境変数」「設定ファイル」「デフォルト値」
-
     host = select_first_not_none([args.host, envs.host, _DEFAULT_HOST])
     port = select_first_not_none([args.port, envs.port, _DEFAULT_PORT])
 
     cors_policy_mode = select_first_not_none(
-        [args.cors_policy_mode, settings.cors_policy_mode]
+        [args.cors_policy_mode, envs.cors_policy_mode, settings.cors_policy_mode]
     )
 
     setting_allow_origins = None
     if settings.allow_origin is not None:
         setting_allow_origins = settings.allow_origin.split(" ")
     allow_origin = select_first_not_none_or_none(
-        [args.allow_origins, setting_allow_origins]
+        [args.allow_origins, envs.allow_origins, setting_allow_origins]
     )
 
     if envs.env_preset_path is not None and len(envs.env_preset_path) != 0:
@@ -427,7 +501,13 @@ def main() -> None:
     if not character_info_dir.exists():
         character_info_dir = root_dir / "speaker_info"
 
-    disable_mutable_api = args.disable_mutable_api or envs.disable_mutable_api
+    disable_mutable_api = select_first_not_none(
+        [
+            args.disable_mutable_api,
+            envs.disable_mutable_api,
+            settings.disable_mutable_api,
+        ]
+    )
 
     # ASGI に準拠した VOICEVOX ENGINE アプリケーションを生成する
     app = generate_app(

--- a/run.py
+++ b/run.py
@@ -106,19 +106,20 @@ def decide_cors_policy_mode_from_env(env_name: str) -> CorsPolicyMode | None:
     """
     環境変数からCORSの許可モードを返す。
 
-    * 環境変数が "all" か "localapps" なら対応する `CorsPolicyMode` を返す
+    * 環境変数が "all" か "localapps" なら対応する CorsPolicyMode を返す
     * 環境変数が空白か存在しないならNoneを返す
     * それ以外はwarningを出してNoneを返す
     """
-    env = os.getenv(env_name, default="")
-    if env == "":
+    env = os.getenv(env_name)
+    if env is None or env == "":
         return None
     try:
         return CorsPolicyMode(env)
     except ValueError:
-        msg = f"Invalid environment variable value: {env_name}={env}"
-        warnings.warn(msg, stacklevel=1)
-        return None
+        pass
+    msg = f"Invalid environment variable value: {env_name}={env}"
+    warnings.warn(msg, stacklevel=1)
+    return None
 
 
 def decide_allow_origin_from_env(env_name: str) -> list[str] | None:
@@ -128,8 +129,8 @@ def decide_allow_origin_from_env(env_name: str) -> list[str] | None:
     * 環境変数が存在するなら、カンマ区切りでリスト化して返す（各要素の前後の空白は除く）
     * 環境変数が空白か存在しないか、有効なオリジンが無いならNoneを返す
     """
-    env = os.getenv(env_name, default="")
-    if env == "":
+    env = os.getenv(env_name)
+    if env is None or env == "":
         return None
     origins = [origin.strip() for origin in env.split(",") if origin.strip()]
     return origins or None

--- a/test/unit/setting/setting-test-load-4.yaml
+++ b/test/unit/setting/setting-test-load-4.yaml
@@ -1,0 +1,4 @@
+allow_origin: null
+cors_policy_mode: localapps
+disable_mutable_api: true
+load_all_models: true

--- a/test/unit/setting/test_setting.py
+++ b/test/unit/setting/test_setting.py
@@ -61,6 +61,36 @@ def test_setting_handler_load_exist_file_3() -> None:
     assert true_setting == setting
 
 
+def test_setting_handler_load_exist_file_4() -> None:
+    """`SettingHandler` は `load_all_models` と `disable_mutable_api` も読み込む。"""
+    # Inputs
+    setting_path = Path("test/unit/setting/setting-test-load-4.yaml")
+    setting_loader = SettingHandler(setting_path)
+    # Expects
+    true_setting = Setting(
+        cors_policy_mode=CorsPolicyMode.localapps,
+        allow_origin=None,
+        load_all_models=True,
+        disable_mutable_api=True,
+    )
+    # Outputs
+    setting = setting_loader.load()
+    # Test
+    assert true_setting == setting
+
+
+def test_setting_handler_load_missing_optional_keys_default() -> None:
+    """設定ファイルに `load_all_models` 等の項目が無い場合はデフォルト値になる。"""
+    # Inputs
+    setting_path = Path("test/unit/setting/setting-test-load-1.yaml")
+    setting_loader = SettingHandler(setting_path)
+    # Outputs
+    setting = setting_loader.load()
+    # Test
+    assert setting.load_all_models is False
+    assert setting.disable_mutable_api is False
+
+
 def test_setting_handler_save(tmp_path: Path) -> None:
     """`SettingHandler.save()` で設定値を保存できる。"""
     # Inputs

--- a/test/unit/test_run.py
+++ b/test/unit/test_run.py
@@ -1,0 +1,114 @@
+"""`run.py` の環境変数読み込みの単体テスト。"""
+
+import pytest
+
+from run import (
+    decide_allow_origin_from_env,
+    decide_boolean_from_env_or_none,
+    decide_cors_policy_mode_from_env,
+)
+from voicevox_engine.setting.model import CorsPolicyMode
+
+_ENV_NAME = "VV_TEST_DUMMY"
+
+
+def test_decide_boolean_from_env_or_none_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """環境変数が存在しない場合は None を返す。"""
+    monkeypatch.delenv(_ENV_NAME, raising=False)
+    assert decide_boolean_from_env_or_none(_ENV_NAME) is None
+
+
+def test_decide_boolean_from_env_or_none_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """環境変数が空文字の場合は None を返す。"""
+    monkeypatch.setenv(_ENV_NAME, "")
+    assert decide_boolean_from_env_or_none(_ENV_NAME) is None
+
+
+def test_decide_boolean_from_env_or_none_true(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """環境変数が "1" の場合は True を返す。"""
+    monkeypatch.setenv(_ENV_NAME, "1")
+    assert decide_boolean_from_env_or_none(_ENV_NAME) is True
+
+
+def test_decide_boolean_from_env_or_none_false(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """環境変数が "0" の場合は False を返す。"""
+    monkeypatch.setenv(_ENV_NAME, "0")
+    assert decide_boolean_from_env_or_none(_ENV_NAME) is False
+
+
+def test_decide_boolean_from_env_or_none_invalid_warns(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """認識できない値の場合は警告を出して None を返す。"""
+    monkeypatch.setenv(_ENV_NAME, "true")
+    with pytest.warns(UserWarning):
+        assert decide_boolean_from_env_or_none(_ENV_NAME) is None
+
+
+def test_decide_cors_policy_mode_from_env_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """環境変数が存在しない場合は None を返す。"""
+    monkeypatch.delenv(_ENV_NAME, raising=False)
+    assert decide_cors_policy_mode_from_env(_ENV_NAME) is None
+
+
+def test_decide_cors_policy_mode_from_env_valid(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """環境変数が許可モードの場合は対応する値を返す。"""
+    monkeypatch.setenv(_ENV_NAME, "all")
+    assert decide_cors_policy_mode_from_env(_ENV_NAME) == CorsPolicyMode.all
+    monkeypatch.setenv(_ENV_NAME, "localapps")
+    assert decide_cors_policy_mode_from_env(_ENV_NAME) == CorsPolicyMode.localapps
+
+
+def test_decide_cors_policy_mode_from_env_invalid_warns(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """認識できない値の場合は警告を出して None を返す。"""
+    monkeypatch.setenv(_ENV_NAME, "invalid")
+    with pytest.warns(UserWarning):
+        assert decide_cors_policy_mode_from_env(_ENV_NAME) is None
+
+
+def test_decide_allow_origin_from_env_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """環境変数が存在しない場合は None を返す。"""
+    monkeypatch.delenv(_ENV_NAME, raising=False)
+    assert decide_allow_origin_from_env(_ENV_NAME) is None
+
+
+def test_decide_allow_origin_from_env_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """環境変数が空文字の場合は None を返す。"""
+    monkeypatch.setenv(_ENV_NAME, "")
+    assert decide_allow_origin_from_env(_ENV_NAME) is None
+
+
+def test_decide_allow_origin_from_env_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """環境変数をカンマ区切りでリスト化して返す。"""
+    monkeypatch.setenv(_ENV_NAME, "app://.,http://localhost:8080")
+    result = decide_allow_origin_from_env(_ENV_NAME)
+    assert result == ["app://.", "http://localhost:8080"]
+
+
+def test_decide_allow_origin_from_env_strips_and_drops_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """各要素の前後の空白を除き、空要素は取り除く。"""
+    monkeypatch.setenv(_ENV_NAME, "app://. , http://localhost:8080 ,")
+    result = decide_allow_origin_from_env(_ENV_NAME)
+    assert result == ["app://.", "http://localhost:8080"]

--- a/voicevox_engine/app/routers/setting.py
+++ b/voicevox_engine/app/routers/setting.py
@@ -58,9 +58,13 @@ def generate_setting_router(
         allow_origin: Annotated[str | SkipJsonSchema[None], Form()] = None,
     ) -> None:
         """設定を更新します。"""
+        # この API では変更しない項目（起動時のみ参照する設定）は既存の値を引き継ぐ
+        previous_settings = setting_loader.load()
         settings = Setting(
             cors_policy_mode=cors_policy_mode,
             allow_origin=allow_origin,
+            load_all_models=previous_settings.load_all_models,
+            disable_mutable_api=previous_settings.disable_mutable_api,
         )
 
         # 更新した設定へ上書き

--- a/voicevox_engine/setting/setting_manager.py
+++ b/voicevox_engine/setting/setting_manager.py
@@ -18,8 +18,8 @@ class Setting:
 
     cors_policy_mode: CorsPolicyMode  # リソース共有ポリシー
     allow_origin: str | None = None  # 許可するオリジン
-    load_all_models: bool = False  # 起動時に全ての音声合成モデルを読み込むか
-    disable_mutable_api: bool = False  # エンジンの静的なデータを変更するAPIを無効化するか
+    load_all_models: bool = False  # 起動時に全モデルを読み込むか
+    disable_mutable_api: bool = False  # データ変更APIを無効化するか
 
 
 _setting_adapter = TypeAdapter(Setting)

--- a/voicevox_engine/setting/setting_manager.py
+++ b/voicevox_engine/setting/setting_manager.py
@@ -18,6 +18,8 @@ class Setting:
 
     cors_policy_mode: CorsPolicyMode  # リソース共有ポリシー
     allow_origin: str | None = None  # 許可するオリジン
+    load_all_models: bool = False  # 起動時に全ての音声合成モデルを読み込むか
+    disable_mutable_api: bool = False  # エンジンの静的なデータを変更するAPIを無効化するか
 
 
 _setting_adapter = TypeAdapter(Setting)


### PR DESCRIPTION
## 内容

`cors_policy_mode`・`allow_origin`・`disable_mutable_api`・`load_all_models` を、いずれも **「引数」→「環境変数」→「設定ファイル」→「デフォルト値」** の優先順位で解決できるようにしました。各設定で対応していた指定方法がバラバラだったため、既存の解決方式に揃えて統一しています。

主な変更:

- **環境変数を追加**（未指定時は下位の指定方法へフォールバック）
  - `VV_CORS_POLICY_MODE` … `all` / `localapps`。認識できない値は警告して無視
  - `VV_ALLOW_ORIGIN` … カンマ区切り（例 `app://.,http://localhost:8080`）。`cors_policy_mode` とは別の環境変数
  - `VV_LOAD_ALL_MODELS` … `1` / `0`
  - `VV_DISABLE_MUTABLE_API` … 既存のものを継続利用
- **設定ファイルに項目を追加**: `Setting` に `load_all_models` / `disable_mutable_api` を追加（項目が無いファイルはデフォルト値で読み込み）。`/setting` の保存時は、起動時のみ参照するこれらの値を引き継ぎ

## 関連 Issue

ref https://github.com/VOICEVOX/voicevox_engine/issues/1798

## スクリーンショット・動画など

なし（API・UI の見た目に変更はありません）

## その他

以下の作り直しです
> https://github.com/VOICEVOX/voicevox_engine/pull/1799

- 互換性メモ:
  - `VV_ALLOW_ORIGIN` はカンマ区切りです（既存の `--allow_origin`・設定ファイルはスペース区切りのまま）。
  - 優先順位に従い、`VV_DISABLE_MUTABLE_API=0` は設定ファイルの `disable_mutable_api: true` を上書きします。
- テスト: 環境変数リーダー（警告・カンマ分割含む）と設定ファイル読み込みの単体テストを追加。`uv run pytest` / `ruff` / `mypy` での確認をお願いします。
