### PR TITLE
refactor: starletteからのimportが不要な部分をfastapiにする

### DIFF
--- a/voicevox_engine/app/routers/morphing.py
+++ b/voicevox_engine/app/routers/morphing.py
@@ -5,10 +5,9 @@ from tempfile import NamedTemporaryFile
 from typing import Annotated
 
 import soundfile
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, BackgroundTasks, HTTPException, Query
+from fastapi.responses import FileResponse
 from pydantic.json_schema import SkipJsonSchema
-from starlette.background import BackgroundTask
-from starlette.responses import FileResponse
 
 from voicevox_engine.metas.metas import StyleId
 from voicevox_engine.metas.metas_store import MetasStore
@@ -77,6 +76,7 @@ def generate_morphing_router(
         summary="2種類のスタイルでモーフィングした音声を合成する",
     )
     def _synthesis_morphing(
+        background_tasks: BackgroundTasks,
         query: AudioQuery,
         base_style_id: Annotated[StyleId, Query(alias="base_speaker")],
         target_style_id: Annotated[StyleId, Query(alias="target_speaker")],
@@ -132,10 +132,7 @@ def generate_morphing_router(
                 format="WAV",
             )
 
-        return FileResponse(
-            f.name,
-            media_type="audio/wav",
-            background=BackgroundTask(try_delete_file, f.name),
-        )
+        background_tasks.add_task(try_delete_file, f.name)
+        return FileResponse(f.name, media_type="audio/wav")
 
     return router

--- a/voicevox_engine/app/routers/morphing.py
+++ b/voicevox_engine/app/routers/morphing.py
@@ -76,11 +76,11 @@ def generate_morphing_router(
         summary="2種類のスタイルでモーフィングした音声を合成する",
     )
     def _synthesis_morphing(
-        background_tasks: BackgroundTasks,
         query: AudioQuery,
         base_style_id: Annotated[StyleId, Query(alias="base_speaker")],
         target_style_id: Annotated[StyleId, Query(alias="target_speaker")],
         morph_rate: Annotated[float, Query(ge=0.0, le=1.0)],
+        background_tasks: BackgroundTasks,
         enable_interrogative_upspeak: Annotated[
             bool,
             Query(

--- a/voicevox_engine/app/routers/tts_pipeline.py
+++ b/voicevox_engine/app/routers/tts_pipeline.py
@@ -6,11 +6,10 @@ from traceback import print_exception
 from typing import Annotated, Self
 
 import soundfile
-from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi import APIRouter, BackgroundTasks, HTTPException, Query, Request
+from fastapi.responses import FileResponse
 from pydantic import BaseModel, Field
 from pydantic.json_schema import SkipJsonSchema
-from starlette.background import BackgroundTask
-from starlette.responses import FileResponse
 
 from voicevox_engine.cancellable_engine import (
     CancellableEngine,
@@ -269,6 +268,7 @@ def generate_tts_pipeline_router(
         summary="音声合成する",
     )
     def synthesis(
+        background_tasks: BackgroundTasks,
         query: AudioQuery,
         style_id: Annotated[StyleId, Query(alias="speaker")],
         enable_interrogative_upspeak: Annotated[
@@ -290,11 +290,8 @@ def generate_tts_pipeline_router(
                 file=f, data=wave, samplerate=query.outputSamplingRate, format="WAV"
             )
 
-        return FileResponse(
-            f.name,
-            media_type="audio/wav",
-            background=BackgroundTask(try_delete_file, f.name),
-        )
+        background_tasks.add_task(try_delete_file, f.name)
+        return FileResponse(f.name, media_type="audio/wav")
 
     @router.post(
         "/cancellable_synthesis",
@@ -310,6 +307,7 @@ def generate_tts_pipeline_router(
         summary="音声合成する（キャンセル可能）",
     )
     def cancellable_synthesis(
+        background_tasks: BackgroundTasks,
         query: AudioQuery,
         request: Request,
         style_id: Annotated[StyleId, Query(alias="speaker")],
@@ -337,11 +335,8 @@ def generate_tts_pipeline_router(
         if f_name == "":
             raise HTTPException(status_code=422, detail="不明なバージョンです")
 
-        return FileResponse(
-            f_name,
-            media_type="audio/wav",
-            background=BackgroundTask(try_delete_file, f_name),
-        )
+        background_tasks.add_task(try_delete_file, f_name)
+        return FileResponse(f_name, media_type="audio/wav")
 
     @router.post(
         "/multi_synthesis",
@@ -359,6 +354,7 @@ def generate_tts_pipeline_router(
         summary="複数まとめて音声合成する",
     )
     def multi_synthesis(
+        background_tasks: BackgroundTasks,
         queries: list[AudioQuery],
         style_id: Annotated[StyleId, Query(alias="speaker")],
         enable_interrogative_upspeak: Annotated[
@@ -395,11 +391,8 @@ def generate_tts_pipeline_router(
                         wav_file.seek(0)
                         zip_file.writestr(f"{str(i + 1).zfill(3)}.wav", wav_file.read())
 
-        return FileResponse(
-            f.name,
-            media_type="application/zip",
-            background=BackgroundTask(try_delete_file, f.name),
-        )
+        background_tasks.add_task(try_delete_file, f.name)
+        return FileResponse(f.name, media_type="application/zip")
 
     @router.post(
         "/sing_frame_audio_query",
@@ -483,6 +476,7 @@ def generate_tts_pipeline_router(
         tags=["音声合成"],
     )
     def frame_synthesis(
+        background_tasks: BackgroundTasks,
         query: FrameAudioQuery,
         style_id: Annotated[StyleId, Query(alias="speaker")],
         core_version: str | SkipJsonSchema[None] = None,
@@ -500,11 +494,8 @@ def generate_tts_pipeline_router(
                 file=f, data=wave, samplerate=query.outputSamplingRate, format="WAV"
             )
 
-        return FileResponse(
-            f.name,
-            media_type="audio/wav",
-            background=BackgroundTask(try_delete_file, f.name),
-        )
+        background_tasks.add_task(try_delete_file, f.name)
+        return FileResponse(f.name, media_type="audio/wav")
 
     @router.post(
         "/connect_waves",
@@ -519,7 +510,9 @@ def generate_tts_pipeline_router(
         tags=["その他"],
         summary="base64エンコードされた複数のwavデータを一つに結合する",
     )
-    def connect_waves(waves: list[str]) -> FileResponse:
+    def connect_waves(
+        background_tasks: BackgroundTasks, waves: list[str]
+    ) -> FileResponse:
         """base64エンコードされたwavデータを一纏めにし、wavファイルで返します。"""
         try:
             waves_nparray, sampling_rate = connect_base64_waves(waves)
@@ -534,11 +527,8 @@ def generate_tts_pipeline_router(
                 format="WAV",
             )
 
-        return FileResponse(
-            f.name,
-            media_type="audio/wav",
-            background=BackgroundTask(try_delete_file, f.name),
-        )
+        background_tasks.add_task(try_delete_file, f.name)
+        return FileResponse(f.name, media_type="audio/wav")
 
     @router.post(
         "/validate_kana",

--- a/voicevox_engine/app/routers/tts_pipeline.py
+++ b/voicevox_engine/app/routers/tts_pipeline.py
@@ -268,9 +268,9 @@ def generate_tts_pipeline_router(
         summary="音声合成する",
     )
     def synthesis(
-        background_tasks: BackgroundTasks,
         query: AudioQuery,
         style_id: Annotated[StyleId, Query(alias="speaker")],
+        background_tasks: BackgroundTasks,
         enable_interrogative_upspeak: Annotated[
             bool,
             Query(
@@ -307,10 +307,10 @@ def generate_tts_pipeline_router(
         summary="音声合成する（キャンセル可能）",
     )
     def cancellable_synthesis(
-        background_tasks: BackgroundTasks,
         query: AudioQuery,
-        request: Request,
         style_id: Annotated[StyleId, Query(alias="speaker")],
+        request: Request,
+        background_tasks: BackgroundTasks,
         enable_interrogative_upspeak: bool = True,
         core_version: str | SkipJsonSchema[None] = None,
     ) -> FileResponse:
@@ -354,9 +354,9 @@ def generate_tts_pipeline_router(
         summary="複数まとめて音声合成する",
     )
     def multi_synthesis(
-        background_tasks: BackgroundTasks,
         queries: list[AudioQuery],
         style_id: Annotated[StyleId, Query(alias="speaker")],
+        background_tasks: BackgroundTasks,
         enable_interrogative_upspeak: Annotated[
             bool,
             Query(
@@ -476,9 +476,9 @@ def generate_tts_pipeline_router(
         tags=["音声合成"],
     )
     def frame_synthesis(
-        background_tasks: BackgroundTasks,
         query: FrameAudioQuery,
         style_id: Annotated[StyleId, Query(alias="speaker")],
+        background_tasks: BackgroundTasks,
         core_version: str | SkipJsonSchema[None] = None,
     ) -> FileResponse:
         """歌唱音声合成を行います。"""
@@ -511,7 +511,7 @@ def generate_tts_pipeline_router(
         summary="base64エンコードされた複数のwavデータを一つに結合する",
     )
     def connect_waves(
-        background_tasks: BackgroundTasks, waves: list[str]
+        waves: list[str], background_tasks: BackgroundTasks
     ) -> FileResponse:
         """base64エンコードされたwavデータを一纏めにし、wavファイルで返します。"""
         try:


### PR DESCRIPTION
## 内容

starletteから直接importしている部分をFastAPI経由でimport するように変更します。

特にBackgroudTaskはFastAPIが推奨する使用方法に変更します。
https://fastapi.tiangolo.com/tutorial/background-tasks/

## その他

[`ServerErrorMiddleware`](https://github.com/VOICEVOX/voicevox_engine/blob/bce80601896db6e5bd64fec7679424c7761b03b1/voicevox_engine/app/middlewares.py#L11)はFastAPIには存在しないためこれを取り除くことはできません。
一応`ServerErrorMiddleware`を使わずに未捕捉の例外にCORSヘッダーを適用する方法はあるのですがテストに影響があるので行いません。

https://github.com/fastapi/fastapi/discussions/8027#discussioncomment-5146484