### PR TITLE
chore: typosで隠しファイルを検査する

### DIFF
--- a/.github/workflows/build-engine.yml
+++ b/.github/workflows/build-engine.yml
@@ -471,7 +471,7 @@ jobs:
           # Compress to artifact.7z.001, artifact.7z.002, ...
           7z -r -v1900m a "${{ steps.vars.outputs.package_name }}.7z" "${{ matrix.target }}/"
 
-          # Output splitted archive list
+          # Output split archive list
           ls ${{ steps.vars.outputs.package_name }}.7z.* > archives_7z.txt
           mv archives_7z.txt "${{ steps.vars.outputs.package_name }}.7z.txt"
 
@@ -516,7 +516,7 @@ jobs:
             mv ${{ steps.vars.outputs.package_name }}.001.vvppp ${{ steps.vars.outputs.package_name }}.vvpp
           fi
 
-          # Output splitted archive list
+          # Output split archive list
           ls ${{ steps.vars.outputs.package_name }}*.vvppp ${{ steps.vars.outputs.package_name }}.vvpp > archives_vvpp.txt || true
           mv archives_vvpp.txt "${{ steps.vars.outputs.package_name }}.vvpp.txt"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
           sudo apt-get install -y shellcheck
 
       - name: <Test> Check shell files
-        run: git ls-files | grep -E '\.(ba)?sh' | xargs shellcheck
+        run: git ls-files | grep -E '\.(bash|sh)' | xargs shellcheck
 
       - name: <Test> Check workflow files
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -148,7 +148,7 @@ dmypy.json
 cython_debug/
 
 # PyCharm
-#  JetBrains specific template is maintainted in a separate JetBrains.gitignore that can
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,8 @@ ignore_missing_imports = true
 warn_unreachable = true
 
 [tool.typos.files]
-extend-exclude = ["tools/licenses"]
+ignore-hidden = false
+extend-exclude = [".git", "tools/licenses"]
 
 [tool.typos.default.extend-words]
 datas = "datas" # PyInstaller's argument


### PR DESCRIPTION
## 内容

typosの検査対象に隠しファイルと隠しディレクトリを追加し、検出された既存の誤字を修正します。
typosは隠しパスを標準で除外するため、隠しパスの検査を有効にし、Gitの内部データだけを対象から除外します。

## 関連 Issue

ref https://github.com/VOICEVOX/voicevox/pull/3070
