### PR TITLE
feat: FramePhonemeに音素単位のシード設定を追加する

### DIFF
--- a/test/e2e/__snapshots__/test_openapi/test_OpenAPIの形が変わっていないことを確認.json
+++ b/test/e2e/__snapshots__/test_openapi/test_OpenAPIの形が変わっていないことを確認.json
@@ -447,6 +447,17 @@
             "description": "音素",
             "title": "Phoneme",
             "type": "string"
+          },
+          "seeding": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Seeding"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "乱数のシード設定。null の場合は毎回結果が変わる。"
           }
         },
         "required": [
@@ -793,6 +804,31 @@
           "notes"
         ],
         "title": "Score",
+        "type": "object"
+      },
+      "Seeding": {
+        "description": "乱数のシード設定。",
+        "properties": {
+          "offset": {
+            "default": 0,
+            "description": "乱数列のオフセット。シード値から生成される乱数列を先頭から何フレーム分ずらして使うかを表す。",
+            "maximum": 2147483647.0,
+            "minimum": -2147483648.0,
+            "title": "Offset",
+            "type": "integer"
+          },
+          "seed": {
+            "description": "乱数シード値。",
+            "maximum": 2147483647.0,
+            "minimum": -2147483648.0,
+            "title": "Seed",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "seed"
+        ],
+        "title": "Seeding",
         "type": "object"
       },
       "Speaker": {

--- a/test/e2e/single_api/tts_pipeline/__snapshots__/test_sing_frame_audio_query/test_post_sing_frame_audio_query_200.json
+++ b/test/e2e/single_api/tts_pipeline/__snapshots__/test_sing_frame_audio_query/test_post_sing_frame_audio_query_200.json
@@ -34,42 +34,50 @@
     {
       "frame_length": 5,
       "note_id": "a",
-      "phoneme": "pau"
+      "phoneme": "pau",
+      "seeding": null
     },
     {
       "frame_length": 5,
       "note_id": "b",
-      "phoneme": "t"
+      "phoneme": "t",
+      "seeding": null
     },
     {
       "frame_length": 2,
       "note_id": "b",
-      "phoneme": "e"
+      "phoneme": "e",
+      "seeding": null
     },
     {
       "frame_length": 1,
       "note_id": "c",
-      "phoneme": "s"
+      "phoneme": "s",
+      "seeding": null
     },
     {
       "frame_length": 2,
       "note_id": "c",
-      "phoneme": "u"
+      "phoneme": "u",
+      "seeding": null
     },
     {
       "frame_length": 1,
       "note_id": "d",
-      "phoneme": "t"
+      "phoneme": "t",
+      "seeding": null
     },
     {
       "frame_length": 1,
       "note_id": "d",
-      "phoneme": "o"
+      "phoneme": "o",
+      "seeding": null
     },
     {
       "frame_length": 10,
       "note_id": "e",
-      "phoneme": "pau"
+      "phoneme": "pau",
+      "seeding": null
     }
   ],
   "volume": [

--- a/test/e2e/single_api/tts_pipeline/__snapshots__/test_sing_frame_audio_query/test_post_sing_old_frame_audio_query_200.json
+++ b/test/e2e/single_api/tts_pipeline/__snapshots__/test_sing_frame_audio_query/test_post_sing_old_frame_audio_query_200.json
@@ -34,42 +34,50 @@
     {
       "frame_length": 5,
       "note_id": null,
-      "phoneme": "pau"
+      "phoneme": "pau",
+      "seeding": null
     },
     {
       "frame_length": 5,
       "note_id": null,
-      "phoneme": "t"
+      "phoneme": "t",
+      "seeding": null
     },
     {
       "frame_length": 2,
       "note_id": null,
-      "phoneme": "e"
+      "phoneme": "e",
+      "seeding": null
     },
     {
       "frame_length": 1,
       "note_id": null,
-      "phoneme": "s"
+      "phoneme": "s",
+      "seeding": null
     },
     {
       "frame_length": 2,
       "note_id": null,
-      "phoneme": "u"
+      "phoneme": "u",
+      "seeding": null
     },
     {
       "frame_length": 1,
       "note_id": null,
-      "phoneme": "t"
+      "phoneme": "t",
+      "seeding": null
     },
     {
       "frame_length": 1,
       "note_id": null,
-      "phoneme": "o"
+      "phoneme": "o",
+      "seeding": null
     },
     {
       "frame_length": 10,
       "note_id": null,
-      "phoneme": "pau"
+      "phoneme": "pau",
+      "seeding": null
     }
   ],
   "volume": [

--- a/test/unit/tts_pipeline/__snapshots__/test_tts_engine/test_mocked_create_phoneme_and_f0_and_volume_output[query].json
+++ b/test/unit/tts_pipeline/__snapshots__/test_tts_engine/test_mocked_create_phoneme_and_f0_and_volume_output[query].json
@@ -3,67 +3,80 @@
     {
       "frame_length": 5,
       "note_id": null,
-      "phoneme": "pau"
+      "phoneme": "pau",
+      "seeding": null
     },
     {
       "frame_length": 5,
       "note_id": null,
-      "phoneme": "d"
+      "phoneme": "d",
+      "seeding": null
     },
     {
       "frame_length": 6,
       "note_id": null,
-      "phoneme": "o"
+      "phoneme": "o",
+      "seeding": null
     },
     {
       "frame_length": 6,
       "note_id": null,
-      "phoneme": "r"
+      "phoneme": "r",
+      "seeding": null
     },
     {
       "frame_length": 7,
       "note_id": null,
-      "phoneme": "e"
+      "phoneme": "e",
+      "seeding": null
     },
     {
       "frame_length": 10,
       "note_id": null,
-      "phoneme": "m"
+      "phoneme": "m",
+      "seeding": null
     },
     {
       "frame_length": 21,
       "note_id": null,
-      "phoneme": "i"
+      "phoneme": "i",
+      "seeding": null
     },
     {
       "frame_length": 3,
       "note_id": null,
-      "phoneme": "pau"
+      "phoneme": "pau",
+      "seeding": null
     },
     {
       "frame_length": 2,
       "note_id": null,
-      "phoneme": "f"
+      "phoneme": "f",
+      "seeding": null
     },
     {
       "frame_length": 0,
       "note_id": null,
-      "phoneme": "a"
+      "phoneme": "a",
+      "seeding": null
     },
     {
       "frame_length": 12,
       "note_id": null,
-      "phoneme": "s"
+      "phoneme": "s",
+      "seeding": null
     },
     {
       "frame_length": 17,
       "note_id": null,
-      "phoneme": "o"
+      "phoneme": "o",
+      "seeding": null
     },
     {
       "frame_length": 10,
       "note_id": null,
-      "phoneme": "pau"
+      "phoneme": "pau",
+      "seeding": null
     }
   ],
   [

--- a/voicevox_engine/tts_pipeline/model.py
+++ b/voicevox_engine/tts_pipeline/model.py
@@ -75,12 +75,32 @@ class Score(BaseModel):
     notes: list[Note] = Field(description="音符のリスト")
 
 
+class Seeding(BaseModel):
+    """乱数のシード設定。"""
+
+    seed: int = Field(
+        ge=-(2**31),
+        le=2**31 - 1,
+        description="乱数シード値。",
+    )
+    offset: int = Field(
+        default=0,
+        ge=-(2**31),
+        le=2**31 - 1,
+        description="乱数列のオフセット。シード値から生成される乱数列を先頭から何フレーム分ずらして使うかを表す。",
+    )
+
+
 class FramePhoneme(BaseModel):
     """音素の情報。"""
 
     phoneme: str = Field(description="音素")
     frame_length: int = Field(description="音素のフレーム長")
     note_id: NoteId | None = Field(default=None, description="音符のID")
+    seeding: Seeding | None = Field(
+        default=None,
+        description="乱数のシード設定。null の場合は毎回結果が変わる。",
+    )
 
 
 class FrameAudioQuery(BaseModel):

--- a/voicevox_engine/tts_pipeline/song_engine.py
+++ b/voicevox_engine/tts_pipeline/song_engine.py
@@ -265,6 +265,9 @@ class SongEngine:
                 phoneme=Phoneme._PHONEME_LIST[phoneme_id],
                 frame_length=phoneme_duration,
                 note_id=phoneme_note_id,
+                # TODO: コアがシード値に対応したら、ここで実際のシード値を生成する
+                # （https://github.com/VOICEVOX/voicevox_engine/issues/1867）
+                seeding=None,
             )
             for phoneme_id, phoneme_duration, phoneme_note_id in zip(
                 phonemes_array, phoneme_lengths, phoneme_note_ids, strict=True

--- a/voicevox_engine/tts_pipeline/song_engine.py
+++ b/voicevox_engine/tts_pipeline/song_engine.py
@@ -266,7 +266,7 @@ class SongEngine:
                 frame_length=phoneme_duration,
                 note_id=phoneme_note_id,
                 # TODO: コアがシード値に対応したら、ここで実際のシード値を生成する
-                # （https://github.com/VOICEVOX/voicevox_engine/issues/1867）
+                # ref: https://github.com/VOICEVOX/voicevox_engine/issues/1867
                 seeding=None,
             )
             for phoneme_id, phoneme_duration, phoneme_note_id in zip(


### PR DESCRIPTION
## 内容

歌声合成用の `FrameAudioQuery` の各 `FramePhoneme` に乱数シード設定を持たせるため、新規スキーマ `Seeding`（`seed` / `offset`）を追加し、`FramePhoneme.seeding: Seeding | null` フィールドを追加します。

コアがまだシード値固定に対応していないので、シード値を使用する処理は入れていません。

## 関連 Issue

- VOICEVOX/voicevox_engine#1867

## その他