### PR TITLE
chore: macOS 13で実行できるようにビルドする

### DIFF
--- a/.github/actions/prepare_python/action.yml
+++ b/.github/actions/prepare_python/action.yml
@@ -13,12 +13,32 @@ runs:
       uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       with:
         activate-environment: true
+      env:
+        UV_MANAGED_PYTHON: 1 # NOTE: python-build-standaloneの使用を強制する
 
     - name: <Setup> Install Python dependencies
       run: |
+        # NOTE: macOSでインストールするwheelのバージョンを制限するために`--python-platform`と`MACOSX_DEPLOYMENT_TARGET`を設定する
+        case "$RUNNER_OS,$RUNNER_ARCH" in
+          Windows,X64) python_platform=x86_64-pc-windows-msvc ;;
+          macOS,X64)
+            python_platform=x86_64-apple-darwin
+            export MACOSX_DEPLOYMENT_TARGET="13.0"
+            ;;
+          macOS,ARM64)
+            python_platform=aarch64-apple-darwin
+            export MACOSX_DEPLOYMENT_TARGET="13.0"
+            ;;
+          Linux,X64) python_platform=x86_64-unknown-linux-gnu ;;
+          Linux,ARM64) python_platform=aarch64-unknown-linux-gnu ;;
+          *)
+            echo 'unexpected runner' >&2
+            exit 1
+            ;;
+        esac
         if [[ -n "${{ inputs.dependency-group }}" ]]; then
-          uv sync --group ${{ inputs.dependency-group }}
+          uv sync --group ${{ inputs.dependency-group }} --python-platform "$python_platform"
         else
-          uv sync
+          uv sync --python-platform "$python_platform"
         fi
       shell: bash

--- a/.github/actions/prepare_python/action.yml
+++ b/.github/actions/prepare_python/action.yml
@@ -16,27 +16,20 @@ runs:
 
     - name: <Setup> Install Python dependencies
       run: |
+        args=()
+        if [[ -n "${{ inputs.dependency-group }}" ]]; then
+          args+=(--group "${{ inputs.dependency-group }}")
+        fi
         # NOTE: macOSでインストールするwheelのバージョンを制限するために`--python-platform`と`MACOSX_DEPLOYMENT_TARGET`を設定する
         case "$RUNNER_OS,$RUNNER_ARCH" in
-          Windows,X64) python_platform=x86_64-pc-windows-msvc ;;
           macOS,X64)
-            python_platform=x86_64-apple-darwin
+            args+=(--python-platform x86_64-apple-darwin)
             export MACOSX_DEPLOYMENT_TARGET="13.0"
             ;;
           macOS,ARM64)
-            python_platform=aarch64-apple-darwin
+            args+=(--python-platform aarch64-apple-darwin)
             export MACOSX_DEPLOYMENT_TARGET="13.0"
             ;;
-          Linux,X64) python_platform=x86_64-unknown-linux-gnu ;;
-          Linux,ARM64) python_platform=aarch64-unknown-linux-gnu ;;
-          *)
-            echo 'unexpected runner' >&2
-            exit 1
-            ;;
         esac
-        if [[ -n "${{ inputs.dependency-group }}" ]]; then
-          uv sync --group ${{ inputs.dependency-group }} --python-platform "$python_platform"
-        else
-          uv sync --python-platform "$python_platform"
-        fi
+        uv sync "${args[@]}"
       shell: bash

--- a/.github/actions/prepare_python/action.yml
+++ b/.github/actions/prepare_python/action.yml
@@ -20,6 +20,7 @@ runs:
         if [[ -n "${{ inputs.dependency-group }}" ]]; then
           args+=(--group "${{ inputs.dependency-group }}")
         fi
+
         # NOTE: macOSでインストールするwheelのバージョンを制限するために`--python-platform`と`MACOSX_DEPLOYMENT_TARGET`を設定する
         case "$RUNNER_OS,$RUNNER_ARCH" in
           macOS,X64)
@@ -31,5 +32,6 @@ runs:
             export MACOSX_DEPLOYMENT_TARGET="13.0"
             ;;
         esac
+
         uv sync "${args[@]}"
       shell: bash

--- a/.github/actions/prepare_python/action.yml
+++ b/.github/actions/prepare_python/action.yml
@@ -13,8 +13,6 @@ runs:
       uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       with:
         activate-environment: true
-      env:
-        UV_MANAGED_PYTHON: 1 # NOTE: python-build-standaloneの使用を強制する
 
     - name: <Setup> Install Python dependencies
       run: |

--- a/.github/actions/prepare_python/action.yml
+++ b/.github/actions/prepare_python/action.yml
@@ -21,7 +21,8 @@ runs:
           args+=(--group "${{ inputs.dependency-group }}")
         fi
 
-        # NOTE: macOSでインストールするwheelのバージョンを制限するために`--python-platform`と`MACOSX_DEPLOYMENT_TARGET`を設定する
+        # NOTE: macOSでインストールするwheelのバージョンを制限する
+        # `MACOSX_DEPLOYMENT_TARGET`だけではランナーのmacOS向けwheelが選ばれるため、`--python-platform`も指定する
         case "$RUNNER_OS,$RUNNER_ARCH" in
           macOS,X64)
             args+=(--python-platform x86_64-apple-darwin)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
 [tool.uv]
 default-groups = []
 exclude-newer = "1 week"
+python-preference = "only-managed"
 
 [tool.uv.sources]
 pyopenjtalk = { git = "https://github.com/VOICEVOX/pyopenjtalk", rev = "74703b034dd90a1f199f49bb70bf3b66b1728a86" }


### PR DESCRIPTION
## 内容

現在のmacOSビルドはビルドに使用したOSより古いバージョンでは動作しない可能性があります。
`MACOSX_DEPLOYMENT_TARGET`環境変数を設定することで(恐らく)macOS 13以上で動作するようにパッケージのインストールとビルドを行うようにします。

## 関連 Issue

close #1688
ref VOICEVOX/onnxruntime-builder#120
ref VOICEVOX/voicevox_project#90

## その他

`uv sync` 実行時に[`--python-platform`](https://docs.astral.sh/uv/reference/cli/#uv-sync--python-platform)引数と`MACOSX_DEPLOYMENT_TARGET`環境変数を設定することでインストール・ビルドするwheelのmacOSのバージョンを制限します。